### PR TITLE
Fix admin.py use of get_agent_model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Updated stale backend config/auth tests to match the production `openai_api_key` requirement
 - Split backend release-gating tests from the current backend static-analysis backlog via `make backend-ci` and `make backend-static`
 - The canonical `bootstrap_install.py` entrypoint is now covered directly in the backend test suite, not only through helper-level script tests
+- Fix broken 'Test model' button in Admin Config UI
 
 ### Security
 - JWT secret validation: app refuses to start with the default `change-me` secret in non-development environments

--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -2025,7 +2025,7 @@ async def test_model(index: int, user: User = Depends(get_current_user)):
     try:
         from pydantic_ai import Agent
 
-        model = get_agent_model(model_name)
+        model = get_agent_model(model_name, system_config_doc=cfg.model_dump())
         agent = Agent(model, system_prompt="Reply with exactly: ok")
         result = await agent.run("Say ok")
         return {


### PR DESCRIPTION
## Summary

Make sure a model's system config is used during testing in Admin panel.

## Changes

`backend/app/routers/admin.py`

## Test Plan

- [x] Shared checks pass (`make ci`)
- [x] Release check passes if packaging or deployment changed (`make release-check`)
- [x] Manually tested the affected feature(s)
- [x] Updated `CHANGELOG.md` for user-facing or operator-facing changes
- [x] Updated deploy/release docs (`README.md`, `DEPLOY.md`, `OPERATIONS.md`, or `RELEASE_CHECKLIST.md`) if the install or release path changed

## Related Issues

Closes #337 
