### PR TITLE
Route team invites through a dedicated accept page

### DIFF
--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -142,6 +142,28 @@ async def register(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Registration failed. Please check your details and try again.",
         )
+
+    # If the user was signing up to accept a team invite, auto-accept it.
+    # Only accepts when the registered email matches the invite's recipient
+    # email — otherwise silently ignore and let them accept manually later.
+    if body.invite_token:
+        from app.services import team_service
+
+        invite = await team_service.get_invite_info(body.invite_token)
+        if (
+            invite
+            and not invite["expired"]
+            and invite["email"].strip().lower() == body.email.strip().lower()
+        ):
+            try:
+                await team_service.accept_invite(body.invite_token, user)
+            except ValueError:
+                logger.warning(
+                    "Auto-accept of invite %s failed for new user %s",
+                    body.invite_token[:8],
+                    user.user_id,
+                )
+
     _set_tokens(response, user, settings)
     return await _user_response(user)
 

--- a/backend/app/routers/teams.py
+++ b/backend/app/routers/teams.py
@@ -94,6 +94,15 @@ async def invite(
     return {"token": inv.token, "email": inv.email}
 
 
+@router.get("/invite/info/{token}")
+async def invite_info(token: str):
+    """Public — return team + inviter metadata for a pending invite token."""
+    info = await team_service.get_invite_info(token)
+    if not info:
+        raise HTTPException(status_code=404, detail="Invalid or already-used invite")
+    return info
+
+
 @router.post("/invite/accept/{token}")
 async def accept_invite(
     token: str,

--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -14,6 +14,7 @@ class RegisterRequest(BaseModel):
     email: str
     password: str
     name: Optional[str] = None
+    invite_token: Optional[str] = None
 
     @field_validator("password")
     @classmethod

--- a/backend/app/services/team_service.py
+++ b/backend/app/services/team_service.py
@@ -182,6 +182,33 @@ async def _send_invite_email(
     await send_email(invite.email, subject, html, settings)
 
 
+async def get_invite_info(token: str) -> dict | None:
+    """Return metadata about an invite token, or None if missing/expired/accepted.
+
+    Public — used so an unauthenticated invitee can see which team invited them
+    before signing up or logging in.
+    """
+    invite = await TeamInvite.find_one(TeamInvite.token == token)
+    if not invite:
+        return None
+    if invite.accepted:
+        return None
+    expired = bool(
+        invite.created_at
+        and (datetime.datetime.now() - invite.created_at).days > INVITE_EXPIRY_DAYS
+    )
+    team = await Team.get(invite.team)
+    inviter = await User.find_one(User.user_id == invite.invited_by_user_id)
+    return {
+        "email": invite.email,
+        "role": invite.role,
+        "team_name": team.name if team else "a team",
+        "team_uuid": team.uuid if team else None,
+        "inviter_name": (inviter.name or inviter.user_id) if inviter else None,
+        "expired": expired,
+    }
+
+
 async def accept_invite(token: str, user: User) -> Team:
     """Accept a team invitation."""
     invite = await TeamInvite.find_one(TeamInvite.token == token)
@@ -212,14 +239,17 @@ async def accept_invite(token: str, user: User) -> Team:
         existing.role = invite.role
         await existing.save()
 
+    was_new_acceptance = not invite.accepted
     invite.accepted = True
     await invite.save()
 
     user.current_team = team.id
     await user.save()
 
-    # Notify the inviter that the invitation was accepted
-    await _notify_invite_accepted(invite, team, user)
+    # Notify the inviter only the first time — later re-accepts (e.g. a
+    # register-then-explicit-accept sequence) must not fire duplicate emails.
+    if was_new_acceptance:
+        await _notify_invite_accepted(invite, team, user)
 
     return team
 

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -37,10 +37,16 @@ export function login(user_id: string, password: string) {
   })
 }
 
-export function register(user_id: string, email: string, password: string, name?: string) {
+export function register(
+  user_id: string,
+  email: string,
+  password: string,
+  name?: string,
+  invite_token?: string,
+) {
   return apiFetch<User>('/api/auth/register', {
     method: 'POST',
-    body: JSON.stringify({ user_id, email, password, name }),
+    body: JSON.stringify({ user_id, email, password, name, invite_token }),
   })
 }
 

--- a/frontend/src/api/teams.ts
+++ b/frontend/src/api/teams.ts
@@ -46,6 +46,23 @@ export function acceptInvite(token: string) {
   })
 }
 
+export interface InviteInfo {
+  email: string
+  role: string
+  team_name: string
+  team_uuid: string | null
+  inviter_name: string | null
+  expired: boolean
+}
+
+export async function getInviteInfo(token: string): Promise<InviteInfo> {
+  const res = await fetch(`/api/teams/invite/info/${encodeURIComponent(token)}`)
+  if (!res.ok) {
+    throw new Error('Invalid or expired invite link.')
+  }
+  return res.json()
+}
+
 export function changeMemberRole(team_id: string, user_id: string, role: string) {
   return apiFetch<{ ok: boolean }>('/api/teams/member/role', {
     method: 'POST',

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -8,7 +8,7 @@ interface AuthContextValue {
   demoExpired: boolean
   demoFeedbackToken: string | null
   login: (userId: string, password: string) => Promise<void>
-  register: (userId: string, email: string, password: string, name?: string) => Promise<void>
+  register: (userId: string, email: string, password: string, name?: string, inviteToken?: string) => Promise<void>
   logout: () => Promise<void>
   refreshUser: () => Promise<void>
 }
@@ -55,8 +55,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }, [])
 
   const register = useCallback(
-    async (userId: string, email: string, password: string, name?: string) => {
-      const u = await authApi.register(userId, email, password, name)
+    async (userId: string, email: string, password: string, name?: string, inviteToken?: string) => {
+      const u = await authApi.register(userId, email, password, name, inviteToken)
       localStorage.removeItem('workspace:mode')
       setUser(u)
     },

--- a/frontend/src/hooks/useAuth.test.tsx
+++ b/frontend/src/hooks/useAuth.test.tsx
@@ -123,7 +123,7 @@ describe('useAuth', () => {
       await result.current.register('bob', 'bob@test.com', 'pass', 'Bob')
     })
 
-    expect(mockRegister).toHaveBeenCalledWith('bob', 'bob@test.com', 'pass', 'Bob')
+    expect(mockRegister).toHaveBeenCalledWith('bob', 'bob@test.com', 'pass', 'Bob', undefined)
     expect(result.current.user).toEqual(user)
   })
 

--- a/frontend/src/pages/InviteAccept.tsx
+++ b/frontend/src/pages/InviteAccept.tsx
@@ -1,50 +1,101 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useState, type FormEvent } from 'react'
 import { useNavigate, useSearch } from '@tanstack/react-router'
 import { useAuth } from '../hooks/useAuth'
 import { useTeams } from '../hooks/useTeams'
-import { acceptInvite } from '../api/teams'
+import { acceptInvite, getInviteInfo, type InviteInfo } from '../api/teams'
 
-type Status = 'loading' | 'success' | 'error' | 'redirecting'
+type Status = 'loading' | 'ready' | 'accepting' | 'success' | 'error'
 
 export default function InviteAccept() {
-  const { user, loading: authLoading } = useAuth()
+  const { user, loading: authLoading, login, register } = useAuth()
   const { refreshTeams } = useTeams()
   const navigate = useNavigate()
   const search = useSearch({ strict: false }) as Record<string, string | undefined>
   const token = search?.token
 
   const [status, setStatus] = useState<Status>('loading')
-  const [teamName, setTeamName] = useState('')
+  const [info, setInfo] = useState<InviteInfo | null>(null)
   const [errorMsg, setErrorMsg] = useState('')
 
+  // Fetch invite metadata (public — works authed or not)
   useEffect(() => {
-    if (authLoading) return
-
     if (!token) {
       setStatus('error')
       setErrorMsg('No invite token provided.')
       return
     }
-
-    // Not authenticated — redirect to landing with invite_token preserved
-    if (!user) {
-      setStatus('redirecting')
-      window.location.href = `/landing?invite_token=${encodeURIComponent(token)}`
-      return
-    }
-
-    // Authenticated — accept the invite
     let cancelled = false
-    setStatus('loading')
+    getInviteInfo(token)
+      .then((data) => {
+        if (cancelled) return
+        if (data.expired) {
+          setStatus('error')
+          setErrorMsg('This invite has expired. Ask the team to send a new one.')
+          return
+        }
+        setInfo(data)
+        setStatus('ready')
+      })
+      .catch((err) => {
+        if (cancelled) return
+        setStatus('error')
+        setErrorMsg(err instanceof Error ? err.message : 'Invalid invite link.')
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [token])
 
+  // If already authenticated, accept immediately
+  useEffect(() => {
+    if (authLoading || status !== 'ready' || !user || !token) return
+    let cancelled = false
+    setStatus('accepting')
     acceptInvite(token)
       .then(async (result) => {
         if (cancelled) return
-        setTeamName(result.name)
-        setStatus('success')
         await refreshTeams()
+        setInfo((prev) => (prev ? { ...prev, team_name: result.name } : prev))
+        setStatus('success')
         setTimeout(() => {
-          if (!cancelled) {
+          if (cancelled) return
+          navigate({
+            to: '/',
+            search: {
+              mode: undefined,
+              tab: undefined,
+              workflow: undefined,
+              extraction: undefined,
+              automation: undefined,
+              kb: undefined,
+            },
+          })
+        }, 1500)
+      })
+      .catch((err) => {
+        if (cancelled) return
+        setStatus('error')
+        setErrorMsg(
+          err instanceof Error ? err.message : 'Failed to accept invite.',
+        )
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [authLoading, user, token, status]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  if (status === 'loading' || authLoading) {
+    return <CenteredCard><Spinner /><p className="mt-4 text-gray-300">Loading invite...</p></CenteredCard>
+  }
+
+  if (status === 'error') {
+    return (
+      <CenteredCard>
+        <ErrorIcon />
+        <h2 className="mt-4 text-lg font-semibold text-white">Invite unavailable</h2>
+        <p className="mt-2 text-sm text-gray-400">{errorMsg}</p>
+        <button
+          onClick={() =>
             navigate({
               to: '/',
               search: {
@@ -57,83 +108,282 @@ export default function InviteAccept() {
               },
             })
           }
-        }, 2000)
-      })
-      .catch((err) => {
-        if (cancelled) return
-        setStatus('error')
-        setErrorMsg(
-          err instanceof Error ? err.message : 'Invalid or expired invite link.',
-        )
-      })
+          className="mt-6 rounded-lg bg-[#f1b300] px-4 py-2 text-sm font-bold text-black hover:bg-[#d49e00]"
+        >
+          Continue
+        </button>
+      </CenteredCard>
+    )
+  }
 
-    return () => {
-      cancelled = true
-    }
-  }, [authLoading, user, token]) // eslint-disable-line react-hooks/exhaustive-deps
+  if (status === 'accepting') {
+    return <CenteredCard><Spinner /><p className="mt-4 text-gray-300">Adding you to {info?.team_name}...</p></CenteredCard>
+  }
+
+  if (status === 'success' && info) {
+    return (
+      <CenteredCard>
+        <SuccessIcon />
+        <h2 className="mt-4 text-lg font-semibold text-white">
+          You've joined {info.team_name}!
+        </h2>
+        <p className="mt-2 text-sm text-gray-400">Redirecting to your workspace...</p>
+      </CenteredCard>
+    )
+  }
+
+  // status === 'ready' and !user — show the invite landing with login/register
+  if (!info || !token) return null
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-gray-50">
-      <div className="w-full max-w-md rounded-xl border border-gray-200 bg-white p-8 shadow-sm text-center">
-        {(status === 'loading' || status === 'redirecting') && (
-          <>
-            <div className="mx-auto mb-4 h-8 w-8 animate-spin rounded-full border-4 border-blue-600 border-t-transparent" />
-            <p className="text-gray-600">
-              {status === 'redirecting'
-                ? 'Redirecting to sign in...'
-                : 'Accepting invite...'}
+    <div className="flex min-h-screen items-center justify-center bg-[#0a0a0a] p-4">
+      <div className="w-full max-w-md rounded-xl border border-white/10 bg-[#171717] p-8 shadow-xl">
+        <div className="text-center">
+          <div className="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-full bg-[#f1b300]/10 text-[#f1b300]">
+            <svg className="h-7 w-7" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.8}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M17 20h5v-2a4 4 0 00-3-3.87M9 20H4v-2a4 4 0 013-3.87M16 3.13a4 4 0 010 7.75M8 11a4 4 0 100-8 4 4 0 000 8z" />
+            </svg>
+          </div>
+          <h1 className="text-2xl font-bold text-white">
+            You're invited to <span className="text-[#f1b300]">{info.team_name}</span>
+          </h1>
+          {info.inviter_name && (
+            <p className="mt-2 text-sm text-gray-400">
+              {info.inviter_name} invited you to join as {info.role === 'member' ? 'a member' : `an ${info.role}`}.
             </p>
-          </>
-        )}
+          )}
+          <p className="mt-1 text-xs text-gray-500">Invite for {info.email}</p>
+        </div>
 
-        {status === 'success' && (
-          <>
-            <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-green-100 text-green-600">
-              <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
-              </svg>
-            </div>
-            <h2 className="text-lg font-semibold text-gray-900">
-              You've joined {teamName}!
-            </h2>
-            <p className="mt-2 text-sm text-gray-500">
-              Redirecting to your workspace...
-            </p>
-          </>
-        )}
-
-        {status === 'error' && (
-          <>
-            <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-red-100 text-red-600">
-              <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
-              </svg>
-            </div>
-            <h2 className="text-lg font-semibold text-gray-900">
-              Invite Failed
-            </h2>
-            <p className="mt-2 text-sm text-gray-500">{errorMsg}</p>
-            <button
-              onClick={() =>
-                navigate({
-                  to: '/',
-                  search: {
-                    mode: undefined,
-                    tab: undefined,
-                    workflow: undefined,
-                    extraction: undefined,
-                    automation: undefined,
-                    kb: undefined,
-                  },
-                })
-              }
-              className="mt-4 rounded-lg bg-gray-900 px-4 py-2 text-sm font-medium text-white hover:bg-gray-800"
-            >
-              Go to Workspace
-            </button>
-          </>
-        )}
+        <div className="mt-8">
+          <InviteAuthTabs
+            info={info}
+            token={token}
+            onLogin={login}
+            onRegister={register}
+          />
+        </div>
       </div>
+    </div>
+  )
+}
+
+function InviteAuthTabs({
+  info,
+  token,
+  onLogin,
+  onRegister,
+}: {
+  info: InviteInfo
+  token: string
+  onLogin: (userId: string, password: string) => Promise<void>
+  onRegister: (
+    userId: string,
+    email: string,
+    password: string,
+    name?: string,
+    inviteToken?: string,
+  ) => Promise<void>
+}) {
+  const [mode, setMode] = useState<'register' | 'login'>('register')
+  return (
+    <>
+      <div className="mb-4 flex rounded-lg bg-white/5 p-1">
+        <button
+          onClick={() => setMode('register')}
+          className={`flex-1 rounded-md px-3 py-2 text-sm font-semibold transition-colors ${
+            mode === 'register' ? 'bg-[#f1b300] text-black' : 'text-gray-400 hover:text-white'
+          }`}
+        >
+          Create account
+        </button>
+        <button
+          onClick={() => setMode('login')}
+          className={`flex-1 rounded-md px-3 py-2 text-sm font-semibold transition-colors ${
+            mode === 'login' ? 'bg-[#f1b300] text-black' : 'text-gray-400 hover:text-white'
+          }`}
+        >
+          Sign in
+        </button>
+      </div>
+      {mode === 'register' ? (
+        <InviteRegisterForm info={info} token={token} onRegister={onRegister} />
+      ) : (
+        <InviteLoginForm info={info} onLogin={onLogin} />
+      )}
+    </>
+  )
+}
+
+function InviteRegisterForm({
+  info,
+  token,
+  onRegister,
+}: {
+  info: InviteInfo
+  token: string
+  onRegister: (
+    userId: string,
+    email: string,
+    password: string,
+    name?: string,
+    inviteToken?: string,
+  ) => Promise<void>
+}) {
+  const [name, setName] = useState('')
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault()
+    setError('')
+    setSubmitting(true)
+    try {
+      await onRegister(info.email, info.email, password, name || undefined, token)
+      // Auth context now has the user; parent effect will accept & redirect.
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Registration failed')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-3">
+      {error && (
+        <div className="rounded-md bg-red-500/20 border border-red-500/30 p-3 text-sm text-red-300">
+          {error}
+        </div>
+      )}
+      <input
+        type="email"
+        value={info.email}
+        readOnly
+        aria-label="Email"
+        className="w-full cursor-not-allowed rounded-lg border border-white/10 bg-white/[0.03] px-4 py-3 text-gray-400"
+      />
+      <input
+        type="text"
+        placeholder="Full name"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        className="w-full rounded-lg border border-white/10 bg-white/5 px-4 py-3 text-white placeholder-gray-500 focus:border-[#f1b300]/50 focus:outline-none focus:ring-1 focus:ring-[#f1b300]/50"
+      />
+      <input
+        type="password"
+        placeholder="Create a password"
+        required
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        className="w-full rounded-lg border border-white/10 bg-white/5 px-4 py-3 text-white placeholder-gray-500 focus:border-[#f1b300]/50 focus:outline-none focus:ring-1 focus:ring-[#f1b300]/50"
+      />
+      <p className="text-xs text-gray-500">
+        8+ characters with uppercase, lowercase, and a digit.
+      </p>
+      <button
+        type="submit"
+        disabled={submitting}
+        className="w-full rounded-lg bg-[#f1b300] px-4 py-3 font-bold text-black transition-all hover:bg-[#d49e00] disabled:opacity-50"
+      >
+        {submitting ? 'Creating account...' : `Join ${info.team_name}`}
+      </button>
+    </form>
+  )
+}
+
+function InviteLoginForm({
+  info,
+  onLogin,
+}: {
+  info: InviteInfo
+  onLogin: (userId: string, password: string) => Promise<void>
+}) {
+  const [userId, setUserId] = useState(info.email)
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault()
+    setError('')
+    setSubmitting(true)
+    try {
+      await onLogin(userId, password)
+      // Auth context now has the user; parent effect will accept & redirect.
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Sign in failed')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-3">
+      {error && (
+        <div className="rounded-md bg-red-500/20 border border-red-500/30 p-3 text-sm text-red-300">
+          {error}
+        </div>
+      )}
+      <input
+        type="text"
+        placeholder="Email"
+        required
+        value={userId}
+        onChange={(e) => setUserId(e.target.value)}
+        className="w-full rounded-lg border border-white/10 bg-white/5 px-4 py-3 text-white placeholder-gray-500 focus:border-[#f1b300]/50 focus:outline-none focus:ring-1 focus:ring-[#f1b300]/50"
+      />
+      <input
+        type="password"
+        placeholder="Password"
+        required
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        className="w-full rounded-lg border border-white/10 bg-white/5 px-4 py-3 text-white placeholder-gray-500 focus:border-[#f1b300]/50 focus:outline-none focus:ring-1 focus:ring-[#f1b300]/50"
+      />
+      <button
+        type="submit"
+        disabled={submitting}
+        className="w-full rounded-lg bg-[#f1b300] px-4 py-3 font-bold text-black transition-all hover:bg-[#d49e00] disabled:opacity-50"
+      >
+        {submitting ? 'Signing in...' : 'Sign in & join'}
+      </button>
+    </form>
+  )
+}
+
+function CenteredCard({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-[#0a0a0a] p-4">
+      <div className="w-full max-w-md rounded-xl border border-white/10 bg-[#171717] p-8 text-center shadow-xl">
+        {children}
+      </div>
+    </div>
+  )
+}
+
+function Spinner() {
+  return (
+    <div className="mx-auto h-8 w-8 animate-spin rounded-full border-4 border-[#f1b300] border-t-transparent" />
+  )
+}
+
+function SuccessIcon() {
+  return (
+    <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-green-500/20 text-green-400">
+      <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+      </svg>
+    </div>
+  )
+}
+
+function ErrorIcon() {
+  return (
+    <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-red-500/20 text-red-400">
+      <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+      </svg>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- Team invitees no longer get bounced to the marketing `/landing` page with a "Try the Free Trial" CTA — they land on a dedicated invite view showing which team they've been invited to.
- `/auth/register` now accepts an optional `invite_token` and auto-joins the invitee to the team on signup (email must match the invite).
- Invitees register as regular (non-demo) users, so they skip the trial waitlist and aren't affected when the inviter's trial later expires.

## Why
User reported that people invited to their team were being sent to the free-trial signup page. Root cause: `InviteAccept` was redirecting unauthenticated visitors to `/landing?invite_token=…`, where (a) the register form never forwarded the token and (b) if `auth_methods` excluded `password`, there was no register form at all, leaving the waitlist CTA as the only visible action.

## Changes
- **Backend**
  - `GET /api/teams/invite/info/{token}` — public endpoint returning `{team_name, inviter_name, email, role, expired}`.
  - `RegisterRequest.invite_token` — new optional field.
  - `/auth/register` auto-accepts the invite after user creation when the registered email matches the invite email.
  - `accept_invite` only notifies the inviter on the *first* acceptance, preventing duplicate "member joined" emails from the register-then-visit path.
- **Frontend**
  - `InviteAccept.tsx` rewritten. Unauthenticated visitors see "You're invited to {team} by {inviter}" with inline Create-account / Sign-in tabs (email prefilled, read-only on register). Authenticated visitors accept immediately as before.
  - `register()` in `api/auth.ts` + `AuthContext` carry `invite_token`.

## Test plan
- [ ] Invite a brand-new email to a team — click link while logged out → see invite landing → register → end up on the invitee's new team
- [ ] Invite an existing user's email — click link while logged out → switch to Sign-in tab → login → get added to team and redirected
- [ ] Invite an existing user's email — click link while already logged in → invite auto-accepts with no duplicate notification
- [ ] Check inviter receives exactly one "member joined" email
- [ ] Expired invite (>30 days) shows an appropriate error message
- [ ] Invalid / already-used token shows an appropriate error message
- [ ] Register with a mismatched email (not the invite's email) — invite is NOT accepted, user still created
- [ ] With `enable_trial_system=true`, inviting an outsider still works (doesn't push them to the waitlist)

🤖 Generated with [Claude Code](https://claude.com/claude-code)