### PR TITLE
Fix library share crash from invalid SearchSetItem.space_id access

### DIFF
--- a/backend/app/services/library_service.py
+++ b/backend/app/services/library_service.py
@@ -725,7 +725,6 @@ async def _clone_underlying_object(item: LibraryItem, user_id: str, *, team_id: 
                 searchtype=oi.searchtype,
                 title=oi.title,
                 user_id=user_id,
-                space_id=oi.space_id,
             )
             await new_item.insert()
 


### PR DESCRIPTION
## Summary
- `_clone_underlying_object` in `library_service.py` referenced `oi.space_id` when cloning a `SearchSetItem`, but the model has no such field — every `/api/library/share` for a SearchSet raised `AttributeError` and returned 500.
- Removed the invalid kwarg.

## Test plan
- [ ] Share a SearchSet-kind library item to a team via `POST /api/library/share` and confirm it succeeds and the cloned items appear in the new SearchSet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
