### PR TITLE
Add knowledge base export and import

### DIFF
--- a/backend/app/routers/knowledge.py
+++ b/backend/app/routers/knowledge.py
@@ -1,6 +1,9 @@
 """Knowledge Base API routes."""
 
+import re
+
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from fastapi.responses import JSONResponse
 
 from app.dependencies import get_current_user
 from app.rate_limit import limiter
@@ -11,6 +14,8 @@ from app.schemas.knowledge import (
     AddUrlsRequest,
     AdoptKBRequest,
     CreateKBRequest,
+    ImportKBRequest,
+    ImportKBResponse,
     KBDetailResponse,
     KBListResponse,
     KBReferenceResponse,
@@ -169,6 +174,44 @@ async def create_knowledge_base(req: CreateKBRequest, user: User = Depends(get_c
         team_id=team_id, description=req.description,
     )
     return _kb_response(kb)
+
+
+@router.post("/import", response_model=ImportKBResponse)
+async def import_knowledge_base(req: ImportKBRequest, user: User = Depends(get_current_user)):
+    """Import a knowledge base from a previously exported payload.
+
+    Creates a new KB owned by the importing user and re-ingests all sources
+    (regenerating embeddings). The importer's team becomes the KB's team.
+    """
+    try:
+        kb = await svc.import_knowledge_base(
+            req.payload.model_dump(),
+            user,
+            title_override=req.title,
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    return ImportKBResponse(
+        uuid=kb.uuid,
+        title=kb.title,
+        imported_sources=kb.total_sources,
+    )
+
+
+@router.get("/{uuid}/export")
+async def export_knowledge_base(uuid: str, user: User = Depends(get_current_user)):
+    """Download a JSON export of a knowledge base (metadata + source content).
+
+    Embeddings are not included — they are regenerated when the file is imported.
+    """
+    kb = await _get_kb_or_404(uuid, user)
+    payload = await svc.export_knowledge_base(kb)
+    safe_title = re.sub(r"[^A-Za-z0-9_.-]+", "_", kb.title or "knowledge_base").strip("_")
+    filename = f"{safe_title or 'knowledge_base'}.kb.json"
+    return JSONResponse(
+        content=payload,
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )
 
 
 @router.get("/{uuid}", response_model=KBDetailResponse)

--- a/backend/app/schemas/knowledge.py
+++ b/backend/app/schemas/knowledge.py
@@ -94,3 +94,40 @@ class KBStatusResponse(BaseModel):
     sources_failed: int = 0
     total_chunks: int = 0
     sources: list[dict] = []
+
+
+# --- Export / Import ---
+
+KB_EXPORT_FORMAT_VERSION = 1
+
+
+class KBExportSource(BaseModel):
+    source_type: str  # "document" | "url"
+    document_uuid: Optional[str] = None
+    document_title: Optional[str] = None  # snapshot of SmartDocument.title at export time
+    url: Optional[str] = None
+    url_title: Optional[str] = None
+    content: Optional[str] = None  # cached raw text (for URLs) or document raw_text (for docs)
+    crawl_enabled: bool = False
+    max_crawl_pages: int = 5
+    parent_source_uuid: Optional[str] = None
+    crawled_urls: Optional[list[str]] = None
+
+
+class KBExportPayload(BaseModel):
+    format_version: int = KB_EXPORT_FORMAT_VERSION
+    exported_at: Optional[str] = None
+    title: str
+    description: Optional[str] = None
+    sources: list[KBExportSource] = []
+
+
+class ImportKBRequest(BaseModel):
+    payload: KBExportPayload
+    title: Optional[str] = None  # override title on import
+
+
+class ImportKBResponse(BaseModel):
+    uuid: str
+    title: str
+    imported_sources: int

--- a/backend/app/services/knowledge_service.py
+++ b/backend/app/services/knowledge_service.py
@@ -705,6 +705,130 @@ async def _crawl_from_source(
     return added
 
 
+# --- Export / Import ---
+
+
+async def export_knowledge_base(kb: KnowledgeBase) -> dict:
+    """Serialize a KB and its sources into a self-contained JSON-safe dict.
+
+    Includes cached raw text for each source (document raw_text or URL-extracted
+    text) so the importer can reconstruct + re-embed without re-fetching. Does
+    NOT include ChromaDB vectors — embeddings are regenerated on import.
+    """
+    sources = await get_kb_sources(kb.uuid)
+    exported_sources: list[dict] = []
+    for s in sources:
+        content = s.content
+        document_title: str | None = None
+        if s.source_type == "document" and s.document_uuid:
+            doc = await SmartDocument.find_one(SmartDocument.uuid == s.document_uuid)
+            if doc:
+                document_title = doc.title
+                if not content:
+                    content = doc.raw_text or None
+        exported_sources.append({
+            "source_type": s.source_type,
+            "document_uuid": s.document_uuid,
+            "document_title": document_title,
+            "url": s.url,
+            "url_title": s.url_title,
+            "content": content,
+            "crawl_enabled": s.crawl_enabled,
+            "max_crawl_pages": s.max_crawl_pages,
+            "parent_source_uuid": s.parent_source_uuid,
+            "crawled_urls": s.crawled_urls,
+        })
+    return {
+        "format_version": 1,
+        "exported_at": datetime.datetime.now(tz=datetime.timezone.utc).isoformat(),
+        "title": kb.title,
+        "description": kb.description,
+        "sources": exported_sources,
+    }
+
+
+async def import_knowledge_base(
+    payload: dict,
+    user: User,
+    *,
+    title_override: str | None = None,
+) -> KnowledgeBase:
+    """Create a new KB for the user from an exported payload and re-ingest sources."""
+    format_version = payload.get("format_version", 1)
+    if format_version != 1:
+        raise ValueError(f"Unsupported export format version: {format_version}")
+
+    raw_title = (title_override or payload.get("title") or "Imported Knowledge Base").strip()
+    if not raw_title:
+        raw_title = "Imported Knowledge Base"
+
+    team_id = str(user.current_team) if user.current_team else None
+    kb = KnowledgeBase(
+        title=raw_title[:300],
+        description=(payload.get("description") or "")[:5000] or None,
+        user_id=user.user_id,
+        team_id=team_id,
+    )
+    await kb.insert()
+
+    imported = 0
+    dm = _get_dm()
+
+    for src in payload.get("sources", []) or []:
+        source_type = src.get("source_type")
+        content = src.get("content")
+        if source_type not in ("document", "url"):
+            continue
+
+        new_src = KnowledgeBaseSource(
+            knowledge_base_uuid=kb.uuid,
+            source_type=source_type,
+            document_uuid=src.get("document_uuid"),
+            url=(src.get("url") or None),
+            url_title=src.get("url_title"),
+            content=content,
+            crawl_enabled=bool(src.get("crawl_enabled", False)),
+            max_crawl_pages=int(src.get("max_crawl_pages") or 5),
+            parent_source_uuid=src.get("parent_source_uuid"),
+            crawled_urls=src.get("crawled_urls"),
+        )
+        await new_src.insert()
+        imported += 1
+
+        if content and content.strip():
+            label = (
+                src.get("document_title")
+                or new_src.url_title
+                or new_src.url
+                or "Imported Source"
+            )
+            new_src.status = "processing"
+            await new_src.save()
+            try:
+                chunk_count = await asyncio.to_thread(
+                    dm.add_to_kb, kb.uuid, new_src.uuid, label, content,
+                )
+                new_src.chunk_count = chunk_count
+                new_src.status = "ready"
+                new_src.processed_at = datetime.datetime.now(tz=datetime.timezone.utc)
+                await new_src.save()
+            except Exception as e:
+                logger.error(f"Error ingesting imported source {new_src.uuid}: {e}")
+                new_src.status = "error"
+                new_src.error_message = str(e)[:2000]
+                await new_src.save()
+        elif source_type == "url" and new_src.url:
+            # No cached content — re-fetch the URL
+            await _ingest_url_source(new_src, kb)
+        else:
+            new_src.status = "error"
+            new_src.error_message = "Imported source had no content and no URL to re-fetch"
+            await new_src.save()
+
+    await recalculate_stats(kb)
+    return kb
+
+
 # --- Ingestion helpers ---
 
 

--- a/frontend/src/api/knowledge.ts
+++ b/frontend/src/api/knowledge.ts
@@ -191,6 +191,60 @@ export function cloneKnowledgeBase(uuid: string, title?: string) {
   })
 }
 
+// Export / Import
+
+export interface KBExportPayload {
+  format_version: number
+  exported_at?: string | null
+  title: string
+  description?: string | null
+  sources: {
+    source_type: 'document' | 'url'
+    document_uuid?: string | null
+    document_title?: string | null
+    url?: string | null
+    url_title?: string | null
+    content?: string | null
+    crawl_enabled?: boolean
+    max_crawl_pages?: number
+    parent_source_uuid?: string | null
+    crawled_urls?: string[] | null
+  }[]
+}
+
+/** Fetch an export payload for a knowledge base. Caller can serialize and save it. */
+export async function fetchKBExport(uuid: string): Promise<KBExportPayload> {
+  return apiFetch<KBExportPayload>(`/api/knowledge/${uuid}/export`)
+}
+
+/** Download a knowledge base as a .kb.json file in the browser. */
+export async function downloadKBExport(uuid: string, fallbackTitle = 'knowledge_base'): Promise<void> {
+  const payload = await fetchKBExport(uuid)
+  const title = payload.title || fallbackTitle
+  const safeTitle = title.replace(/[^A-Za-z0-9_.-]+/g, '_').replace(/^_+|_+$/g, '') || 'knowledge_base'
+  const blob = new Blob([JSON.stringify(payload, null, 2)], { type: 'application/json' })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = `${safeTitle}.kb.json`
+  document.body.appendChild(a)
+  a.click()
+  document.body.removeChild(a)
+  URL.revokeObjectURL(url)
+}
+
+export function importKnowledgeBase(payload: KBExportPayload, title?: string) {
+  return apiFetch<{ uuid: string; title: string; imported_sources: number }>(
+    '/api/knowledge/import',
+    {
+      method: 'POST',
+      body: JSON.stringify({ payload, title }),
+      // Importing may involve many re-embed calls; allow more time.
+      timeoutMs: 300_000,
+    },
+  )
+}
+
 // Suggestions
 
 export function submitKBSuggestion(uuid: string, data: {

--- a/frontend/src/components/workspace/KnowledgePanel.tsx
+++ b/frontend/src/components/workspace/KnowledgePanel.tsx
@@ -1,5 +1,5 @@
-import { useState, useEffect, useCallback } from 'react'
-import { Plus, Loader2, ArrowLeft, X, FileText, Globe, MessageSquare, AlertCircle, CheckCircle2, Users, ShieldCheck, Send, Tag, Check } from 'lucide-react'
+import { useState, useEffect, useCallback, useRef } from 'react'
+import { Plus, Loader2, ArrowLeft, X, FileText, Globe, MessageSquare, AlertCircle, CheckCircle2, Users, ShieldCheck, Send, Tag, Check, Download, Upload } from 'lucide-react'
 import { useKnowledgeBases, useScopedKnowledgeBases } from '../../hooks/useKnowledgeBases'
 import { useWorkspace } from '../../contexts/WorkspaceContext'
 import { useAuth } from '../../hooks/useAuth'
@@ -244,6 +244,50 @@ export function KnowledgePanel() {
     }
   }
 
+  // Export / Import state
+  const [exporting, setExporting] = useState(false)
+  const [importing, setImporting] = useState(false)
+  const importInputRef = useRef<HTMLInputElement | null>(null)
+
+  const handleExport = async () => {
+    if (!selectedKB) return
+    setExporting(true)
+    try {
+      await api.downloadKBExport(selectedKB.uuid, selectedKB.title)
+    } catch (err) {
+      console.error('Failed to export KB:', err)
+      toast(err instanceof Error ? err.message : 'Failed to export knowledge base', 'error')
+    } finally {
+      setExporting(false)
+    }
+  }
+
+  const handleImportFile = async (file: File) => {
+    setImporting(true)
+    try {
+      const text = await file.text()
+      let payload: api.KBExportPayload
+      try {
+        payload = JSON.parse(text) as api.KBExportPayload
+      } catch {
+        throw new Error('Invalid JSON file')
+      }
+      if (!payload || typeof payload !== 'object' || !Array.isArray(payload.sources)) {
+        throw new Error('File is not a valid knowledge base export')
+      }
+      const result = await api.importKnowledgeBase(payload)
+      toast(`Imported "${result.title}" with ${result.imported_sources} source${result.imported_sources === 1 ? '' : 's'}`, 'success')
+      refresh()
+      loadDetail(result.uuid)
+    } catch (err) {
+      console.error('Failed to import KB:', err)
+      toast(err instanceof Error ? err.message : 'Failed to import knowledge base', 'error')
+    } finally {
+      setImporting(false)
+      if (importInputRef.current) importInputRef.current.value = ''
+    }
+  }
+
   // Verification modal state
   const [showVerifyModal, setShowVerifyModal] = useState(false)
   const [verifySummary, setVerifySummary] = useState('')
@@ -479,6 +523,22 @@ export function KnowledgePanel() {
               >
                 <Users size={13} />
                 {selectedKB.shared_with_team ? 'Shared with Team' : 'Share with Team'}
+              </button>
+              <button
+                onClick={handleExport}
+                disabled={exporting}
+                title="Download this knowledge base as a JSON file"
+                style={{
+                  display: 'flex', alignItems: 'center', gap: 6,
+                  padding: '6px 12px', fontSize: 12, fontWeight: 600, fontFamily: 'inherit',
+                  color: '#e5e5e5', backgroundColor: '#2a2a2a',
+                  border: '1px solid #3a3a3a', borderRadius: 6,
+                  cursor: exporting ? 'default' : 'pointer',
+                  opacity: exporting ? 0.5 : 1,
+                }}
+              >
+                {exporting ? <Loader2 size={13} style={{ animation: 'spin 1s linear infinite' }} /> : <Download size={13} />}
+                {exporting ? 'Exporting...' : 'Export'}
               </button>
               {selectedKB.status === 'ready' && !selectedKB.verified && (
                 verificationSubmitted ? (
@@ -805,28 +865,63 @@ export function KnowledgePanel() {
       >
         <span style={{ fontSize: 18, fontWeight: 600, color: '#fff' }}>Knowledge Bases</span>
         {activeTab === 'mine' && (
-          <button
-            onClick={handleCreate}
-            disabled={creating}
-            style={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: 6,
-              padding: '6px 14px',
-              fontSize: 13,
-              fontWeight: 600,
-              fontFamily: 'inherit',
-              color: 'var(--highlight-text-color, #000)',
-              backgroundColor: 'var(--highlight-color, #eab308)',
-              border: 'none',
-              borderRadius: 6,
-              cursor: creating ? 'default' : 'pointer',
-              opacity: creating ? 0.6 : 1,
-            }}
-          >
-            {creating ? <Loader2 style={{ width: 14, height: 14, animation: 'spin 1s linear infinite' }} /> : <Plus style={{ width: 14, height: 14 }} />}
-            New
-          </button>
+          <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+            <input
+              ref={importInputRef}
+              type="file"
+              accept=".json,application/json"
+              style={{ display: 'none' }}
+              onChange={(e) => {
+                const f = e.target.files?.[0]
+                if (f) handleImportFile(f)
+              }}
+            />
+            <button
+              onClick={() => importInputRef.current?.click()}
+              disabled={importing}
+              title="Import a knowledge base from a .kb.json file"
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 6,
+                padding: '6px 12px',
+                fontSize: 13,
+                fontWeight: 600,
+                fontFamily: 'inherit',
+                color: '#e5e5e5',
+                backgroundColor: '#2a2a2a',
+                border: '1px solid #3a3a3a',
+                borderRadius: 6,
+                cursor: importing ? 'default' : 'pointer',
+                opacity: importing ? 0.6 : 1,
+              }}
+            >
+              {importing ? <Loader2 style={{ width: 14, height: 14, animation: 'spin 1s linear infinite' }} /> : <Upload style={{ width: 14, height: 14 }} />}
+              {importing ? 'Importing...' : 'Import'}
+            </button>
+            <button
+              onClick={handleCreate}
+              disabled={creating}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 6,
+                padding: '6px 14px',
+                fontSize: 13,
+                fontWeight: 600,
+                fontFamily: 'inherit',
+                color: 'var(--highlight-text-color, #000)',
+                backgroundColor: 'var(--highlight-color, #eab308)',
+                border: 'none',
+                borderRadius: 6,
+                cursor: creating ? 'default' : 'pointer',
+                opacity: creating ? 0.6 : 1,
+              }}
+            >
+              {creating ? <Loader2 style={{ width: 14, height: 14, animation: 'spin 1s linear infinite' }} /> : <Plus style={{ width: 14, height: 14 }} />}
+              New
+            </button>
+          </div>
         )}
       </div>
 


### PR DESCRIPTION
## Summary
- New **Export** button on the KB detail view downloads a self-contained `.kb.json` file with KB metadata and source text (document `raw_text` or URL-extracted text). ChromaDB vectors are not serialized — they regenerate on import.
- New **Import** button on the My KBs tab reads a `.kb.json` file, creates a new KB in the importer's tenant (own `user_id`, current team), and re-ingests sources through `DocumentManager.add_to_kb`. URL sources with no cached content are re-fetched.
- Backend: `GET /api/knowledge/{uuid}/export` and `POST /api/knowledge/import`, with matching Pydantic schemas and service functions.

## Test plan
- [ ] Create a KB with a mix of document and URL sources; export it and confirm the downloaded `.kb.json` contains metadata + source content.
- [ ] Import the downloaded file; verify a new KB is created, sources show `ready` status, and chunk counts match the source.
- [ ] Import as a different user/team; verify the new KB is owned by the importer with the correct `team_id`.
- [ ] Import a file with a URL source whose `content` field is empty; verify the URL is re-fetched.
- [ ] Confirm non-owners cannot export a KB they do not have access to (access check goes through `_get_kb_or_404`).
- [ ] Run `make backend-ci` and `make frontend-ci`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)