### PR TITLE
Fix txt/md upload rejection (backend allowlist + secondary picker)

### DIFF
--- a/backend/app/utils/file_validation.py
+++ b/backend/app/utils/file_validation.py
@@ -1,7 +1,7 @@
 import io
 import zipfile
 
-ALLOWED_EXTS = {"pdf", "doc", "docx", "xlsx", "xls", "csv"}
+ALLOWED_EXTS = {"pdf", "doc", "docx", "xlsx", "xls", "csv", "txt", "md"}
 
 
 def is_allowed_file(filename: str) -> bool:
@@ -34,7 +34,7 @@ def is_valid_file_content(data: bytes, extension: str) -> bool:
             return False
         return True
 
-    if ext == "csv":
+    if ext in ("csv", "txt", "md"):
         try:
             data[:8192].decode("utf-8")
             return True

--- a/frontend/src/components/files/FileBrowser.tsx
+++ b/frontend/src/components/files/FileBrowser.tsx
@@ -454,7 +454,7 @@ export function FileBrowser({ onDocClick, searchQuery = '', contentMatches, onSe
           ref={fileInputRef}
           type="file"
           multiple
-          accept=".pdf,.docx,.xlsx,.xls,.csv"
+          accept=".pdf,.doc,.docx,.xlsx,.xls,.csv,.txt,.md"
           className="hidden"
           onChange={(e) => {
             if (e.target.files?.length) upload(e.target.files)


### PR DESCRIPTION
## Summary
Follow-up to #329. Drag-and-drop of `.txt` / `.md` files still failed with a "not allowed" error because two gates hadn't been updated:

- **Backend allowlist** (`backend/app/utils/file_validation.py`): `ALLOWED_EXTS` rejected `txt`/`md` before upload even reached the storage layer. `is_valid_file_content` also had no branch for these extensions, so content validation would have failed regardless. Added both to `ALLOWED_EXTS` and to the UTF-8 decode path already used by `csv`.
- **Secondary file picker** (`frontend/src/components/files/FileBrowser.tsx`): the "Upload Files" menu item in FileBrowser uses its own hidden `<input>` with a stale `accept` list. Added `.txt`/`.md`, and included `.doc` for parity with `UploadZone`.

## Test plan
- [ ] Drag-and-drop a `.md` file → uploads without "not allowed" error
- [ ] Drag-and-drop a `.txt` file → uploads without "not allowed" error
- [ ] Click "Upload Files" from the Add menu → file picker shows `.txt` / `.md` as selectable
- [ ] Non-text garbage renamed to `.txt` (binary bytes) → rejected by `is_valid_file_content` (UTF-8 decode fails)
- [ ] Existing `.pdf`, `.docx`, `.xlsx`, `.csv` uploads still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)