### PR TITLE
Let admins pick the default LLM model

### DIFF
--- a/backend/app/models/system_config.py
+++ b/backend/app/models/system_config.py
@@ -111,6 +111,9 @@ class SystemConfig(Document):
     ocr_api_key: str = ""
     llm_endpoint: str = ""
     available_models: list[dict] = []
+    # Name of the model to use when no explicit model is chosen. Empty = fall
+    # back to the first entry in available_models.
+    default_model: str = ""
 
     # Legacy fields kept for backwards compatibility
     extraction_model: str = ""

--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -1224,6 +1224,7 @@ async def get_config(
         "auth_methods": cfg.auth_methods,
         "oauth_providers": _sanitize_providers(cfg.oauth_providers),
         "available_models": _sanitize_models(cfg.available_models),
+        "default_model": cfg.default_model or "",
         "ocr_endpoint": cfg.ocr_endpoint,
         "ocr_api_key": "***" if decrypt_value(cfg.ocr_api_key) else "",
         "llm_endpoint": cfg.llm_endpoint,
@@ -1334,6 +1335,7 @@ async def update_model(
     else:
         new_api_key = encrypt_value(new_api_key)
 
+    prev_name = cfg.available_models[index].get("name", "")
     cfg.available_models[index] = {
         "name": body.name,
         "tag": body.tag,
@@ -1350,13 +1352,16 @@ async def update_model(
         "supports_pdf": body.supports_pdf,
         "context_window": body.context_window,
     }
+    # Keep default_model pointer stable when the default is renamed.
+    if cfg.default_model and cfg.default_model == prev_name and body.name != prev_name:
+        cfg.default_model = body.name
     cfg.updated_at = datetime.datetime.now(datetime.timezone.utc)
     cfg.updated_by = user.user_id
     await cfg.save()
     clear_agent_caches()
     await _audit(user, "update_model", f"Updated model at index {index}: {body.tag}")
 
-    return {"status": "ok", "models": _sanitize_models(cfg.available_models)}
+    return {"status": "ok", "models": _sanitize_models(cfg.available_models), "default_model": cfg.default_model or ""}
 
 
 # ---------------------------------------------------------------------------
@@ -1375,13 +1380,52 @@ async def delete_model(
         raise HTTPException(status_code=404, detail="Model index out of range")
 
     removed = cfg.available_models.pop(index)
+    # Clear default_model if we just deleted it.
+    if cfg.default_model and cfg.default_model == removed.get("name", ""):
+        cfg.default_model = ""
     cfg.updated_at = datetime.datetime.now(datetime.timezone.utc)
     cfg.updated_by = user.user_id
     await cfg.save()
     clear_agent_caches()
     await _audit(user, "delete_model", f"Deleted model at index {index}: {removed.get('tag', '?')}")
 
-    return {"status": "ok", "removed": removed, "models": cfg.available_models}
+    return {"status": "ok", "removed": removed, "models": cfg.available_models, "default_model": cfg.default_model or ""}
+
+
+# ---------------------------------------------------------------------------
+# 8b. PUT /config/models/default  - Set (or clear) the system default model
+# ---------------------------------------------------------------------------
+
+class DefaultModelRequest(BaseModel):
+    name: str = ""
+
+
+@router.put("/config/models/default")
+async def set_default_model(
+    body: DefaultModelRequest,
+    user: User = Depends(get_current_user),
+):
+    await _require_superadmin(user)
+
+    cfg = await SystemConfig.get_config()
+    name = (body.name or "").strip()
+
+    if name:
+        match = next(
+            (m for m in cfg.available_models if isinstance(m, dict) and m.get("name") == name),
+            None,
+        )
+        if not match:
+            raise HTTPException(status_code=404, detail=f"Model '{name}' is not configured")
+
+    cfg.default_model = name
+    cfg.updated_at = datetime.datetime.now(datetime.timezone.utc)
+    cfg.updated_by = user.user_id
+    await cfg.save()
+    clear_agent_caches()
+    await _audit(user, "set_default_model", f"Default model: {name or '(cleared)'}")
+
+    return {"status": "ok", "default_model": cfg.default_model or ""}
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/services/config_service.py
+++ b/backend/app/services/config_service.py
@@ -22,8 +22,18 @@ async def get_llm_models() -> list[dict]:
 
 
 async def get_default_model_name() -> str:
-    """Return the first configured model name (never empty when models exist)."""
-    models = await get_llm_models()
+    """Return the configured default model name, or fall back to the first
+    available model. Never returns empty when at least one model is configured.
+    """
+    config = await SystemConfig.get_config()
+    models = config.available_models if config and config.available_models else []
+
+    configured_default = (config.default_model or "").strip() if config else ""
+    if configured_default:
+        for m in models:
+            if isinstance(m, dict) and m.get("name") == configured_default:
+                return configured_default
+
     for m in models:
         if isinstance(m, dict):
             name = m.get("name", "")

--- a/frontend/src/api/admin.ts
+++ b/frontend/src/api/admin.ts
@@ -213,6 +213,7 @@ export interface SystemConfigData {
   auth_methods: string[]
   oauth_providers: Record<string, unknown>[]
   available_models: { name: string; tag: string; external: boolean; thinking: boolean; endpoint?: string; api_protocol?: string; api_key?: string; speed?: string; tier?: string; privacy?: string; supports_structured?: boolean; multimodal?: boolean; supports_pdf?: boolean }[]
+  default_model: string
   ocr_endpoint: string
   ocr_api_key: string
   llm_endpoint: string
@@ -302,7 +303,14 @@ export function updateModel(index: number, data: { name: string; tag: string; ex
 }
 
 export function deleteModel(index: number) {
-  return apiFetch<{ status: string }>(`/api/admin/config/models/${index}`, { method: 'DELETE' })
+  return apiFetch<{ status: string; default_model?: string }>(`/api/admin/config/models/${index}`, { method: 'DELETE' })
+}
+
+export function setDefaultModel(name: string) {
+  return apiFetch<{ status: string; default_model: string }>('/api/admin/config/models/default', {
+    method: 'PUT',
+    body: JSON.stringify({ name }),
+  })
 }
 
 // Test connectivity

--- a/frontend/src/pages/Admin.tsx
+++ b/frontend/src/pages/Admin.tsx
@@ -6,7 +6,7 @@ import {
   CheckCircle2, XCircle, Clock, Download, TrendingUp, TrendingDown,
   ChevronDown, ChevronUp, ArrowUpDown, Play, Minus, AlertCircle,
   ArrowLeft, FileText, FolderTree, X, Eye, Check, CheckCircle,
-  Mail, Send, Link, UserPlus,
+  Mail, Send, Link, UserPlus, Star,
 } from 'lucide-react'
 import {
   AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer,
@@ -22,7 +22,7 @@ import {
   getUsageStats, getUsageTimeseries, getUserLeaderboard, getTeamLeaderboard,
   getTeamDetail, getUserDetail,
   getWorkflowEvents, getSystemConfig, updateSystemConfig, updateM365Config,
-  addModel, updateModel, deleteModel, testOcr, testModel, addOAuthProvider,
+  addModel, updateModel, deleteModel, setDefaultModel, testOcr, testModel, addOAuthProvider,
   updateOAuthProvider, deleteOAuthProvider, updateAuthMethods,
   getQualitySummary, getQualityTimeline, runRegressionSuite,
   getQualityAlerts, acknowledgeAlert, getQualityItems, getQualityItemDetail,
@@ -2346,7 +2346,14 @@ function ConfigTab() {
       } else {
         res = await addModel(newModel)
       }
-      if (cfg) setCfg({ ...cfg, available_models: res.models })
+      if (cfg) {
+        const resDefault = (res as { default_model?: string }).default_model
+        setCfg({
+          ...cfg,
+          available_models: res.models,
+          ...(resDefault !== undefined ? { default_model: resDefault } : {}),
+        })
+      }
       setNewModel({ name: '', tag: '', external: false, thinking: false, endpoint: '', api_protocol: '', api_key: '', speed: '', tier: '', privacy: '', supports_structured: true, multimodal: false, supports_pdf: false })
       setShowModelForm(false)
       setEditingModelIndex(null)
@@ -2381,14 +2388,29 @@ function ConfigTab() {
 
   const handleDeleteModel = async (index: number) => {
     try {
-      await deleteModel(index)
+      const res = await deleteModel(index)
       if (cfg) {
         const models = [...cfg.available_models]
         models.splice(index, 1)
-        setCfg({ ...cfg, available_models: models })
+        setCfg({
+          ...cfg,
+          available_models: models,
+          ...(res.default_model !== undefined ? { default_model: res.default_model } : {}),
+        })
       }
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Failed to delete model')
+    }
+  }
+
+  const handleSetDefaultModel = async (name: string) => {
+    try {
+      // Toggle off if clicking the current default.
+      const next = cfg?.default_model === name ? '' : name
+      const res = await setDefaultModel(next)
+      if (cfg) setCfg({ ...cfg, default_model: res.default_model })
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to set default model')
     }
   }
 
@@ -2573,6 +2595,11 @@ function ConfigTab() {
                     <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
                       <span style={{ fontSize: 14, fontWeight: 600, color: '#111' }}>{m.name}</span>
                       <span style={{ fontSize: 11, padding: '2px 8px', borderRadius: 9999, background: '#f3f4f6', color: '#6b7280', fontWeight: 600 }}>{m.tag}</span>
+                      {cfg?.default_model === m.name && (
+                        <span style={{ fontSize: 11, padding: '2px 8px', borderRadius: 9999, background: '#fef9c3', color: '#854d0e', fontWeight: 600, display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+                          <Star size={11} fill="currentColor" /> Default
+                        </span>
+                      )}
                       {m.external && (
                         <span style={{ fontSize: 11, padding: '2px 8px', borderRadius: 9999, background: '#fef3c7', color: '#92400e', fontWeight: 600 }}>External</span>
                       )}
@@ -2604,6 +2631,17 @@ function ConfigTab() {
                         {modelTestResults[i].ok ? <CheckCircle2 size={14} style={{ verticalAlign: -2 }} /> : <XCircle size={14} style={{ verticalAlign: -2 }} />}
                       </span>
                     )}
+                    <button
+                      onClick={() => handleSetDefaultModel(m.name)}
+                      style={{
+                        background: 'none', border: 'none', cursor: 'pointer',
+                        color: cfg?.default_model === m.name ? '#ca8a04' : '#9ca3af',
+                        padding: 4,
+                      }}
+                      title={cfg?.default_model === m.name ? 'Remove as default' : 'Set as default model'}
+                    >
+                      <Star size={16} fill={cfg?.default_model === m.name ? 'currentColor' : 'none'} />
+                    </button>
                     <button
                       onClick={() => handleTestModel(i)}
                       disabled={modelTesting === i}


### PR DESCRIPTION
## Summary
- Admin UI now lets you designate a specific LLM as the system default (star toggle + "Default" pill on the model row)
- `SystemConfig.default_model` stores the designated model name; `get_default_model_name()` prefers it when valid and falls back to the first available model otherwise
- Fixes the gap where UI referenced a "Default Model" (Regression Suite dropdown, extraction progress, extraction config fallbacks) but admins had no way to set it — the "default" was silently whichever model happened to be first in `available_models`

## Changes

**Backend**
- `SystemConfig.default_model: str = ""` new field
- `get_default_model_name()` reads configured default, validates it still exists, falls back to first model
- New endpoint `PUT /api/admin/config/models/default` to set/clear (validates target exists)
- Model rename updates the pointer; model delete clears it if it was the default
- `default_model` now included in `GET /api/admin/config` response

**Frontend**
- `SystemConfigData.default_model` added
- `setDefaultModel(name)` API helper
- Yellow "Default" pill next to the current default model
- Star action button on each model row (click to set; click the filled star to clear)

## Test plan
- [ ] Open Admin → Config → Available Models; click the star next to a model; confirm the "Default" pill appears on that row and no other
- [ ] Click the filled star on the default; confirm the pill disappears and the field clears
- [ ] Try to set a nonexistent model as default via the API directly; confirm 404
- [ ] Rename the current default model via Edit; confirm it remains marked as default after save
- [ ] Delete the current default model; confirm the default becomes unset
- [ ] In Chat with no user-model preference set, confirm the admin-designated default is used (not just the first in the list)
- [ ] Reload the page after setting; confirm the choice persists

Generated with Claude Code (https://claude.com/claude-code)
