### PR TITLE
Support .txt and .md file uploads

### DIFF
--- a/backend/app/routers/files.py
+++ b/backend/app/routers/files.py
@@ -49,6 +49,8 @@ MEDIA_TYPES = {
     ".xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
     ".xls": "application/vnd.ms-excel",
     ".csv": "text/csv",
+    ".txt": "text/plain; charset=utf-8",
+    ".md": "text/markdown; charset=utf-8",
 }
 
 

--- a/frontend/src/components/files/DocumentViewer.tsx
+++ b/frontend/src/components/files/DocumentViewer.tsx
@@ -101,7 +101,12 @@ export function DocumentViewer({ docUuid, highlightTerms = [], onClearHighlights
           if (cancelled) return
           pdfDataRef.current = data
           setIsPdf(true)
-        } else if (ct.includes('wordprocessingml') || ct.includes('msword')) {
+        } else if (
+          ct.includes('wordprocessingml') ||
+          ct.includes('msword') ||
+          ct.includes('markdown') ||
+          ct.includes('text/plain')
+        ) {
           setIsDocx(true)
           setIsPdf(false)
           pollStatus(docUuid).then(res => {

--- a/frontend/src/components/files/UploadZone.tsx
+++ b/frontend/src/components/files/UploadZone.tsx
@@ -64,13 +64,13 @@ export function UploadZone({ onFilesSelected, highlighted }: UploadZoneProps) {
         {active ? 'Drop files here' : 'Drag & Drop to Upload Files'}
       </div>
       <div style={{ fontSize: 12, fontWeight: 300, color: '#5d5d5d78' }}>
-        <i>pdf, doc, docx, xls, xlsx, csv</i>
+        <i>pdf, doc, docx, xls, xlsx, csv, txt, md</i>
       </div>
       <input
         ref={inputRef}
         type="file"
         multiple
-        accept=".pdf,.doc,.docx,.xlsx,.xls,.csv"
+        accept=".pdf,.doc,.docx,.xlsx,.xls,.csv,.txt,.md"
         className="hidden"
         onChange={(e) => {
           if (e.target.files?.length) onFilesSelected(e.target.files)


### PR DESCRIPTION
## Summary
- Accept `.txt` and `.md` in the upload zone and update the hint text.
- Send proper MIME types (`text/plain`, `text/markdown`) from `/api/files/download` so browsers render these inline instead of treating them as `application/octet-stream` downloads.
- Route markdown/plain-text responses through the viewer's existing `raw_text` renderer (marked + DOMPurify) — same path used for DOCX.

No backend pipeline changes were needed: `extract_text_from_file()` already handles `txt` and `md` by reading the file directly, so `raw_text`, token counts, compliance validation, and ChromaDB ingestion all work unchanged.

## Test plan
- [ ] Upload a `.txt` file: appears in document list, `raw_text` populated, opens in viewer as readable text
- [ ] Upload a `.md` file: renders as formatted markdown in the viewer (headings, lists, etc.)
- [ ] Existing `.pdf`, `.docx`, `.xlsx`, `.csv` uploads still work
- [ ] Uploaded `.txt`/`.md` docs are chat-able (ChromaDB ingestion path works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)