### PR TITLE
feat: add celery multi queues and improve retries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,7 @@ htmlcov/
 
 /app/static/db/
 /.python-version
+/data/
+*.log
+/logs/
+/pids/

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -55,6 +55,12 @@ def create_app() -> Flask:
         CELERY=dict(
             broker_url=f"redis://{REDIS_HOST}:6379/0",
             result_backend=f"redis://{REDIS_HOST}:6379/1",
+            task_default_queue="default",
+            task_routes={
+                "tasks.documents.*": {"queue": "documents"},
+                "tasks.workflow.*": {"queue": "workflows"},
+                "tasks.upload.*": {"queue": "uploads"},
+            },
         ),
     )
     app.config.from_prefixed_env()

--- a/app/utilities/document_manager.py
+++ b/app/utilities/document_manager.py
@@ -33,7 +33,7 @@ MIN_PDF_TEXT_LENGTH = 100
 doctr_url = "https://ocr.insight.uidaho.edu/doctr"
 
 
-@celery_app.task
+@celery_app.task(name="tasks.document.extraction", autoretry_for=(Exception,), max_retries=3, default_retry_delay=5)
 def perform_extraction_and_update(document_uuid, extension):
     document = SmartDocument.objects(uuid=document_uuid).first()
     absolute_path = document.absolute_path
@@ -102,14 +102,14 @@ def perform_extraction_and_update(document_uuid, extension):
         return raw_text
 
 
-@celery_app.task
+@celery_app.task(name="tasks.document.update", autoretry_for=(Exception,), max_retries=3, default_retry_delay=5)
 def update_document_fields(document_uuid: str):
     document = SmartDocument.objects(uuid=document_uuid).first()
     document.task_id = None
     document.save()
 
 
-@celery_app.task
+@celery_app.task(name="tasks.document.cleanup", autoretry_for=(Exception,), max_retries=3, default_retry_delay=5)
 def cleanup_document(document_uuid: str):
     """
     Delete the document record and its file when validation or ingestion fails.
@@ -122,7 +122,8 @@ def cleanup_document(document_uuid: str):
     document.save()
 
 
-@celery_app.task
+@celery_app.task(name="tasks.document.semantic_ingestion",
+    autoretry_for=(Exception,), max_retries=3, default_retry_delay=5)
 def perform_semantic_ingestion(raw_text, document_uuid, user_id):
     document = SmartDocument.objects(uuid=document_uuid).first()
     document.task_status = "readying"

--- a/app/utilities/upload_manager.py
+++ b/app/utilities/upload_manager.py
@@ -20,7 +20,9 @@ load_dotenv()
 chat_agent = create_chat_agent(settings.base_model)
 
 
-@celery_app.task(bind=True, max_retries=3, default_retry_delay=5, rate_limit="1/s")
+@celery_app.task(bind=True, name="tasks.upload.validation.chunk",
+                    autoretry_for=(Exception,),
+                 max_retries=3, default_retry_delay=5, rate_limit="1/s")
 def validate_chunk(
     self, document_path: str, compliance: str, chunk_text: str, index: int, total: int
 ) -> dict:
@@ -49,7 +51,9 @@ def validate_chunk(
         raise self.retry(exc=e)
 
 
-@celery_app.task(bind=True, max_retries=3, default_retry_delay=5, rate_limit="1/s")
+@celery_app.task(bind=True, name="tasks.upload.validation.summary",
+                 autoretry_for=(Exception,),
+                 max_retries=3, default_retry_delay=5, rate_limit="1/s")
 def summarize_results(self, results: list, document_uuid: str) -> dict:
     """
     Summarize validation feedback from all chunks and update the SmartDocument.
@@ -95,7 +99,9 @@ def summarize_results(self, results: list, document_uuid: str) -> dict:
     return summary
 
 
-@celery_app.task(bind=True, max_retries=3, default_retry_delay=5, rate_limit="1/s")
+@celery_app.task(bind=True, name="tasks.upload.validation",
+                 autoretry_for=(Exception,),
+                 max_retries=3, default_retry_delay=5, rate_limit="1/s")
 def perform_document_validation(
     self,
     document_text: str,

--- a/app/utilities/workflow.py
+++ b/app/utilities/workflow.py
@@ -607,7 +607,11 @@ class WorkflowManager:
             )
 
 
-@celery_app.task(bind=True, name="workflow.execute_workflow")
+@celery_app.task(bind=True, name="tasks.workflow.execution",
+                 autoretry_for=(Exception,),
+                 rate_limit="1/s",
+                 max_retries=3, default_retry_delay=5
+                 )
 def execute_workflow_task(
     self, workflow_result_id, workflow_id, workflow_trigger_step_id, model
 ):
@@ -664,7 +668,7 @@ def execute_workflow_task(
     }
 
 
-@celery_app.task(bind=True, name="workflow.execute_workflow_step_test")
+@celery_app.task(bind=True, name="tasks.workflow.execution_step_test")
 def execute_task_step_test(self, task_name, task_data, document_trigger_step_id):
     process_node = None
     latest_output = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ dependencies = [
     "markitdown[all]>=0.1.2",
     "jsonschema",
     "markdown>=3.8.2",
+    "flower>=2.0.1",
 ]
 
 

--- a/run_celery.sh
+++ b/run_celery.sh
@@ -1,8 +1,104 @@
 #!/usr/bin/env sh
 
-# on macos celery has some issues pandoc on macos with the default pool, use solo pool to fix it
-# celery -A app.celery_worker.celery_app worker --pool=solo --loglevel INFO
-celery -A app.celery_worker.celery_app worker -l info -P threads --concurrency=8
+# # on macos celery has some issues pandoc on macos with the default pool, use solo pool to fix it
+# # celery -A app.celery_worker.celery_app worker --pool=solo --loglevel INFO
+# celery -A app.celery_worker.celery_app worker -l info -P threads --concurrency=8
 
 
-# nohup celery -A app.celery_worker:celery_app worker --loglevel INFO > celery.log 2>&1 &
+# # nohup celery -A app.celery_worker:celery_app worker --loglevel INFO > celery.log 2>&1 &
+
+#!/usr/bin/env sh
+
+# kill_and_start_workers_with_flower.sh
+
+#!/usr/bin/env sh
+
+# run_celery.sh - Fixed version
+
+CELERY_APP="app.celery_worker.celery_app"
+LOG_LEVEL="info"
+WORKER_COUNT=10
+CONCURRENCY=4
+FLOWER_PORT=5555
+
+# Create local directories for logs and pids
+mkdir -p logs pids
+
+# Function to stop flower
+stop_flower() {
+    echo "Stopping existing Flower instances..."
+    FLOWER_PIDS=$(ps aux | grep "[f]lower" | grep -v grep | awk '{print $2}')
+
+    if [ -n "$FLOWER_PIDS" ]; then
+        echo "Found Flower with PIDs: $FLOWER_PIDS"
+        echo $FLOWER_PIDS | xargs kill -TERM
+        sleep 3
+
+        # Force kill if still running
+        REMAINING=$(ps aux | grep "[f]lower" | grep -v grep | awk '{print $2}')
+        if [ -n "$REMAINING" ]; then
+            echo $REMAINING | xargs kill -KILL
+        fi
+    fi
+
+    rm -f pids/flower.pid
+}
+
+# Function to start flower
+start_flower() {
+    echo "Starting Flower monitoring..."
+    nohup celery -A $CELERY_APP \
+        flower \
+        --port=$FLOWER_PORT \
+        --address=0.0.0.0 \
+        --loglevel=INFO \
+        --pidfile=pids/flower.pid \
+        > logs/flower.log 2>&1 &
+
+    sleep 2
+    echo "Flower started on http://0.0.0.0:$FLOWER_PORT"
+}
+
+# Stop any existing workers gracefully
+echo "Stopping existing workers..."
+celery -A $CELERY_APP multi stopwait 1-$WORKER_COUNT \
+    --pidfile=pids/celery_%n.pid \
+    --logfile=logs/celery_%n%I.log
+
+# Stop flower
+stop_flower
+
+# Clean up any stale pid files
+rm -f pids/celery_worker*.pid logs/celery_worker*.log
+
+# Start new workers with LOCAL log and pid directories
+echo "Starting new workers..."
+celery -A $CELERY_APP multi start $WORKER_COUNT \
+    --pidfile=pids/celery_%n.pid \
+    --logfile=logs/celery_%n%I.log \
+    --loglevel=$LOG_LEVEL \
+    --pool=threads \
+    --concurrency=$CONCURRENCY \
+    -Q:1-2 uploads \
+    -Q:3-5 documents \
+    -Q:6-9 workflows \
+    -Q default
+
+
+# Start flower
+start_flower
+
+echo "Workers and Flower started successfully!"
+
+# Show worker status
+celery -A $CELERY_APP multi show \
+    -Q:1-2 uploads \
+    -Q:3-5 documents \
+    -Q:6-9 workflows \
+    -Q default \
+    --pidfile=pids/celery_%n.pid --logfile=logs/celery_%n%I.log
+
+echo "=== Services Running ==="
+echo "Flower Web UI: http://localhost:$FLOWER_PORT"
+echo "Worker logs: ./logs/"
+echo "PID files: ./pids/"


### PR DESCRIPTION
The PR adds multiple queues (workflows, uploads, documents) for handling various tasks. Additionally, the script for starting celery workers now supports choosing the number of celery workers to run and the distribution of queues among those workers.