### PR TITLE
Keep extraction results visible when user clicks a document

### DIFF
--- a/frontend/src/components/workspace/ExtractionEditorPanel.tsx
+++ b/frontend/src/components/workspace/ExtractionEditorPanel.tsx
@@ -116,16 +116,6 @@ export function ExtractionEditorPanel() {
     getQualityStatus(openExtractionId).then(setQualityStatus).catch(() => {})
   }, [openExtractionId, refreshSparkline])
 
-  // Clear stale results when document selection changes
-  const prevDocUuidsRef = useRef(selectedDocUuids)
-  useEffect(() => {
-    if (prevDocUuidsRef.current !== selectedDocUuids) {
-      prevDocUuidsRef.current = selectedDocUuids
-      setResultSets([])
-      setActiveResultIdx(0)
-    }
-  }, [selectedDocUuids])
-
   // Nudge dismissal state
   useEffect(() => {
     if (!openExtractionId) return


### PR DESCRIPTION
## Summary
- Removes a "clear stale results" effect in `ExtractionEditorPanel` that wiped the Design-view results panel whenever `selectedDocUuids` changed.
- Clicking a document in the file browser calls `setSelectedDocUuids([doc.uuid])`, which tripped that effect — so users ran an extraction, clicked the source doc to view highlighting, and watched their results vanish. The only recovery was to close the extraction and re-open it from the activity rail (which reseeds results from a snapshot).
- The clear was redundant: `handleRun` already overwrites `resultSets` on re-run, and the initial-load effect reseeds when a different extraction is opened. Dropping the effect lets results persist naturally while the user inspects the source document alongside them.

## Test plan
- [ ] Run an extraction on one or more selected documents.
- [ ] Click one of the extracted documents in the file browser to open it in the viewer — confirm the Design-view results panel stays populated.
- [ ] Click a result value — confirm highlights appear on the open document.
- [ ] Re-run the extraction with a different selection — confirm the old results are replaced (not merged).
- [ ] Open a different extraction while results are visible — confirm results reseed from that extraction's state (empty or restored via activity rail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)