### PR TITLE
Switch Chroma to HttpClient for multi-process deployments

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,13 +18,13 @@ redis_host=localhost
 ENVIRONMENT=development
 
 # --- ChromaDB ---
-# Use ChromaDB server (HttpClient) instead of persistent client.
-# Automatically enabled for staging/production environments.
-USE_CHROMA_SERVER=false
-
-# ChromaDB server connection details (for staging/production)
-CHROMA_HOST=localhost
-CHROMA_PORT=8000
+# Set CHROMADB_HOST (e.g. "chromadb:8000") to connect to a running Chroma
+# server via HTTP. REQUIRED for any deployment with more than one writer
+# process (multi-worker uvicorn and/or Celery) — PersistentClient is not
+# process-safe for concurrent writers.
+# Leave unset only for single-process local development, which will use
+# PersistentClient against CHROMADB_PERSIST_DIR.
+CHROMADB_HOST=
 CHROMADB_PERSIST_DIR=../app/static/db
 
 # --- Config Encryption ---

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -154,6 +154,7 @@ CONFIG_ENCRYPTION_KEY=<generate-a-fernet-key>
 UPLOAD_DIR=/app/static/uploads
 FRONTEND_URL=https://vandalizer.example.edu
 ENVIRONMENT=production
+CHROMADB_HOST=chromadb:8000
 CHROMADB_PERSIST_DIR=../app/static/db
 ```
 
@@ -164,6 +165,7 @@ Key notes:
 - **`MONGO_HOST`**: Use the Docker service name (`mongo`) if running in Docker Compose, or the hostname/IP of your MongoDB instance if externalized.
 - **`UPLOAD_DIR`**: Directory where user-uploaded documents are stored. Must be a persistent volume.
 - **`FRONTEND_URL`**: The public URL users will access. Used for CORS and redirect configuration.
+- **`CHROMADB_HOST`**: Hostname:port of the Chroma server. Required for any multi-process deployment — the Python `PersistentClient` is not process-safe for concurrent writers, so FastAPI workers + Celery workers sharing a persist directory will hit "attempt to write a readonly database" errors. Leave unset only for single-process local development.
 
 ### LLM Configuration
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -33,7 +33,13 @@ ENVIRONMENT=development
 INSIGHT_ENDPOINT=
 
 # --- ChromaDB ---
+# Used only for local single-process development.
 CHROMADB_PERSIST_DIR=../app/static/db
+# Set (e.g. "chromadb:8000") to connect to a Chroma server via HTTP.
+# REQUIRED for any deployment with more than one writer process
+# (multi-worker uvicorn and/or Celery). PersistentClient is not
+# process-safe for concurrent writers.
+CHROMADB_HOST=
 
 # --- Config Encryption ---
 # Fernet key for encrypting LLM API keys and OAuth secrets stored in MongoDB.

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -21,6 +21,10 @@ class Settings(BaseSettings):
     environment: str = "development"
     insight_endpoint: str = ""
     chromadb_persist_dir: str = "../app/static/db"
+    # If set (e.g. "chromadb:8000"), connect to a Chroma server via HttpClient.
+    # Required when multiple processes (FastAPI workers + Celery) share Chroma —
+    # PersistentClient is not process-safe for concurrent writers.
+    chromadb_host: str = ""
     max_context_length: int = 100000
     max_upload_size_mb: int = 500
 

--- a/backend/app/services/document_manager.py
+++ b/backend/app/services/document_manager.py
@@ -12,15 +12,27 @@ logger = logging.getLogger(__name__)
 
 
 def get_chroma_client(persist_directory: str | None = None) -> chromadb.ClientAPI:
-    """Create a ChromaDB PersistentClient with consistent settings.
+    """Create a ChromaDB client — HttpClient if CHROMADB_HOST is set, else PersistentClient.
 
-    All code that needs a ChromaDB client should use this function to avoid
-    the 'instance already exists with different settings' error.
+    PersistentClient is not process-safe for concurrent writers. Any deployment
+    with more than one writer (multi-worker uvicorn + Celery) must set
+    CHROMADB_HOST and run the Chroma server container.
     """
-    if persist_directory is None:
-        from app.config import Settings
+    from app.config import Settings
 
-        persist_directory = Settings().chromadb_persist_dir
+    settings = Settings()
+    host = (settings.chromadb_host or "").strip()
+    if host:
+        hostname, _, port_str = host.partition(":")
+        port = int(port_str) if port_str else 8000
+        return chromadb.HttpClient(
+            host=hostname,
+            port=port,
+            settings=ChromaSettings(anonymized_telemetry=False),
+        )
+
+    if persist_directory is None:
+        persist_directory = settings.chromadb_persist_dir
     Path(persist_directory).mkdir(parents=True, exist_ok=True)
     return chromadb.PersistentClient(
         path=persist_directory,

--- a/compose.yaml
+++ b/compose.yaml
@@ -71,13 +71,12 @@ services:
     environment:
       - REDIS_HOST=redis
       - MONGO_HOST=mongodb://mongo:27017/
-      - CHROMADB_PERSIST_DIR=/app/static/db
+      - CHROMADB_HOST=chromadb:8000
       - UPLOAD_DIR=/app/static/uploads
     networks:
       - vandalizer
     volumes:
       - uploads:/app/static/uploads
-      - chroma-data:/app/static/db
     restart: unless-stopped
     deploy:
       resources:
@@ -100,13 +99,12 @@ services:
     environment:
       - REDIS_HOST=redis
       - MONGO_HOST=mongodb://mongo:27017/
-      - CHROMADB_PERSIST_DIR=/app/static/db
+      - CHROMADB_HOST=chromadb:8000
       - UPLOAD_DIR=/app/static/uploads
     networks:
       - vandalizer
     volumes:
       - uploads:/app/static/uploads
-      - chroma-data:/app/static/db
     entrypoint: ["sh", "run_celery.sh", "start"]
     restart: unless-stopped
     deploy:

--- a/deploy.sh
+++ b/deploy.sh
@@ -599,6 +599,9 @@ LOG_FORMAT=json
 INSIGHT_ENDPOINT=${LLM_ENDPOINT}
 
 # ── ChromaDB ─────────────────────────────────────────────────
+# Backend connects to the chromadb service via HTTP — PersistentClient is
+# not process-safe for concurrent writers (FastAPI workers + Celery).
+CHROMADB_HOST=chromadb:8000
 CHROMADB_PERSIST_DIR=/app/static/db
 
 # ── File Storage ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- `get_chroma_client()` now returns `HttpClient` when `CHROMADB_HOST` is set, keeping `PersistentClient` only as a single-process local-dev fallback.
- `api` and `celery` services in `compose.yaml` talk to the existing `chromadb` service over HTTP; the shared `chroma-data` volume mount is removed from both (only the `chromadb` container still touches the sqlite files).
- `deploy.sh`, `DEPLOY.md`, and both `.env.example` files document the new `CHROMADB_HOST` variable.

## Why
Users were hitting `attempt to write a readonly database` when creating a knowledge base or adding a document. Root cause: ChromaDB's `PersistentClient` is explicitly **not process-safe for concurrent writers** ([docs](https://cookbook.chromadb.dev/core/system_constraints/)), yet multi-worker uvicorn + Celery + the `chromadb/chroma` server container were all writing to the same `chroma.sqlite3`. Moving the Python processes to `HttpClient` against the Chroma server leaves a single writer (the server) and matches the recommended production topology.

## Data migration
Nathan's existing volume data was written by the `chromadb` server all along (the Python writers were failing), so it stays intact. On redeploy the server keeps its bind, api/celery connect over HTTP, and ingestion should resume.

## Compatibility note
`chromadb` Python client is pinned to `0.5.23` and the server image is `chromadb/chroma:0.6.3` — they share the v1 API. If the client is ever bumped to 1.x, bump the server image to match.

## Test plan
- [ ] `docker compose up` — verify api/celery start and `/api/health` reports `chromadb: ok`
- [ ] Create a knowledge base via the UI (previously failing path)
- [ ] Upload a PDF, then Add Documents → select it (previously failing path)
- [ ] Upload + ingest a document, confirm chunks appear in KB
- [ ] Local dev (no `CHROMADB_HOST`): verify `PersistentClient` path still works
- [ ] Delete a KB and confirm the Chroma collection is dropped

🤖 Generated with [Claude Code](https://claude.com/claude-code)