### PR TITLE
Fix email funnels for trial users and reset trials on bulk resend

### DIFF
--- a/backend/app/services/auth_service.py
+++ b/backend/app/services/auth_service.py
@@ -12,8 +12,8 @@ async def _stamp_login(user: User) -> None:
     is_first_login = user.last_login_at is None
     user.last_login_at = now
 
-    # Start onboarding drip for new non-demo users on first login
-    if is_first_login and not user.is_demo_user and user.onboarding_drip_step == 0:
+    # Start onboarding drip for new users on first login
+    if is_first_login and user.onboarding_drip_step == 0:
         user.onboarding_drip_next_at = now  # eligible immediately for step 1
         user.email_preferences = user.email_preferences or {}
         user.email_preferences.setdefault("onboarding", True)

--- a/backend/app/services/demo_service.py
+++ b/backend/app/services/demo_service.py
@@ -190,6 +190,7 @@ async def _activate_application(app: DemoApplication, settings: Settings) -> Non
     # Seed recapture drip — first email 24h after activation
     app.recapture_step = 0
     app.recapture_next_at = now + datetime.timedelta(days=_RECAPTURE_SCHEDULE_DAYS[0])
+    await app.save()
 
     # Send activation email
     expires_str = expires_at.strftime("%B %d, %Y")
@@ -593,12 +594,22 @@ async def bulk_resend_credentials(settings: Settings | None = None) -> dict:
             skipped += 1
             continue
 
-        # Generate new password and update
+        # Reset trial expiration to 14 days from now
+        now = datetime.datetime.now(datetime.timezone.utc)
+        new_expires = now + datetime.timedelta(days=TRIAL_DAYS)
+        app.expires_at = new_expires
+        # Restart recapture drip so they get reminder emails
+        app.recapture_step = 0
+        app.recapture_next_at = now + datetime.timedelta(days=_RECAPTURE_SCHEDULE_DAYS[0])
+        await app.save()
+
+        # Generate new password and update user
         password = secrets.token_urlsafe(10)
         user.password_hash = hash_password(password)
+        user.demo_expires_at = new_expires
         await user.save()
 
-        expires_str = app.expires_at.strftime("%B %d, %Y") if app.expires_at else "N/A"
+        expires_str = new_expires.strftime("%B %d, %Y")
         subject, html = activation_email(
             app.name, user.user_id, password, expires_str, settings.frontend_url
         )

--- a/backend/app/services/engagement_service.py
+++ b/backend/app/services/engagement_service.py
@@ -53,11 +53,10 @@ async def process_onboarding_drips(settings: Settings | None = None) -> int:
     now = datetime.datetime.now(datetime.timezone.utc)
     sent = 0
 
-    # Find users with a pending drip
+    # Find users with a pending drip (includes demo/trial users)
     users = await User.find(
         User.onboarding_drip_step < len(_DRIP_MODULES),
         User.onboarding_drip_next_at <= now,
-        User.is_demo_user != True,  # noqa: E712
     ).to_list()
 
     for user in users:


### PR DESCRIPTION
- Include demo/trial users in onboarding drip emails (was excluded by is_demo_user filter in both initialization and processing)
- Fix recapture drip never starting: app.save() was called before recapture fields were set during activation
- Reset recapture drip sequence when bulk-resending credentials so reminder emails restart for users who haven't logged in
- Reset trial expiration to 14 days from now on bulk resend

## Summary

Brief description of the changes in this PR.

## Changes

-

## Test Plan

- [ ] Shared checks pass (`make ci`)
- [ ] Release check passes if packaging or deployment changed (`make release-check`)
- [ ] Manually tested the affected feature(s)
- [ ] Updated `CHANGELOG.md` for user-facing or operator-facing changes
- [ ] Updated deploy/release docs (`README.md`, `DEPLOY.md`, `OPERATIONS.md`, or `RELEASE_CHECKLIST.md`) if the install or release path changed

## Related Issues

Closes #
