### PR TITLE
Add the procps package to the runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 FROM python:3.13 AS builder
 
-RUN apt-get update && apt-get install -y procps
-
 RUN pip install uv
 
 WORKDIR /app
@@ -11,6 +9,8 @@ COPY pyproject.toml ./
 RUN uv sync
 
 FROM python:3.13-slim AS runtime
+
+RUN apt-get update && apt-get install -y procps
 
 WORKDIR /app
 


### PR DESCRIPTION
Made a mistake, it's only in the builder in the old pr