### PR TITLE
Add run history tab to workflow and extraction editors

### DIFF
--- a/backend/app/routers/extractions.py
+++ b/backend/app/routers/extractions.py
@@ -822,6 +822,42 @@ async def create_test_cases_from_extraction(request: Request, user: User = Depen
         raise HTTPException(status_code=400, detail=str(e))
 
 
+@router.get("/search-sets/{uuid}/history")
+async def get_extraction_history(
+    uuid: str, limit: int = 50, user: User = Depends(get_current_user),
+) -> dict:
+    """List the current user's past runs of this extraction."""
+    await _get_search_set_or_404(uuid, user)
+    from app.models.activity import ActivityEvent
+    events = (
+        await ActivityEvent.find(
+            ActivityEvent.search_set_uuid == uuid,
+            ActivityEvent.user_id == user.user_id,
+            ActivityEvent.type == "search_set_run",
+        )
+        .sort("-started_at")
+        .limit(limit)
+        .to_list()
+    )
+    return {
+        "runs": [
+            {
+                "id": str(ev.id),
+                "status": ev.status,
+                "started_at": ev.started_at.isoformat() if ev.started_at else None,
+                "finished_at": ev.finished_at.isoformat() if ev.finished_at else None,
+                "duration_ms": ev.duration_ms,
+                "error": ev.error or "",
+                "tokens_input": ev.tokens_input,
+                "tokens_output": ev.tokens_output,
+                "documents_touched": ev.documents_touched,
+                "result_snapshot": ev.result_snapshot or {},
+            }
+            for ev in events
+        ],
+    }
+
+
 @router.get("/search-sets/{uuid}/quality-history")
 async def get_extraction_quality_history(
     uuid: str, limit: int = 50, user: User = Depends(get_current_user),

--- a/backend/app/routers/workflows.py
+++ b/backend/app/routers/workflows.py
@@ -570,6 +570,47 @@ async def reorder_steps(workflow_id: str, req: ReorderStepsRequest, user: User =
     return {"ok": True}
 
 
+@router.get("/{workflow_id}/history")
+async def get_workflow_history(
+    workflow_id: str, limit: int = 50, user: User = Depends(get_current_user),
+):
+    """List the current user's past runs of this workflow."""
+    wf = await get_authorized_workflow(workflow_id, user)
+    if not wf:
+        raise HTTPException(status_code=404, detail="Workflow not found")
+    from app.models.activity import ActivityEvent
+    events = (
+        await ActivityEvent.find(
+            ActivityEvent.workflow == wf.id,
+            ActivityEvent.user_id == user.user_id,
+            ActivityEvent.type == "workflow_run",
+        )
+        .sort("-started_at")
+        .limit(limit)
+        .to_list()
+    )
+    return {
+        "runs": [
+            {
+                "id": str(ev.id),
+                "status": ev.status,
+                "started_at": ev.started_at.isoformat() if ev.started_at else None,
+                "finished_at": ev.finished_at.isoformat() if ev.finished_at else None,
+                "duration_ms": ev.duration_ms,
+                "error": ev.error or "",
+                "tokens_input": ev.tokens_input,
+                "tokens_output": ev.tokens_output,
+                "documents_touched": ev.documents_touched,
+                "steps_completed": ev.steps_completed,
+                "steps_total": ev.steps_total,
+                "session_id": ev.workflow_session_id,
+                "result_snapshot": ev.result_snapshot or {},
+            }
+            for ev in events
+        ],
+    }
+
+
 @router.get("/{workflow_id}/quality-history")
 async def get_workflow_quality_history(
     workflow_id: str, limit: int = 50, user: User = Depends(get_current_user),

--- a/frontend/src/api/extractions.ts
+++ b/frontend/src/api/extractions.ts
@@ -286,6 +286,23 @@ export interface QualityHistoryRun {
   extraction_config?: Record<string, unknown> | null
 }
 
+export interface ExtractionRunHistoryEntry {
+  id: string
+  status: string
+  started_at: string | null
+  finished_at: string | null
+  duration_ms: number | null
+  error: string
+  tokens_input: number
+  tokens_output: number
+  documents_touched: number
+  result_snapshot: Record<string, unknown>
+}
+
+export function getExtractionHistory(uuid: string, limit = 50) {
+  return apiFetch<{ runs: ExtractionRunHistoryEntry[] }>(`/api/extractions/search-sets/${uuid}/history?limit=${limit}`)
+}
+
 export function getExtractionQualityHistory(uuid: string) {
   return apiFetch<{ runs: QualityHistoryRun[] }>(`/api/extractions/search-sets/${uuid}/quality-history`)
 }

--- a/frontend/src/api/workflows.ts
+++ b/frontend/src/api/workflows.ts
@@ -300,6 +300,26 @@ export interface QualityHistoryRun {
   checks_failed: number
 }
 
+export interface RunHistoryEntry {
+  id: string
+  status: string
+  started_at: string | null
+  finished_at: string | null
+  duration_ms: number | null
+  error: string
+  tokens_input: number
+  tokens_output: number
+  documents_touched: number
+  steps_completed?: number
+  steps_total?: number
+  session_id?: string
+  result_snapshot: Record<string, unknown>
+}
+
+export function getWorkflowHistory(workflowId: string, limit = 50) {
+  return apiFetch<{ runs: RunHistoryEntry[] }>(`/api/workflows/${workflowId}/history?limit=${limit}`)
+}
+
 export function getWorkflowQualityHistory(workflowId: string) {
   return apiFetch<{ runs: QualityHistoryRun[] }>(`/api/workflows/${workflowId}/quality-history`)
 }

--- a/frontend/src/components/workspace/ExtractionEditorPanel.tsx
+++ b/frontend/src/components/workspace/ExtractionEditorPanel.tsx
@@ -1,6 +1,6 @@
 import React, { Fragment, useCallback, useEffect, useRef, useState } from 'react'
 import { ExtractionTutorial } from './ExtractionTutorial'
-import { X, Pencil, Loader2, Copy, Trash2, GripVertical, Plus, ChevronDown, ChevronRight, Play, TrendingUp, Sparkles, FileText, AlertTriangle, Eye, Shield, ShieldCheck, Download } from 'lucide-react'
+import { X, Pencil, Loader2, Copy, Trash2, GripVertical, Plus, ChevronDown, ChevronRight, Play, TrendingUp, Sparkles, FileText, AlertTriangle, Eye, Shield, ShieldCheck, Download, Clock } from 'lucide-react'
 import { useWorkspace } from '../../contexts/WorkspaceContext'
 import { useToast } from '../../contexts/ToastContext'
 import { useSearchSetItems } from '../../hooks/useExtractions'
@@ -25,7 +25,9 @@ import {
   importSearchSet,
   getTuningResult,
   clearTuningResult,
+  getExtractionHistory,
 } from '../../api/extractions'
+import { RunHistoryTab } from './RunHistoryTab'
 import type { ValidationV2Result, QualityHistoryRun, ValidationSource, TuningResult, TuningStreamEvent } from '../../api/extractions'
 import { findBestSettingsStream } from '../../api/extractions'
 import { DocumentPickerDialog } from '../shared/DocumentPickerDialog'
@@ -44,7 +46,7 @@ import DOMPurify from 'dompurify'
 
 marked.setOptions({ breaks: true, gfm: true })
 
-type Tab = 'design' | 'tools' | 'validate' | 'advanced'
+type Tab = 'design' | 'tools' | 'validate' | 'advanced' | 'history'
 
 interface ExtractionConfig {
   mode?: 'one_pass' | 'two_pass'
@@ -443,7 +445,7 @@ export function ExtractionEditorPanel() {
           flexShrink: 0,
         }}
       >
-        {(['design', 'tools', 'validate', 'advanced'] as const).map((tab) => {
+        {(['design', 'tools', 'validate', 'advanced', 'history'] as const).map((tab) => {
           const isActive = activeTab === tab
           // Colored dot for validate tab
           let tabDot: string | null = null
@@ -578,6 +580,14 @@ export function ExtractionEditorPanel() {
           onSetUseDefaults={setUseDefaults}
           onSaveConfig={saveConfig}
         />
+      </div>
+      <div style={{ flex: 1, overflowY: 'auto', minHeight: 0, display: activeTab === 'history' ? undefined : 'none' }}>
+        {openExtractionId && (
+          <RunHistoryTab
+            fetchHistory={() => getExtractionHistory(openExtractionId)}
+            type="extraction"
+          />
+        )}
       </div>
 
       {/* Nudge banner for unvalidated items */}

--- a/frontend/src/components/workspace/ExtractionEditorPanel.tsx
+++ b/frontend/src/components/workspace/ExtractionEditorPanel.tsx
@@ -1,6 +1,6 @@
 import React, { Fragment, useCallback, useEffect, useRef, useState } from 'react'
 import { ExtractionTutorial } from './ExtractionTutorial'
-import { X, Pencil, Loader2, Copy, Trash2, GripVertical, Plus, ChevronDown, ChevronRight, Play, TrendingUp, Sparkles, FileText, AlertTriangle, Eye, Shield, ShieldCheck, Download, Clock } from 'lucide-react'
+import { X, Pencil, Loader2, Copy, Trash2, GripVertical, Plus, ChevronDown, ChevronRight, Play, TrendingUp, Sparkles, FileText, AlertTriangle, Eye, Shield, ShieldCheck, Download } from 'lucide-react'
 import { useWorkspace } from '../../contexts/WorkspaceContext'
 import { useToast } from '../../contexts/ToastContext'
 import { useSearchSetItems } from '../../hooks/useExtractions'

--- a/frontend/src/components/workspace/RunHistoryTab.tsx
+++ b/frontend/src/components/workspace/RunHistoryTab.tsx
@@ -1,0 +1,211 @@
+import React, { useCallback, useEffect, useState } from 'react'
+import { CheckCircle, XCircle, Loader2, Clock, FileText, ChevronDown, ChevronRight, Zap } from 'lucide-react'
+import { relativeTime } from '../../utils/time'
+
+export interface HistoryRun {
+  id: string
+  status: string
+  started_at: string | null
+  finished_at: string | null
+  duration_ms: number | null
+  error: string
+  tokens_input: number
+  tokens_output: number
+  documents_touched: number
+  steps_completed?: number
+  steps_total?: number
+  session_id?: string
+  result_snapshot: Record<string, unknown>
+}
+
+function formatDuration(ms: number): string {
+  if (ms < 1000) return `${ms}ms`
+  const secs = ms / 1000
+  if (secs < 60) return `${secs.toFixed(1)}s`
+  const mins = Math.floor(secs / 60)
+  const remSecs = Math.round(secs % 60)
+  return `${mins}m ${remSecs}s`
+}
+
+function StatusIcon({ status }: { status: string }) {
+  if (status === 'completed') return <CheckCircle style={{ width: 14, height: 14, color: '#16a34a', flexShrink: 0 }} />
+  if (status === 'failed' || status === 'error') return <XCircle style={{ width: 14, height: 14, color: '#dc2626', flexShrink: 0 }} />
+  if (status === 'running' || status === 'queued') return <Loader2 style={{ width: 14, height: 14, color: '#2563eb', flexShrink: 0, animation: 'spin 1s linear infinite' }} />
+  return <Clock style={{ width: 14, height: 14, color: '#9ca3af', flexShrink: 0 }} />
+}
+
+function ResultPreview({ snapshot, type }: { snapshot: Record<string, unknown>; type: 'workflow' | 'extraction' }) {
+  if (!snapshot || Object.keys(snapshot).length === 0) return null
+
+  if (type === 'extraction') {
+    const normalized = snapshot.normalized as Record<string, unknown> | undefined
+    if (!normalized || Object.keys(normalized).length === 0) return null
+    const entries = Object.entries(normalized)
+    return (
+      <div style={{ marginTop: 8, fontSize: 12, color: '#374151' }}>
+        <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+          <tbody>
+            {entries.map(([key, val]) => (
+              <tr key={key}>
+                <td style={{ padding: '3px 8px 3px 0', color: '#6b7280', fontWeight: 500, verticalAlign: 'top', whiteSpace: 'nowrap' }}>{key}</td>
+                <td style={{ padding: '3px 0', wordBreak: 'break-word' }}>{val != null ? String(val) : <span style={{ color: '#d1d5db' }}>--</span>}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    )
+  }
+
+  // Workflow: just show a summary of what's in the snapshot
+  const keys = Object.keys(snapshot)
+  if (keys.length === 0) return null
+  return (
+    <div style={{ marginTop: 8, fontSize: 12, color: '#6b7280' }}>
+      {keys.length} result field{keys.length !== 1 ? 's' : ''}
+    </div>
+  )
+}
+
+function RunRow({ run, type }: { run: HistoryRun; type: 'workflow' | 'extraction' }) {
+  const [expanded, setExpanded] = useState(false)
+  const hasResults = run.result_snapshot && Object.keys(run.result_snapshot).length > 0
+
+  return (
+    <div style={{
+      borderBottom: '1px solid #f3f4f6',
+    }}>
+      <button
+        onClick={() => hasResults && setExpanded(e => !e)}
+        style={{
+          width: '100%',
+          display: 'flex',
+          alignItems: 'center',
+          gap: 10,
+          padding: '12px 24px',
+          background: 'none',
+          border: 'none',
+          cursor: hasResults ? 'pointer' : 'default',
+          fontFamily: 'inherit',
+          textAlign: 'left',
+        }}
+      >
+        <StatusIcon status={run.status} />
+
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+            <span style={{ fontSize: 13, fontWeight: 500, color: '#202124' }}>
+              {run.started_at ? relativeTime(run.started_at) : 'Unknown'}
+            </span>
+            <span style={{
+              fontSize: 11,
+              fontWeight: 500,
+              padding: '1px 6px',
+              borderRadius: 4,
+              backgroundColor: run.status === 'completed' ? '#dcfce7' : run.status === 'failed' || run.status === 'error' ? '#fef2f2' : '#f3f4f6',
+              color: run.status === 'completed' ? '#166534' : run.status === 'failed' || run.status === 'error' ? '#991b1b' : '#6b7280',
+            }}>
+              {run.status}
+            </span>
+          </div>
+
+          <div style={{ display: 'flex', gap: 12, marginTop: 4, fontSize: 11, color: '#9ca3af' }}>
+            {run.duration_ms != null && (
+              <span style={{ display: 'flex', alignItems: 'center', gap: 3 }}>
+                <Clock style={{ width: 11, height: 11 }} />
+                {formatDuration(run.duration_ms)}
+              </span>
+            )}
+            {run.documents_touched > 0 && (
+              <span style={{ display: 'flex', alignItems: 'center', gap: 3 }}>
+                <FileText style={{ width: 11, height: 11 }} />
+                {run.documents_touched} doc{run.documents_touched !== 1 ? 's' : ''}
+              </span>
+            )}
+            {type === 'workflow' && run.steps_total != null && run.steps_total > 0 && (
+              <span>
+                {run.steps_completed ?? 0}/{run.steps_total} steps
+              </span>
+            )}
+            {(run.tokens_input > 0 || run.tokens_output > 0) && (
+              <span style={{ display: 'flex', alignItems: 'center', gap: 3 }}>
+                <Zap style={{ width: 11, height: 11 }} />
+                {(run.tokens_input + run.tokens_output).toLocaleString()} tokens
+              </span>
+            )}
+          </div>
+
+          {run.error && (
+            <div style={{ fontSize: 12, color: '#dc2626', marginTop: 4 }}>
+              {run.error.length > 120 ? run.error.slice(0, 120) + '...' : run.error}
+            </div>
+          )}
+        </div>
+
+        {hasResults && (
+          expanded
+            ? <ChevronDown style={{ width: 14, height: 14, color: '#9ca3af', flexShrink: 0 }} />
+            : <ChevronRight style={{ width: 14, height: 14, color: '#9ca3af', flexShrink: 0 }} />
+        )}
+      </button>
+
+      {expanded && hasResults && (
+        <div style={{ padding: '0 24px 12px 48px' }}>
+          <ResultPreview snapshot={run.result_snapshot} type={type} />
+        </div>
+      )}
+    </div>
+  )
+}
+
+export function RunHistoryTab({
+  fetchHistory,
+  type,
+}: {
+  fetchHistory: () => Promise<{ runs: HistoryRun[] }>
+  type: 'workflow' | 'extraction'
+}) {
+  const [runs, setRuns] = useState<HistoryRun[]>([])
+  const [loading, setLoading] = useState(true)
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    try {
+      const data = await fetchHistory()
+      setRuns(data.runs)
+    } catch {
+      // silent
+    } finally {
+      setLoading(false)
+    }
+  }, [fetchHistory])
+
+  useEffect(() => { load() }, [load])
+
+  if (loading) {
+    return (
+      <div style={{ display: 'flex', justifyContent: 'center', padding: 48, color: '#9ca3af' }}>
+        <Loader2 style={{ width: 20, height: 20, animation: 'spin 1s linear infinite' }} />
+      </div>
+    )
+  }
+
+  if (runs.length === 0) {
+    return (
+      <div style={{ padding: '48px 24px', textAlign: 'center', color: '#9ca3af', fontSize: 13 }}>
+        No runs yet. Results will appear here after you run this {type}.
+      </div>
+    )
+  }
+
+  return (
+    <div>
+      <div style={{ padding: '12px 24px 8px', fontSize: 12, color: '#9ca3af', fontWeight: 500 }}>
+        {runs.length} run{runs.length !== 1 ? 's' : ''}
+      </div>
+      {runs.map(run => (
+        <RunRow key={run.id} run={run} type={type} />
+      ))}
+    </div>
+  )
+}

--- a/frontend/src/components/workspace/RunHistoryTab.tsx
+++ b/frontend/src/components/workspace/RunHistoryTab.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { CheckCircle, XCircle, Loader2, Clock, FileText, ChevronDown, ChevronRight, Zap } from 'lucide-react'
 import { relativeTime } from '../../utils/time'
 

--- a/frontend/src/components/workspace/WorkflowEditorPanel.tsx
+++ b/frontend/src/components/workspace/WorkflowEditorPanel.tsx
@@ -7,7 +7,7 @@ import {
   AlertTriangle, ChevronDown, ChevronRight, ArrowUp, ArrowDown,
   Circle, Hand, Keyboard, Sparkles, ShieldCheck, Type,
   ArrowRight, Pause, TrendingUp, RefreshCw,
-  Upload,
+  Upload, Clock,
 } from 'lucide-react'
 import { useWorkspace } from '../../contexts/WorkspaceContext'
 import {
@@ -17,8 +17,9 @@ import {
   getWorkflowQualityHistory, getWorkflowImprovementSuggestions, getWorkflowQualityStatus,
   getValidationPlan, updateValidationPlan, generateValidationPlan,
   getValidationInputs, updateValidationInputs,
-  exportWorkflowUrl, importWorkflow,
+  exportWorkflowUrl, importWorkflow, getWorkflowHistory,
 } from '../../api/workflows'
+import { RunHistoryTab } from './RunHistoryTab'
 import type { ValidationCheck, ValidationCheckDefinition, ValidationInputDefinition, QualityHistoryRun, BatchStatus, WorkflowQualityStatus } from '../../api/workflows'
 import { ItemPickerModal } from './ItemPickerModal'
 import { getModels } from '../../api/config'
@@ -44,7 +45,7 @@ import type { ApprovalRequest } from '../../api/approvals'
 // Types & constants
 // ---------------------------------------------------------------------------
 
-type Tab = 'design' | 'input' | 'validate'
+type Tab = 'design' | 'input' | 'validate' | 'history'
 type TaskCategory = 'all' | 'text' | 'files' | 'web' | 'output'
 type TaskSubTab = 'design' | 'input' | 'output'
 type TaskInputSource = 'step_input' | 'select_document' | 'workflow_documents'
@@ -89,6 +90,7 @@ const TABS: { key: Tab; label: string; icon: typeof PenTool }[] = [
   { key: 'design', label: 'Design', icon: PenTool },
   { key: 'input', label: 'Input', icon: Zap },
   { key: 'validate', label: 'Validate', icon: ClipboardCheck },
+  { key: 'history', label: 'History', icon: Clock },
 ]
 
 // ---------------------------------------------------------------------------
@@ -593,6 +595,12 @@ export function WorkflowEditorPanel() {
               refreshSparkline()
               if (openWorkflowId) getWorkflowQualityStatus(openWorkflowId).then(setQualityStatus).catch(() => {})
             }}
+          />
+        )}
+        {activeTab === 'history' && openWorkflowId && (
+          <RunHistoryTab
+            fetchHistory={() => getWorkflowHistory(openWorkflowId)}
+            type="workflow"
           />
         )}
       </div>


### PR DESCRIPTION
Users can now view their past runs with status, duration, document count, token usage, and expandable result previews. History is scoped to the current user's own runs via ActivityEvent queries.

## Summary

Brief description of the changes in this PR.

## Changes

-

## Test Plan

- [ ] Shared checks pass (`make ci`)
- [ ] Release check passes if packaging or deployment changed (`make release-check`)
- [ ] Manually tested the affected feature(s)
- [ ] Updated `CHANGELOG.md` for user-facing or operator-facing changes
- [ ] Updated deploy/release docs (`README.md`, `DEPLOY.md`, `OPERATIONS.md`, or `RELEASE_CHECKLIST.md`) if the install or release path changed

## Related Issues

Closes #
