### PR TITLE
Fix: import definition into open extraction instead of creating a ghost SearchSet

### DIFF
--- a/backend/app/routers/extractions.py
+++ b/backend/app/routers/extractions.py
@@ -212,9 +212,14 @@ async def export_search_set(uuid: str, user: User = Depends(get_current_user)):
 @router.post("/search-sets/import", response_model=SearchSetResponse)
 async def import_search_set(
     file: UploadFile = File(...),
+    target_uuid: Optional[str] = Form(None),
     user: User = Depends(get_current_user),
 ):
-    """Import an extraction from an exported JSON file."""
+    """Import an extraction from an exported JSON file.
+
+    If *target_uuid* is provided, items are appended to that existing SearchSet
+    and its extraction_config is replaced. Otherwise a new SearchSet is created.
+    """
     from app.services import export_import_service as eis
 
     content = await file.read()
@@ -223,9 +228,13 @@ async def import_search_set(
     except json.JSONDecodeError:
         raise HTTPException(status_code=400, detail="Invalid JSON file")
 
+    target = None
+    if target_uuid:
+        target = await _get_search_set_or_404(target_uuid, user, manage=True)
+
     team_id = str(user.current_team) if user.current_team else None
     try:
-        ss = await eis.import_search_set(data, user.user_id, team_id=team_id)
+        ss = await eis.import_search_set(data, user.user_id, team_id=team_id, target=target)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
 

--- a/backend/app/services/export_import_service.py
+++ b/backend/app/services/export_import_service.py
@@ -358,8 +358,18 @@ async def export_search_set(search_set_uuid: str, user_email: str) -> dict:
     return _envelope("search_set", user_email, [export_item])
 
 
-async def import_search_set(data: dict, user_id: str, team_id: str | None = None) -> SearchSet:
-    """Import a search set from export data. Returns the new SearchSet."""
+async def import_search_set(
+    data: dict,
+    user_id: str,
+    team_id: str | None = None,
+    target: SearchSet | None = None,
+) -> SearchSet:
+    """Import a search set from export data.
+
+    If *target* is provided, items and test cases are appended to it and its
+    extraction_config is replaced with the imported one. Otherwise a new
+    SearchSet is created. Returns the target or newly-created SearchSet.
+    """
     err = validate_export_data(data)
     if err:
         raise ValueError(err)
@@ -367,24 +377,30 @@ async def import_search_set(data: dict, user_id: str, team_id: str | None = None
         raise ValueError("Expected a search_set export file")
 
     item = data["items"][0]
-    new_uuid = str(uuid_mod.uuid4())
 
-    clone = SearchSet(
-        title=f"{item['title']} (Imported)",
-        uuid=new_uuid,
-        team_id=team_id,
-        status="active",
-        set_type=item.get("set_type", "extraction"),
-        user_id=user_id,
-        created_by_user_id=user_id,
-        extraction_config=item.get("extraction_config", {}),
-    )
-    await clone.insert()
+    if target is not None:
+        target.extraction_config = item.get("extraction_config", {})
+        await target.save()
+        ss_uuid = target.uuid
+        result = target
+    else:
+        ss_uuid = str(uuid_mod.uuid4())
+        result = SearchSet(
+            title=f"{item['title']} (Imported)",
+            uuid=ss_uuid,
+            team_id=team_id,
+            status="active",
+            set_type=item.get("set_type", "extraction"),
+            user_id=user_id,
+            created_by_user_id=user_id,
+            extraction_config=item.get("extraction_config", {}),
+        )
+        await result.insert()
 
     for field in item.get("items", []):
         new_item = SearchSetItem(
             searchphrase=field["searchphrase"],
-            searchset=new_uuid,
+            searchset=ss_uuid,
             searchtype=field.get("searchtype", "extraction"),
             title=field.get("title", field["searchphrase"]),
             user_id=user_id,
@@ -396,7 +412,7 @@ async def import_search_set(data: dict, user_id: str, team_id: str | None = None
     # Import text-based test cases
     for tc_data in item.get("test_cases", []):
         tc = ExtractionTestCase(
-            search_set_uuid=new_uuid,
+            search_set_uuid=ss_uuid,
             label=tc_data.get("label", "Imported test case"),
             source_type="text",
             source_text=tc_data.get("source_text", ""),
@@ -405,7 +421,7 @@ async def import_search_set(data: dict, user_id: str, team_id: str | None = None
         )
         await tc.insert()
 
-    return clone
+    return result
 
 
 # ---------------------------------------------------------------------------

--- a/frontend/src/api/extractions.ts
+++ b/frontend/src/api/extractions.ts
@@ -431,9 +431,10 @@ export function exportSearchSetUrl(uuid: string) {
   return `/api/extractions/search-sets/${uuid}/export`
 }
 
-export async function importSearchSet(file: File): Promise<SearchSet> {
+export async function importSearchSet(file: File, targetUuid?: string): Promise<SearchSet> {
   const form = new FormData()
   form.append('file', file)
+  if (targetUuid) form.append('target_uuid', targetUuid)
   const res = await fetch('/api/extractions/search-sets/import', {
     method: 'POST',
     credentials: 'include',

--- a/frontend/src/components/workspace/ExtractionEditorPanel.tsx
+++ b/frontend/src/components/workspace/ExtractionEditorPanel.tsx
@@ -527,8 +527,13 @@ export function ExtractionEditorPanel() {
               if (!f) return
               e.target.value = ''
               try {
-                const result = await importSearchSet(f)
-                openExtraction(result.uuid)
+                const result = await importSearchSet(f, openExtractionId ?? undefined)
+                if (openExtractionId) {
+                  await refresh()
+                  await refreshItems()
+                } else {
+                  openExtraction(result.uuid)
+                }
               } catch (err: unknown) {
                 alert(err instanceof Error ? err.message : 'Import failed')
               }


### PR DESCRIPTION
## Summary
- Clicking **Import Definition** from inside an open extraction used to create a brand-new SearchSet and navigate to it, leaving the user's original (empty) extraction behind. Returning to that extraction from the library made the imported targets appear to have been lost.
- The import endpoint now accepts an optional `target_uuid`. When provided, items and test cases are appended to the existing SearchSet and its `extraction_config` is replaced. The ToolsTab's import action passes the currently-open extraction's UUID and refreshes the SearchSet/items queries in place.
- Catalog imports (`import_catalog`) are unchanged — they continue to use the create-new path.

## Files
- `backend/app/services/export_import_service.py` — `import_search_set(..., target=None)`; when `target` is given, append to it and replace its config.
- `backend/app/routers/extractions.py` — `/search-sets/import` accepts `target_uuid` form field, resolves with `manage=True` access before calling the service.
- `frontend/src/api/extractions.ts` — `importSearchSet(file, targetUuid?)`.
- `frontend/src/components/workspace/ExtractionEditorPanel.tsx` — pass `openExtractionId`; after a successful import, refresh the SearchSet + items query instead of navigating.

## Test plan
- [ ] Create a new empty extraction → click **Tools → Import Definition** → pick a definition JSON. Targets appear in the current extraction (no navigation). Navigate away, reopen from the library — targets persist.
- [ ] Repeat with an extraction that already has items — imported items are appended; existing items remain.
- [ ] Verify extraction_config (model, one_pass/two_pass) updates to the imported value.
- [ ] Test cases from the export are attached to the target extraction and visible in the Validate tab.
- [ ] Import without a target UUID (e.g. via catalog import flow) still creates a new SearchSet.
- [ ] Import with a `target_uuid` the caller does not have manage access to returns 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)