### PR TITLE
KB: upload files from picker + filter by folder, and stop ingest EMFILE crashes

### DIFF
--- a/backend/app/routers/documents.py
+++ b/backend/app/routers/documents.py
@@ -43,9 +43,14 @@ async def list_documents(
 async def search_documents(
     q: str = Query(default="", min_length=0),
     limit: int = Query(default=20, ge=1, le=100),
+    folder: str | None = Query(default=None),
     user: User = Depends(get_current_user),
 ):
-    """Search documents by title or content text. Returns recent docs when q is empty."""
+    """Search documents by title or content text. Returns recent docs when q is empty.
+
+    When `folder` is provided, results are restricted to that folder value.
+    Pass folder="__root__" to match documents with no folder assigned.
+    """
     # Include user's own docs and team-scoped docs
     team_access = await access_control.get_team_access_context(user)
     owner_conditions: list[dict] = [{"user_id": user.user_id}]
@@ -53,18 +58,23 @@ async def search_documents(
         owner_conditions.append({"team_id": {"$in": list(team_access.team_uuids)}})
     if team_access.team_object_ids:
         owner_conditions.append({"team_id": {"$in": list(team_access.team_object_ids)}})
-    owner_filter = {"$or": owner_conditions}
+    owner_filter: dict = {"$or": owner_conditions}
+
+    base_conditions: list[dict] = [owner_filter]
+    if folder is not None:
+        if folder == "__root__":
+            base_conditions.append({"$or": [{"folder": None}, {"folder": ""}, {"folder": "0"}]})
+        else:
+            base_conditions.append({"folder": folder})
 
     if not q.strip():
-        results = await SmartDocument.find(
-            owner_filter,
-        ).sort(-SmartDocument.created_at).limit(limit).to_list()
+        query: dict = {"$and": base_conditions} if len(base_conditions) > 1 else owner_filter
+        results = await SmartDocument.find(query).sort(-SmartDocument.created_at).limit(limit).to_list()
     else:
         regex = re.compile(re.escape(q), re.IGNORECASE)
         results = await SmartDocument.find(
             {
-                "$and": [
-                    owner_filter,
+                "$and": base_conditions + [
                     {
                         "$or": [
                             {"title": {"$regex": regex.pattern, "$options": "i"}},

--- a/backend/app/services/document_manager.py
+++ b/backend/app/services/document_manager.py
@@ -1,6 +1,7 @@
 """Document Manager  - ChromaDB-backed document ingestion and semantic search for RAG."""
 
 import logging
+import threading
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Optional
@@ -9,6 +10,47 @@ import chromadb
 from chromadb.config import Settings as ChromaSettings
 
 logger = logging.getLogger(__name__)
+
+# Process-wide singletons. ChromaDB's default (ONNX MiniLM) does a stateful,
+# file-descriptor-heavy tarball extraction on first use; constructing a fresh
+# instance per task can exhaust fds (EMFILE on `onnx.tar.gz`) because Chroma's
+# `_download_model_if_not_exists` re-extracts whenever the extracted folder
+# isn't complete. Caching one instance per worker process ensures the model is
+# initialized exactly once.
+_EF_LOCK = threading.Lock()
+_DEFAULT_EF: Any = None
+_DM_LOCK = threading.Lock()
+_SHARED_DM: "DocumentManager | None" = None
+
+
+def get_default_embedding_function() -> Any:
+    """Return a process-wide cached ChromaDB default embedding function.
+
+    Lazily initialized on first call (inside the Celery worker process, after
+    fork) so model download/extraction happens once per process.
+    """
+    global _DEFAULT_EF
+    if _DEFAULT_EF is None:
+        with _EF_LOCK:
+            if _DEFAULT_EF is None:
+                from chromadb.utils import embedding_functions
+                _DEFAULT_EF = embedding_functions.DefaultEmbeddingFunction()
+    return _DEFAULT_EF
+
+
+def get_document_manager() -> "DocumentManager":
+    """Return a process-wide cached DocumentManager.
+
+    Reusing one DocumentManager (and therefore one PersistentClient + one
+    embedding function instance) across tasks prevents fd leaks and repeated
+    ONNX model initialization.
+    """
+    global _SHARED_DM
+    if _SHARED_DM is None:
+        with _DM_LOCK:
+            if _SHARED_DM is None:
+                _SHARED_DM = DocumentManager()
+    return _SHARED_DM
 
 
 def get_chroma_client(persist_directory: str | None = None) -> chromadb.ClientAPI:
@@ -78,7 +120,11 @@ def _split_text(text: str, chunk_size: int, chunk_overlap: int) -> list[str]:
 class DocumentManager:
     """Synchronous document manager  - safe to call from asyncio.to_thread()."""
 
-    def __init__(self, persist_directory: str | None = None) -> None:
+    def __init__(
+        self,
+        persist_directory: str | None = None,
+        embedding_function: Any = None,
+    ) -> None:
         if persist_directory is None:
             from app.config import Settings
             persist_directory = Settings().chromadb_persist_dir
@@ -87,10 +133,16 @@ class DocumentManager:
         self.chunk_overlap = 200
 
         self.client = get_chroma_client(persist_directory)
+        # Always pass an explicit embedding function to get_or_create_collection
+        # so Chroma doesn't construct a fresh ONNXMiniLM_L6_V2 per collection.
+        self.embedding_function = embedding_function or get_default_embedding_function()
 
     def get_user_collection(self, user_id: str) -> chromadb.Collection:
         collection_name = f"user_{user_id}_docs"
-        return self.client.get_or_create_collection(name=collection_name)
+        return self.client.get_or_create_collection(
+            name=collection_name,
+            embedding_function=self.embedding_function,
+        )
 
     def add_document(
         self,
@@ -175,7 +227,10 @@ class DocumentManager:
     def get_kb_collection(self, kb_uuid: str) -> chromadb.Collection:
         """Get or create a ChromaDB collection for a knowledge base."""
         collection_name = f"kb_{kb_uuid}"
-        return self.client.get_or_create_collection(name=collection_name)
+        return self.client.get_or_create_collection(
+            name=collection_name,
+            embedding_function=self.embedding_function,
+        )
 
     def add_to_kb(
         self,

--- a/backend/app/tasks/knowledge_base_tasks.py
+++ b/backend/app/tasks/knowledge_base_tasks.py
@@ -66,7 +66,7 @@ def _recalculate_kb(db, kb_uuid: str) -> None:
 )
 def kb_ingest_document(self, source_uuid: str) -> None:
     """Fetch a SmartDocument's raw_text, chunk and embed into the KB collection."""
-    from app.services.document_manager import DocumentManager
+    from app.services.document_manager import get_document_manager
 
     db = _get_db()
     source = db.knowledge_base_sources.find_one({"uuid": source_uuid})
@@ -100,8 +100,7 @@ def kb_ingest_document(self, source_uuid: str) -> None:
             _recalculate_kb(db, kb_uuid)
             return
 
-        from app.config import Settings
-        dm = DocumentManager(persist_directory=Settings().chromadb_persist_dir)
+        dm = get_document_manager()
         chunk_count = dm.add_to_kb(
             kb_uuid=kb_uuid,
             source_id=source_uuid,
@@ -142,7 +141,7 @@ def kb_ingest_document(self, source_uuid: str) -> None:
 )
 def kb_ingest_url(self, source_uuid: str) -> None:
     """Fetch URL content, chunk and embed into the KB collection."""
-    from app.services.document_manager import DocumentManager
+    from app.services.document_manager import get_document_manager
 
     db = _get_db()
     source = db.knowledge_base_sources.find_one({"uuid": source_uuid})
@@ -204,8 +203,7 @@ def kb_ingest_url(self, source_uuid: str) -> None:
             },
         )
 
-        from app.config import Settings
-        dm = DocumentManager(persist_directory=Settings().chromadb_persist_dir)
+        dm = get_document_manager()
         chunk_count = dm.add_to_kb(
             kb_uuid=kb_uuid,
             source_id=source_uuid,

--- a/backend/tests/test_knowledge_base_tasks.py
+++ b/backend/tests/test_knowledge_base_tasks.py
@@ -170,9 +170,9 @@ class TestKbIngestDocument:
         assert error_call[1]["$set"]["status"] == "error"
         assert "no text content" in error_call[1]["$set"]["error_message"]
 
-    @patch("app.services.document_manager.DocumentManager")
+    @patch("app.services.document_manager.get_document_manager")
     @patch("app.tasks.knowledge_base_tasks._get_db")
-    def test_successful_ingestion_sets_ready(self, mock_get_db, MockDM):
+    def test_successful_ingestion_sets_ready(self, mock_get_db, mock_get_dm):
         from app.tasks.knowledge_base_tasks import kb_ingest_document
 
         db = MagicMock()
@@ -186,10 +186,9 @@ class TestKbIngestDocument:
 
         mock_dm_instance = MagicMock()
         mock_dm_instance.add_to_kb.return_value = 42
-        MockDM.return_value = mock_dm_instance
+        mock_get_dm.return_value = mock_dm_instance
 
-        with patch("app.config.Settings"):
-            kb_ingest_document("src-uuid")
+        kb_ingest_document("src-uuid")
 
         mock_dm_instance.add_to_kb.assert_called_once_with(
             kb_uuid="kb-uuid",
@@ -204,9 +203,9 @@ class TestKbIngestDocument:
         assert ready_call[1]["$set"]["status"] == "ready"
         assert ready_call[1]["$set"]["chunk_count"] == 42
 
-    @patch("app.services.document_manager.DocumentManager")
+    @patch("app.services.document_manager.get_document_manager")
     @patch("app.tasks.knowledge_base_tasks._get_db")
-    def test_ingestion_error_sets_error_and_reraises(self, mock_get_db, MockDM):
+    def test_ingestion_error_sets_error_and_reraises(self, mock_get_db, mock_get_dm):
         from app.tasks.knowledge_base_tasks import kb_ingest_document
 
         db = MagicMock()
@@ -220,11 +219,10 @@ class TestKbIngestDocument:
 
         mock_dm_instance = MagicMock()
         mock_dm_instance.add_to_kb.side_effect = RuntimeError("ChromaDB down")
-        MockDM.return_value = mock_dm_instance
+        mock_get_dm.return_value = mock_dm_instance
 
-        with patch("app.config.Settings"):
-            with pytest.raises(RuntimeError, match="ChromaDB down"):
-                kb_ingest_document("src-uuid")
+        with pytest.raises(RuntimeError, match="ChromaDB down"):
+            kb_ingest_document("src-uuid")
 
         # Should have set error status
         calls = db.knowledge_base_sources.update_one.call_args_list
@@ -269,9 +267,9 @@ class TestKbIngestUrl:
         assert error_call[1]["$set"]["status"] == "error"
         assert "No URL specified" in error_call[1]["$set"]["error_message"]
 
-    @patch("app.services.document_manager.DocumentManager")
+    @patch("app.services.document_manager.get_document_manager")
     @patch("app.tasks.knowledge_base_tasks._get_db")
-    def test_successful_url_ingestion(self, mock_get_db, MockDM):
+    def test_successful_url_ingestion(self, mock_get_db, mock_get_dm):
         from app.tasks.knowledge_base_tasks import kb_ingest_url
 
         db = MagicMock()
@@ -283,14 +281,13 @@ class TestKbIngestUrl:
 
         mock_dm_instance = MagicMock()
         mock_dm_instance.add_to_kb.return_value = 7
-        MockDM.return_value = mock_dm_instance
+        mock_get_dm.return_value = mock_dm_instance
 
         mock_response = MagicMock()
         mock_response.text = "<html><head><title>Example Page</title></head><body><p>Hello world</p></body></html>"
         mock_response.raise_for_status = MagicMock()
 
-        with patch("app.config.Settings"), \
-             patch("httpx.get", return_value=mock_response), \
+        with patch("httpx.get", return_value=mock_response), \
              patch("app.utils.url_validation.validate_outbound_url"):
             kb_ingest_url("src-uuid")
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -77,6 +77,10 @@ services:
       - vandalizer
     volumes:
       - uploads:/app/static/uploads
+    ulimits:
+      nofile:
+        soft: 8192
+        hard: 8192
     restart: unless-stopped
     deploy:
       resources:
@@ -105,6 +109,10 @@ services:
       - vandalizer
     volumes:
       - uploads:/app/static/uploads
+    ulimits:
+      nofile:
+        soft: 8192
+        hard: 8192
     entrypoint: ["sh", "run_celery.sh", "start"]
     restart: unless-stopped
     deploy:

--- a/frontend/src/api/documents.ts
+++ b/frontend/src/api/documents.ts
@@ -28,9 +28,10 @@ export interface SearchResult {
   token_count: number
 }
 
-export function searchDocuments(query: string = '', limit: number = 20) {
+export function searchDocuments(query: string = '', limit: number = 20, folder?: string | null) {
   const params = new URLSearchParams({ limit: String(limit) })
   if (query) params.set('q', query)
+  if (folder !== undefined && folder !== null) params.set('folder', folder)
   return apiFetch<{ items: SearchResult[]; total: number }>(
     `/api/documents/search?${params}`
   )

--- a/frontend/src/api/folders.ts
+++ b/frontend/src/api/folders.ts
@@ -28,3 +28,16 @@ export function getBreadcrumbs(folderUuid: string) {
     `/api/folders/breadcrumbs/${folderUuid}`,
   )
 }
+
+export interface FolderSummary {
+  uuid: string
+  title: string
+  path: string
+  parent_id: string
+  is_shared_team_root: boolean
+  team_id: string | null
+}
+
+export function listAllFolders() {
+  return apiFetch<FolderSummary[]>('/api/folders/all')
+}

--- a/frontend/src/components/knowledge/DocumentPickerModal.tsx
+++ b/frontend/src/components/knowledge/DocumentPickerModal.tsx
@@ -1,6 +1,8 @@
-import { useState, useEffect, useCallback } from 'react'
-import { X, Search, FileText, Loader2, Check } from 'lucide-react'
+import { useState, useEffect, useCallback, useRef } from 'react'
+import { X, Search, FileText, Loader2, Check, Upload, FolderIcon } from 'lucide-react'
 import { searchDocuments, type SearchResult } from '../../api/documents'
+import { listAllFolders, type FolderSummary } from '../../api/folders'
+import { uploadFile } from '../../api/files'
 
 interface DocumentPickerModalProps {
   onSubmit: (docUuids: string[]) => void
@@ -8,16 +10,43 @@ interface DocumentPickerModalProps {
   existingSourceUuids?: string[]
 }
 
+type UploadStatus = 'uploading' | 'done' | 'error'
+interface UploadItem {
+  name: string
+  status: UploadStatus
+  uuid?: string
+  error?: string
+}
+
+function fileToBase64(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = () => {
+      const result = reader.result as string
+      resolve(result.split(',')[1])
+    }
+    reader.onerror = reject
+    reader.readAsDataURL(file)
+  })
+}
+
 export function DocumentPickerModal({ onSubmit, onClose, existingSourceUuids = [] }: DocumentPickerModalProps) {
   const [query, setQuery] = useState('')
   const [results, setResults] = useState<SearchResult[]>([])
   const [loading, setLoading] = useState(false)
   const [selected, setSelected] = useState<Set<string>>(new Set())
+  const [folders, setFolders] = useState<FolderSummary[]>([])
+  const [folderFilter, setFolderFilter] = useState<string>('')  // '' = all folders
+  const [uploads, setUploads] = useState<UploadItem[]>([])
+  const [dragActive, setDragActive] = useState(false)
+  const fileInputRef = useRef<HTMLInputElement>(null)
+  const dragCounterRef = useRef(0)
 
-  const doSearch = useCallback(async (q: string) => {
+  const doSearch = useCallback(async (q: string, folder: string) => {
     setLoading(true)
     try {
-      const data = await searchDocuments(q, 30)
+      const folderParam = folder === '' ? undefined : folder
+      const data = await searchDocuments(q, 30, folderParam)
       setResults(data.items.filter(d => !existingSourceUuids.includes(d.uuid)))
     } catch (err) {
       console.error('Search failed:', err)
@@ -26,17 +55,25 @@ export function DocumentPickerModal({ onSubmit, onClose, existingSourceUuids = [
     }
   }, [existingSourceUuids])
 
-  // Load initial results
+  // Load folders on mount
   useEffect(() => {
-    doSearch('')
-  }, [doSearch])
+    listAllFolders()
+      .then(setFolders)
+      .catch(err => console.error('Failed to load folders:', err))
+  }, [])
+
+  // Load initial results and reload when folder filter changes
+  useEffect(() => {
+    doSearch(query, folderFilter)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [folderFilter])
 
   // Debounced search on query change
   useEffect(() => {
-    if (!query) return
-    const timer = setTimeout(() => doSearch(query), 300)
+    const timer = setTimeout(() => doSearch(query, folderFilter), 300)
     return () => clearTimeout(timer)
-  }, [query, doSearch])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [query])
 
   const toggleDoc = (uuid: string) => {
     setSelected(prev => {
@@ -53,6 +90,105 @@ export function DocumentPickerModal({ onSubmit, onClose, existingSourceUuids = [
     }
   }
 
+  const folderPathByUuid = useCallback((uuid: string | null | undefined) => {
+    if (!uuid || uuid === '0' || uuid === '') return ''
+    return folders.find(f => f.uuid === uuid)?.path ?? ''
+  }, [folders])
+
+  const handleFiles = async (files: File[]) => {
+    if (files.length === 0) return
+    const targetFolder = folderFilter && folderFilter !== '__root__' ? folderFilter : undefined
+    const initial: UploadItem[] = files.map(f => ({ name: f.name, status: 'uploading' }))
+    setUploads(prev => [...prev, ...initial])
+    const startIdx = uploads.length
+    const newUuids: string[] = []
+    for (let i = 0; i < files.length; i++) {
+      const file = files[i]
+      const ext = file.name.split('.').pop() || ''
+      try {
+        const base64 = await fileToBase64(file)
+        const result = await uploadFile({
+          contentAsBase64String: base64,
+          fileName: file.name,
+          extension: ext,
+          folder: targetFolder,
+        })
+        if (result.uuid) {
+          newUuids.push(result.uuid)
+          setUploads(prev => {
+            const next = [...prev]
+            next[startIdx + i] = { ...next[startIdx + i], status: 'done', uuid: result.uuid }
+            return next
+          })
+        } else {
+          setUploads(prev => {
+            const next = [...prev]
+            next[startIdx + i] = { ...next[startIdx + i], status: 'error', error: 'Upload failed' }
+            return next
+          })
+        }
+      } catch (err) {
+        setUploads(prev => {
+          const next = [...prev]
+          next[startIdx + i] = {
+            ...next[startIdx + i],
+            status: 'error',
+            error: err instanceof Error ? err.message : 'Upload failed',
+          }
+          return next
+        })
+      }
+    }
+    if (newUuids.length > 0) {
+      setSelected(prev => {
+        const next = new Set(prev)
+        newUuids.forEach(u => next.add(u))
+        return next
+      })
+      // Refresh list so uploaded docs are visible in results
+      doSearch(query, folderFilter)
+    }
+  }
+
+  const onFileInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = e.target.files ? Array.from(e.target.files) : []
+    handleFiles(files)
+    if (fileInputRef.current) fileInputRef.current.value = ''
+  }
+
+  const onDragEnter = (e: React.DragEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+    dragCounterRef.current += 1
+    if (e.dataTransfer.items && e.dataTransfer.items.length > 0) {
+      setDragActive(true)
+    }
+  }
+  const onDragLeave = (e: React.DragEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+    dragCounterRef.current -= 1
+    if (dragCounterRef.current <= 0) {
+      dragCounterRef.current = 0
+      setDragActive(false)
+    }
+  }
+  const onDragOver = (e: React.DragEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+  }
+  const onDrop = (e: React.DragEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+    dragCounterRef.current = 0
+    setDragActive(false)
+    const files = e.dataTransfer.files ? Array.from(e.dataTransfer.files) : []
+    handleFiles(files)
+  }
+
+  const uploadingCount = uploads.filter(u => u.status === 'uploading').length
+  const sortedFolders = [...folders].sort((a, b) => a.path.localeCompare(b.path))
+
   return (
     <div
       style={{
@@ -64,13 +200,31 @@ export function DocumentPickerModal({ onSubmit, onClose, existingSourceUuids = [
     >
       <div
         style={{
-          width: 520, maxHeight: '80vh',
+          width: 560, maxHeight: '85vh',
           backgroundColor: '#1e1e1e', borderRadius: 12,
-          border: '1px solid #3a3a3a', padding: 24,
-          display: 'flex', flexDirection: 'column', gap: 16,
+          border: dragActive ? '1px dashed var(--highlight-color, #eab308)' : '1px solid #3a3a3a',
+          padding: 24,
+          display: 'flex', flexDirection: 'column', gap: 14,
+          position: 'relative',
         }}
         onClick={e => e.stopPropagation()}
+        onDragEnter={onDragEnter}
+        onDragLeave={onDragLeave}
+        onDragOver={onDragOver}
+        onDrop={onDrop}
       >
+        {dragActive && (
+          <div style={{
+            position: 'absolute', inset: 0, borderRadius: 12, pointerEvents: 'none',
+            backgroundColor: 'rgba(234, 179, 8, 0.08)',
+            display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 2,
+          }}>
+            <div style={{ fontSize: 14, fontWeight: 600, color: 'var(--highlight-color, #eab308)' }}>
+              Drop files to upload
+            </div>
+          </div>
+        )}
+
         {/* Header */}
         <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
           <span style={{ fontSize: 16, fontWeight: 600, color: '#fff' }}>Add Documents</span>
@@ -82,22 +236,92 @@ export function DocumentPickerModal({ onSubmit, onClose, existingSourceUuids = [
           </button>
         </div>
 
-        {/* Search */}
-        <div style={{ position: 'relative' }}>
-          <Search size={14} style={{ position: 'absolute', left: 12, top: '50%', transform: 'translateY(-50%)', color: '#666' }} />
+        {/* Upload row */}
+        <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
           <input
-            type="text"
-            value={query}
-            onChange={e => setQuery(e.target.value)}
-            placeholder="Search documents..."
-            style={{
-              width: '100%', padding: '10px 12px 10px 34px', fontSize: 13, fontFamily: 'inherit',
-              backgroundColor: '#2a2a2a', color: '#e5e5e5',
-              border: '1px solid #3a3a3a', borderRadius: 8, outline: 'none',
-              boxSizing: 'border-box',
-            }}
+            ref={fileInputRef}
+            type="file"
+            multiple
+            onChange={onFileInputChange}
+            style={{ display: 'none' }}
           />
+          <button
+            onClick={() => fileInputRef.current?.click()}
+            style={{
+              display: 'flex', alignItems: 'center', gap: 6,
+              padding: '8px 12px', fontSize: 13, fontWeight: 500, fontFamily: 'inherit',
+              color: '#000', backgroundColor: 'var(--highlight-color, #eab308)',
+              border: 'none', borderRadius: 6, cursor: 'pointer',
+            }}
+          >
+            <Upload size={14} />
+            Upload files
+          </button>
+          <span style={{ fontSize: 12, color: '#888' }}>
+            or drag &amp; drop anywhere in this dialog
+          </span>
         </div>
+
+        {/* Folder filter + Search */}
+        <div style={{ display: 'flex', gap: 8 }}>
+          <div style={{ position: 'relative', flex: 1 }}>
+            <Search size={14} style={{ position: 'absolute', left: 12, top: '50%', transform: 'translateY(-50%)', color: '#666' }} />
+            <input
+              type="text"
+              value={query}
+              onChange={e => setQuery(e.target.value)}
+              placeholder="Search by name or content..."
+              style={{
+                width: '100%', padding: '10px 12px 10px 34px', fontSize: 13, fontFamily: 'inherit',
+                backgroundColor: '#2a2a2a', color: '#e5e5e5',
+                border: '1px solid #3a3a3a', borderRadius: 8, outline: 'none',
+                boxSizing: 'border-box',
+              }}
+            />
+          </div>
+          <div style={{ position: 'relative', width: 180 }}>
+            <FolderIcon size={14} style={{ position: 'absolute', left: 10, top: '50%', transform: 'translateY(-50%)', color: '#666', pointerEvents: 'none' }} />
+            <select
+              value={folderFilter}
+              onChange={e => setFolderFilter(e.target.value)}
+              style={{
+                width: '100%', padding: '10px 10px 10px 30px', fontSize: 13, fontFamily: 'inherit',
+                backgroundColor: '#2a2a2a', color: '#e5e5e5',
+                border: '1px solid #3a3a3a', borderRadius: 8, outline: 'none',
+                appearance: 'none', boxSizing: 'border-box', cursor: 'pointer',
+              }}
+            >
+              <option value="">All folders</option>
+              <option value="__root__">Root (no folder)</option>
+              {sortedFolders.map(f => (
+                <option key={f.uuid} value={f.uuid}>{f.path}</option>
+              ))}
+            </select>
+          </div>
+        </div>
+
+        {/* Upload progress */}
+        {uploads.length > 0 && (
+          <div style={{
+            display: 'flex', flexDirection: 'column', gap: 4,
+            maxHeight: 100, overflowY: 'auto',
+            padding: 8, backgroundColor: '#252525', borderRadius: 6,
+            border: '1px solid #333',
+          }}>
+            {uploads.map((u, i) => (
+              <div key={i} style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 12 }}>
+                {u.status === 'uploading' && <Loader2 size={12} style={{ color: '#888', animation: 'spin 1s linear infinite' }} />}
+                {u.status === 'done' && <Check size={12} style={{ color: '#6a9955' }} />}
+                {u.status === 'error' && <X size={12} style={{ color: '#c75450' }} />}
+                <span style={{ color: '#ccc', flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                  {u.name}
+                </span>
+                {u.status === 'error' && <span style={{ color: '#c75450', fontSize: 11 }}>{u.error}</span>}
+                {u.status === 'done' && <span style={{ color: '#6a9955', fontSize: 11 }}>uploaded &amp; selected</span>}
+              </div>
+            ))}
+          </div>
+        )}
 
         {/* Results */}
         <div style={{ flex: 1, overflowY: 'auto', maxHeight: 360, minHeight: 120 }}>
@@ -107,12 +331,13 @@ export function DocumentPickerModal({ onSubmit, onClose, existingSourceUuids = [
             </div>
           ) : results.length === 0 ? (
             <div style={{ textAlign: 'center', padding: 30, color: '#888', fontSize: 13 }}>
-              {query ? 'No documents found' : 'No documents available'}
+              {query ? 'No documents found' : folderFilter ? 'No documents in this folder' : 'No documents available — upload some above'}
             </div>
           ) : (
             <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
               {results.map(doc => {
                 const isSelected = selected.has(doc.uuid)
+                const folderPath = folderPathByUuid(doc.folder)
                 return (
                   <button
                     key={doc.uuid}
@@ -144,8 +369,13 @@ export function DocumentPickerModal({ onSubmit, onClose, existingSourceUuids = [
                       }}>
                         {doc.title}
                       </div>
-                      <div style={{ fontSize: 11, color: '#888', marginTop: 2 }}>
-                        {doc.extension.toUpperCase()}{doc.num_pages > 0 ? ` \u00b7 ${doc.num_pages} pages` : ''}
+                      <div style={{
+                        fontSize: 11, color: '#888', marginTop: 2,
+                        overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+                      }}>
+                        {doc.extension.toUpperCase()}
+                        {doc.num_pages > 0 ? ` · ${doc.num_pages} pages` : ''}
+                        {folderPath ? ` · ${folderPath}` : ''}
                       </div>
                     </div>
                   </button>
@@ -159,6 +389,7 @@ export function DocumentPickerModal({ onSubmit, onClose, existingSourceUuids = [
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
           <span style={{ fontSize: 12, color: '#888' }}>
             {selected.size > 0 ? `${selected.size} selected` : ''}
+            {uploadingCount > 0 ? `${selected.size > 0 ? ' · ' : ''}${uploadingCount} uploading` : ''}
           </span>
           <div style={{ display: 'flex', gap: 8 }}>
             <button
@@ -173,13 +404,13 @@ export function DocumentPickerModal({ onSubmit, onClose, existingSourceUuids = [
             </button>
             <button
               onClick={handleSubmit}
-              disabled={selected.size === 0}
+              disabled={selected.size === 0 || uploadingCount > 0}
               style={{
                 padding: '8px 16px', fontSize: 13, fontWeight: 600, fontFamily: 'inherit',
                 color: '#000', backgroundColor: 'var(--highlight-color, #eab308)',
                 border: 'none', borderRadius: 6,
-                cursor: selected.size > 0 ? 'pointer' : 'default',
-                opacity: selected.size > 0 ? 1 : 0.5,
+                cursor: selected.size > 0 && uploadingCount === 0 ? 'pointer' : 'default',
+                opacity: selected.size > 0 && uploadingCount === 0 ? 1 : 0.5,
               }}
             >
               Add {selected.size > 0 ? `(${selected.size})` : ''}


### PR DESCRIPTION
## Summary

Two related knowledge-base changes bundled so they ship together.

### 1. Richer Add-Documents picker (feat)

Adding sources to a KB previously required searching an existing document by name/content with no folder context and no way to bring in a new file. The picker now supports folder filtering, direct local upload, and shows folder paths on each result.

- New optional folder param on GET /api/documents/search — pass a folder uuid to scope results, or the special value __root__ to match documents with no folder.
- listAllFolders() API wrapper + a folder dropdown in DocumentPickerModal.
- Upload-from-local inside the picker: an "Upload files" button plus whole-dialog drag-and-drop. Uploaded docs are auto-selected so one click adds them to the KB. If a folder filter is active, uploads land in that folder.
- Each result now shows its folder path alongside extension/pages, which is how users tell apart similarly-named files.
- "Add" is disabled while uploads are in flight to avoid partial adds.

### 2. Fix EMFILE on KB ingest (bug)

Users reported "[Errno 24] Too many open files: /home/appuser/.cache/chroma/onnx_models/all-MiniLM-L6-v2/onnx.tar.gz in add" after adding 2 xlsx sources to a new KB. Status went to "Error", chunks stayed at 0, chat became unavailable.

Root cause: every KB task built a fresh DocumentManager → fresh PersistentClient → get_or_create_collection() with no embedding_function. ChromaDB then constructed a brand-new ONNXMiniLM_L6_V2 per collection. That class re-runs _download_model_if_not_exists() on every __call__ and re-extracts onnx.tar.gz whenever any file is missing from the extracted folder. With OSError in TRANSIENT_EXCEPTIONS, a single EMFILE cascaded into three retries that each tried to re-extract — once the first extraction failed partway through, the half-populated folder guaranteed all subsequent attempts would also try to re-extract (and also fail).

Fix:
- Process-wide thread-safe lazy singletons for the ChromaDB default embedding function and for DocumentManager. Lazy init (not at import) keeps it fork-safe under Celery prefork.
- Both get_user_collection and get_kb_collection now pass the cached embedding_function explicitly into get_or_create_collection, so Chroma never constructs its own ONNX instance per collection.
- kb_ingest_document / kb_ingest_url use the cached DocumentManager so retries and sibling tasks share one client + one embedder.
- compose.yaml: raised ulimits.nofile to 8192 on api and celery as defense-in-depth.

## Test plan

- [x] backend-ci — test_knowledge_base_tasks, test_document_tasks, test_documents_routes all pass (53 tests relevant to this change).
- [x] Frontend typecheck clean; documents.test.ts still passes.
- [x] Ruff clean on modified backend files.
- [ ] Manual: open the KB picker in the workspace, verify folder dropdown is populated, upload a local file via the button, upload another via drag-and-drop, confirm both appear selected and land in the KB on "Add".
- [ ] Manual: in a compose environment, add 2+ xlsx sources to a fresh KB and confirm ingestion reaches ready with chunk counts.
- [ ] Manual: existing KBs that were left in "Error" state still need their failed sources removed + re-added — the fix prevents new occurrences but does not retroactively recover them.

## Notes for review

- The picker upload / drag-and-drop path has no automated test coverage (the modal has no test file). Worth a brief manual pass in the KB view.
- Ingest fix only touches the KB Celery tasks directly; other DocumentManager() call sites (chat_service, knowledge_service, etc.) already use cached-instance patterns or are not on the per-task hot path, so they are left untouched here.
- If the production container still has a half-populated ~/.cache/chroma/onnx_models/all-MiniLM-L6-v2/onnx/ from the failed run, the first post-deploy ingest will cleanly re-extract — no manual cleanup strictly required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)