### PR TITLE
Add context-budget planner and compaction for chat

### DIFF
--- a/backend/app/services/chat_service.py
+++ b/backend/app/services/chat_service.py
@@ -21,7 +21,11 @@ from app.models.activity import ActivityEvent, ActivityStatus
 from app.models.chat import ChatConversation, ChatRole
 from app.models.document import SmartDocument
 from app.models.system_config import SystemConfig
-from app.services.config_service import get_user_model_name
+from app.services.config_service import get_llm_model_by_name, get_user_model_name
+from app.services.context_budget import (
+    DocumentSegment,
+    plan_and_compact_context,
+)
 from app.services.llm_service import (
     create_chat_agent,
     DOCUMENT_CHAT_SYSTEM_PROMPT,
@@ -173,15 +177,18 @@ async def chat_stream(
         if doc:
             documents.append(doc)
 
-    # Build attachment context
-    attachment_context = ""
+    # Build attachment segments (each can be independently trimmed by the budget planner)
+    attachment_segments: list[DocumentSegment] = []
     url_attachments = await conversation.get_url_attachments()
     for att in url_attachments:
         if att.content:
-            attachment_context += (
-                f"\n\n## Web Content: {att.title}\nSource: {att.url}\n\n"
-                f"{att.content[:10000]}\n"
-            )
+            attachment_segments.append(DocumentSegment(
+                label=f"web:{att.title or att.url}",
+                text=(
+                    f"\n\n## Web Content: {att.title}\nSource: {att.url}\n\n"
+                    f"{att.content[:10000]}\n"
+                ),
+            ))
 
     file_attachments = await conversation.get_file_attachments()
     logger.info(
@@ -191,9 +198,10 @@ async def chat_stream(
     )
     for att in file_attachments:
         if att.content:
-            attachment_context += (
-                f"\n\n## Document: {att.filename}\n\n{att.content[:10000]}\n"
-            )
+            attachment_segments.append(DocumentSegment(
+                label=f"file:{att.filename}",
+                text=f"\n\n## Document: {att.filename}\n\n{att.content[:10000]}\n",
+            ))
 
     # If the conversation was created during first-session onboarding, honour
     # that flag even when the frontend doesn't pass it (e.g. after a remount).
@@ -208,20 +216,27 @@ async def chat_stream(
     if previous_messages:
         previous_messages = previous_messages[:-1]
 
-    # Build prompt and select appropriate system prompt
-    full_text = _get_full_text(documents)
+    # Document segments — one entry per SmartDocument so each can be trimmed
+    # independently by the budget planner.
+    doc_segments: list[DocumentSegment] = []
+    for doc in documents:
+        if doc.raw_text:
+            doc_segments.append(DocumentSegment(
+                label=f"doc:{doc.title or doc.uuid}",
+                text=f"\n\n## Document: {doc.title}\n{doc.raw_text}",
+            ))
+
+    total_text_len = sum(len(s.text) for s in doc_segments)
     if document_uuids:
         logger.info(
             "Chat doc context: requested=%d found=%d with_text=%d text_len=%d",
             len(document_uuids),
             len(documents),
             sum(1 for d in documents if d.raw_text),
-            len(full_text),
+            total_text_len,
         )
 
-    parts: list[str] = []
-
-    # KB context: query ChromaDB for relevant chunks
+    # KB context: query ChromaDB for relevant chunks and add as a segment.
     if kb_uuid:
         try:
             import asyncio
@@ -233,47 +248,105 @@ async def chat_stream(
                 for r in kb_results:
                     src = r.get("metadata", {}).get("source_name", "Unknown")
                     kb_text += f"\n**Source: {src}**\n{r['content']}\n"
-                parts.append(kb_text)
+                doc_segments.insert(0, DocumentSegment(label="kb", text=kb_text))
             else:
                 logger.warning("KB query returned no results for kb_uuid=%s", kb_uuid)
         except Exception as e:
             logger.error("KB context retrieval failed for kb_uuid=%s: %s", kb_uuid, e)
 
-    if full_text:
-        parts.append(full_text)
-    if attachment_context:
-        parts.append(attachment_context)
-
-    # Select system prompt based on whether we have document context
-    if parts:
-        context_block = "\n\n".join(parts)
-        prompt = (
-            f"{message}\n\n"
-            "--- BEGIN REFERENCE DOCUMENTS (provided for context only) ---\n"
-            f"{context_block}\n"
-            "--- END REFERENCE DOCUMENTS ---"
-        )
-        system_prompt = DOCUMENT_CHAT_SYSTEM_PROMPT
+    # Select system prompt based on whether we have document context.
+    have_context = bool(doc_segments or attachment_segments)
+    if have_context:
+        system_prompt: Optional[str] = DOCUMENT_CHAT_SYSTEM_PROMPT
     elif is_first_session:
         # First-session onboarding: conversational value discovery.
         # Do NOT inject VANDALIZER_CONTEXT here — it's a technical how-to dump
         # that causes the LLM to skip the conversation and spit out directions.
         # The FIRST_SESSION_SYSTEM_PROMPT already has everything it needs.
-        prompt = message
         system_prompt = FIRST_SESSION_SYSTEM_PROMPT
     elif include_onboarding_context:
         # Inject Vandalizer help context only when explicitly requested
         # (triggered by the placeholder pills in the chat UI).
-        prompt = (
-            "--- BEGIN ONBOARDING CONTEXT ---\n"
-            f"{VANDALIZER_CONTEXT}\n"
-            "--- END ONBOARDING CONTEXT ---\n\n"
-            f"User question: {message}"
-        )
+        doc_segments.append(DocumentSegment(
+            label="onboarding",
+            text=(
+                "--- BEGIN ONBOARDING CONTEXT ---\n"
+                f"{VANDALIZER_CONTEXT}\n"
+                "--- END ONBOARDING CONTEXT ---"
+            ),
+        ))
         system_prompt = HELP_CHAT_SYSTEM_PROMPT
     else:
-        prompt = message
         system_prompt = None  # uses default
+
+    # Resolve the model's context window and compact oversize components.
+    model_config = await get_llm_model_by_name(model_name)
+    compacted = plan_and_compact_context(
+        model_name=model_name,
+        model_config=model_config,
+        system_prompt=system_prompt or "",
+        user_message=message,
+        history=previous_messages,
+        documents=doc_segments,
+        attachments=attachment_segments,
+    )
+
+    # Tell the client what we planned (and whether we had to compact).
+    yield json.dumps({
+        "kind": "context_budget",
+        "content": "",
+        "plan": compacted.plan.to_dict(),
+    }) + "\n"
+    for action in compacted.actions:
+        yield json.dumps({
+            "kind": "context_notice",
+            "content": action.detail,
+            "action": action.kind,
+            "tokens_dropped": action.tokens_dropped,
+        }) + "\n"
+
+    if compacted.fatal:
+        logger.warning(
+            "Chat context over budget for model=%s: plan=%s actions=%s",
+            model_name, compacted.plan.to_dict(),
+            [a.to_dict() for a in compacted.actions],
+        )
+        yield json.dumps({
+            "kind": "error",
+            "content": (
+                "This request is too large for the selected model "
+                f"(~{compacted.plan.total_input_tokens} tokens vs "
+                f"{compacted.plan.input_budget} token input budget). "
+                "Remove some documents or switch to a larger model."
+            ),
+        }) + "\n"
+        if activity_id:
+            ev = await ActivityEvent.get(activity_id)
+            if ev:
+                ev.status = ActivityStatus.FAILED.value
+                ev.error = "context over budget"
+                await ev.save()
+        return
+
+    previous_messages = compacted.history
+
+    # Rebuild the final prompt from compacted segments.
+    if have_context or include_onboarding_context:
+        context_pieces: list[str] = [s.text for s in compacted.documents]
+        context_pieces.extend(s.text for s in compacted.attachments)
+        context_block = "\n\n".join(context_pieces)
+        if include_onboarding_context and not have_context:
+            # Preserve the original onboarding wording when that's the only context.
+            prompt = f"{context_block}\n\nUser question: {message}"
+        else:
+            prompt = (
+                f"{message}\n\n"
+                "--- BEGIN REFERENCE DOCUMENTS (provided for context only) ---\n"
+                f"{context_block}\n"
+                "--- END REFERENCE DOCUMENTS ---"
+            )
+    else:
+        prompt = message
 
     agent = create_chat_agent(model_name, system_prompt=system_prompt, system_config_doc=sys_config_doc)
 
@@ -381,15 +454,6 @@ async def chat_stream(
                 ev.error = str(e)[:2000]
                 await ev.save()
 
-
-
-def _get_full_text(documents: list[SmartDocument]) -> str:
-    """Combine document texts for direct-prompt chat."""
-    parts = []
-    for doc in documents:
-        if doc.raw_text:
-            parts.append(f"\n\n## Document: {doc.title}\n{doc.raw_text}")
-    return "".join(parts)
 
 
 async def _finalize(

--- a/backend/app/services/context_budget.py
+++ b/backend/app/services/context_budget.py
@@ -1,0 +1,503 @@
+"""Context-budget planning and compaction for chat requests.
+
+Sizes every component of a prompt, decides what to trim when the total
+exceeds the model's input budget, and returns compacted pieces the caller
+can safely send to the LLM.  All compaction is logged as structured
+``CompactionAction`` entries so the caller can surface them to the user
+and to Sentry.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from functools import lru_cache
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Tokenization
+# ---------------------------------------------------------------------------
+
+_CHAR_TO_TOKEN_RATIO = 4
+
+
+@lru_cache(maxsize=8)
+def _get_encoder(encoding_name: str):
+    try:
+        import tiktoken
+
+        return tiktoken.get_encoding(encoding_name)
+    except Exception as exc:
+        logger.warning("tiktoken unavailable (%s); falling back to char heuristic", exc)
+        return None
+
+
+def _encoding_for(model_name: str) -> str:
+    name = (model_name or "").lower()
+    if any(tok in name for tok in ("gpt-4o", "gpt-4.1", "o1", "o3", "o4")):
+        return "o200k_base"
+    return "cl100k_base"
+
+
+def count_tokens(text: str, model_name: str = "") -> int:
+    """Estimate token count for ``text`` using tiktoken when available."""
+    if not text:
+        return 0
+    encoder = _get_encoder(_encoding_for(model_name))
+    if encoder is not None:
+        try:
+            return len(encoder.encode(text, disallowed_special=()))
+        except Exception:
+            pass
+    return max(1, len(text) // _CHAR_TO_TOKEN_RATIO)
+
+
+def count_message_tokens(message: Any, model_name: str = "") -> int:
+    """Estimate tokens for one pydantic-ai ``ModelMessage``."""
+    total = 4  # per-message overhead for role wrapping
+    for part in getattr(message, "parts", ()):
+        content = getattr(part, "content", None)
+        if content is None:
+            content = str(part)
+        total += count_tokens(str(content), model_name)
+    return total
+
+
+# ---------------------------------------------------------------------------
+# Model context window
+# ---------------------------------------------------------------------------
+
+# Order matters — the first substring match wins, so more specific entries
+# must appear before broader ones.
+_CONTEXT_WINDOW_FALLBACKS: list[tuple[str, int]] = [
+    ("gpt-4.1", 1_000_000),
+    ("gpt-4o-mini", 128_000),
+    ("gpt-4o", 128_000),
+    ("gpt-4-turbo", 128_000),
+    ("gpt-4-32k", 32_768),
+    ("gpt-4", 8_192),
+    ("gpt-3.5", 16_385),
+    ("o1-mini", 128_000),
+    ("o1", 200_000),
+    ("o3", 200_000),
+    ("o4", 200_000),
+    ("claude-opus-4", 200_000),
+    ("claude-sonnet-4", 200_000),
+    ("claude-haiku-4", 200_000),
+    ("claude-3-7", 200_000),
+    ("claude-3-5", 200_000),
+    ("claude-3", 200_000),
+    ("llama-3", 131_072),
+    ("llama3", 131_072),
+    ("mixtral", 32_768),
+    ("mistral", 32_768),
+    ("qwen", 131_072),
+    ("gemma", 8_192),
+]
+
+DEFAULT_CONTEXT_WINDOW = 65_536
+
+
+def resolve_context_window(
+    model_name: str, model_config: Optional[dict] = None
+) -> int:
+    """Return the max input-context length for a model, in tokens.
+
+    Priority: ``model_config['context_window']`` → fallback registry → default.
+    """
+    if model_config:
+        raw = model_config.get("context_window")
+        try:
+            value = int(raw) if raw not in (None, "") else 0
+        except (TypeError, ValueError):
+            value = 0
+        if value > 0:
+            return value
+
+    name = (model_name or "").lower()
+    for pattern, window in _CONTEXT_WINDOW_FALLBACKS:
+        if pattern in name:
+            return window
+    return DEFAULT_CONTEXT_WINDOW
+
+
+# ---------------------------------------------------------------------------
+# Budgeting + compaction
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class DocumentSegment:
+    """A single compactable chunk of context (doc body, KB block, attachment)."""
+
+    label: str
+    text: str
+    required: bool = False  # required segments are never trimmed
+
+
+@dataclass
+class CompactionAction:
+    """A single edit the planner applied to fit the budget."""
+
+    kind: str  # "history_trimmed" | "documents_trimmed" | "attachments_trimmed" | "over_budget"
+    detail: str
+    tokens_dropped: int = 0
+
+    def to_dict(self) -> dict:
+        return {
+            "kind": self.kind,
+            "detail": self.detail,
+            "tokens_dropped": self.tokens_dropped,
+        }
+
+
+@dataclass
+class BudgetPlan:
+    model: str
+    context_window: int
+    response_reserve: int
+    input_budget: int
+
+    system_tokens: int = 0
+    user_message_tokens: int = 0
+    history_tokens: int = 0
+    documents_tokens: int = 0
+    attachments_tokens: int = 0
+
+    @property
+    def total_input_tokens(self) -> int:
+        return (
+            self.system_tokens
+            + self.user_message_tokens
+            + self.history_tokens
+            + self.documents_tokens
+            + self.attachments_tokens
+        )
+
+    @property
+    def over_budget(self) -> bool:
+        return self.total_input_tokens > self.input_budget
+
+    def to_dict(self) -> dict:
+        return {
+            "model": self.model,
+            "context_window": self.context_window,
+            "response_reserve": self.response_reserve,
+            "input_budget": self.input_budget,
+            "total_input_tokens": self.total_input_tokens,
+            "system_tokens": self.system_tokens,
+            "user_message_tokens": self.user_message_tokens,
+            "history_tokens": self.history_tokens,
+            "documents_tokens": self.documents_tokens,
+            "attachments_tokens": self.attachments_tokens,
+            "headroom_tokens": self.input_budget - self.total_input_tokens,
+        }
+
+
+@dataclass
+class CompactedContext:
+    documents: list[DocumentSegment]
+    attachments: list[DocumentSegment]
+    history: list  # list[pydantic_ai.messages.ModelMessage]
+    plan: BudgetPlan
+    actions: list[CompactionAction] = field(default_factory=list)
+
+    @property
+    def fatal(self) -> bool:
+        """True when we could not shrink the request below the input budget."""
+        return self.plan.over_budget
+
+
+def _default_response_reserve(context_window: int) -> int:
+    """Reserve tokens for the model's response.
+
+    Scales with window size so tiny models don't lose all their budget to the
+    reserve and large models don't overreserve.
+    """
+    return max(1024, min(8192, context_window // 4))
+
+
+def _truncate_text_to_tokens(
+    text: str,
+    max_tokens: int,
+    model_name: str,
+    marker: str = "\n\n…[truncated]…\n\n",
+) -> tuple[str, int]:
+    """Truncate ``text`` to ≤ ``max_tokens``, preserving head and tail.
+
+    Returns ``(truncated_text, dropped_tokens)``.
+    """
+    original_tokens = count_tokens(text, model_name)
+    if max_tokens <= 0:
+        return "", original_tokens
+    if original_tokens <= max_tokens:
+        return text, 0
+
+    marker_tokens = count_tokens(marker, model_name)
+    usable = max(1, max_tokens - marker_tokens)
+
+    encoder = _get_encoder(_encoding_for(model_name))
+    if encoder is not None:
+        try:
+            toks = encoder.encode(text, disallowed_special=())
+            head_n = int(usable * 0.75)
+            tail_n = max(0, usable - head_n)
+            head_text = encoder.decode(toks[:head_n]) if head_n else ""
+            tail_text = encoder.decode(toks[-tail_n:]) if tail_n else ""
+            new_text = head_text + marker + tail_text
+            return new_text, original_tokens - count_tokens(new_text, model_name)
+        except Exception:
+            pass
+
+    approx_chars = usable * _CHAR_TO_TOKEN_RATIO
+    head_chars = int(approx_chars * 0.75)
+    tail_chars = max(0, approx_chars - head_chars)
+    new_text = text[:head_chars] + marker + (text[-tail_chars:] if tail_chars else "")
+    return new_text, original_tokens - count_tokens(new_text, model_name)
+
+
+def plan_and_compact_context(
+    *,
+    model_name: str,
+    model_config: Optional[dict],
+    system_prompt: str,
+    user_message: str,
+    history: list,
+    documents: list[DocumentSegment],
+    attachments: list[DocumentSegment],
+    response_reserve: Optional[int] = None,
+) -> CompactedContext:
+    """Plan a context budget for this request and compact oversize components.
+
+    Returns the same pieces (possibly trimmed) plus a ``BudgetPlan`` and the
+    list of ``CompactionAction``s the planner applied.  The caller should
+    check ``result.fatal`` — if true, sending the request will still fail.
+    """
+    documents = list(documents)
+    attachments = list(attachments)
+    history = list(history)
+
+    context_window = resolve_context_window(model_name, model_config)
+    reserve = (
+        response_reserve
+        if response_reserve is not None
+        else _default_response_reserve(context_window)
+    )
+    input_budget = max(1, context_window - reserve)
+
+    plan = BudgetPlan(
+        model=model_name,
+        context_window=context_window,
+        response_reserve=reserve,
+        input_budget=input_budget,
+    )
+    actions: list[CompactionAction] = []
+
+    plan.system_tokens = count_tokens(system_prompt, model_name) if system_prompt else 0
+    plan.user_message_tokens = count_tokens(user_message, model_name)
+    plan.history_tokens = sum(count_message_tokens(m, model_name) for m in history)
+    plan.documents_tokens = sum(count_tokens(d.text, model_name) for d in documents)
+    plan.attachments_tokens = sum(
+        count_tokens(a.text, model_name) for a in attachments
+    )
+
+    if not plan.over_budget:
+        return CompactedContext(
+            documents=documents,
+            attachments=attachments,
+            history=history,
+            plan=plan,
+            actions=actions,
+        )
+
+    # Non-compactable floor covers the system prompt, user message, and an
+    # allowance for prompt scaffolding ("--- BEGIN REFERENCE DOCUMENTS ---" etc.).
+    floor = plan.system_tokens + plan.user_message_tokens + 64
+    if floor >= input_budget:
+        actions.append(
+            CompactionAction(
+                kind="over_budget",
+                detail=(
+                    f"System prompt + your message alone ({floor} tokens) already "
+                    f"exceed this model's input budget ({input_budget} tokens). "
+                    "Shorten the message or pick a larger model."
+                ),
+            )
+        )
+        return CompactedContext(
+            documents=documents,
+            attachments=attachments,
+            history=history,
+            plan=plan,
+            actions=actions,
+        )
+
+    remaining = input_budget - floor
+    doc_target = int(remaining * 0.65)
+    hist_target = int(remaining * 0.25)
+    attach_target = remaining - doc_target - hist_target
+
+    # 1. Drop oldest history messages until under target.
+    if plan.history_tokens > hist_target:
+        dropped = 0
+        while history and sum(
+            count_message_tokens(m, model_name) for m in history
+        ) > hist_target:
+            m = history.pop(0)
+            dropped += count_message_tokens(m, model_name)
+        plan.history_tokens = sum(count_message_tokens(m, model_name) for m in history)
+        if dropped:
+            actions.append(
+                CompactionAction(
+                    kind="history_trimmed",
+                    detail=f"Dropped {dropped} tokens of older conversation history.",
+                    tokens_dropped=dropped,
+                )
+            )
+
+    # 2. Trim attachments proportionally.
+    if plan.attachments_tokens > attach_target and attachments:
+        dropped = 0
+        scale = attach_target / max(1, plan.attachments_tokens)
+        for i, a in enumerate(attachments):
+            if a.required:
+                continue
+            raw = count_tokens(a.text, model_name)
+            allowed = max(256, int(raw * scale))
+            if allowed >= raw:
+                continue
+            new_text, loss = _truncate_text_to_tokens(a.text, allowed, model_name)
+            dropped += loss
+            attachments[i] = DocumentSegment(
+                label=a.label, text=new_text, required=a.required
+            )
+        plan.attachments_tokens = sum(
+            count_tokens(a.text, model_name) for a in attachments
+        )
+        if dropped:
+            actions.append(
+                CompactionAction(
+                    kind="attachments_trimmed",
+                    detail=f"Trimmed {dropped} tokens from attached files.",
+                    tokens_dropped=dropped,
+                )
+            )
+
+    # 3. Trim documents proportionally.
+    if plan.documents_tokens > doc_target and documents:
+        dropped = 0
+        scale = doc_target / max(1, plan.documents_tokens)
+        for i, d in enumerate(documents):
+            if d.required:
+                continue
+            raw = count_tokens(d.text, model_name)
+            allowed = max(512, int(raw * scale))
+            if allowed >= raw:
+                continue
+            new_text, loss = _truncate_text_to_tokens(d.text, allowed, model_name)
+            dropped += loss
+            documents[i] = DocumentSegment(
+                label=d.label, text=new_text, required=d.required
+            )
+        plan.documents_tokens = sum(
+            count_tokens(d.text, model_name) for d in documents
+        )
+        if dropped:
+            actions.append(
+                CompactionAction(
+                    kind="documents_trimmed",
+                    detail=f"Trimmed {dropped} tokens from reference documents.",
+                    tokens_dropped=dropped,
+                )
+            )
+
+    # 4. Last-ditch: aggressively shrink or drop segments until we fit.
+    _MIN_USEFUL_TOKENS = 64  # smaller than this is not worth keeping
+    safety_counter = 0
+    while plan.over_budget and safety_counter < 50:
+        safety_counter += 1
+        overflow = plan.total_input_tokens - input_budget
+        candidate: Optional[DocumentSegment] = None
+        bucket_name: Optional[str] = None
+        container: Optional[list[DocumentSegment]] = None
+        for bucket_name_try, bucket in (
+            ("documents", documents),
+            ("attachments", attachments),
+        ):
+            for seg in bucket:
+                if seg.required:
+                    continue
+                if candidate is None or count_tokens(
+                    seg.text, model_name
+                ) > count_tokens(candidate.text, model_name):
+                    candidate = seg
+                    bucket_name = bucket_name_try
+                    container = bucket
+        if candidate is None or container is None:
+            actions.append(
+                CompactionAction(
+                    kind="over_budget",
+                    detail=(
+                        f"Compaction could not reduce input below {input_budget} "
+                        f"tokens (still at {plan.total_input_tokens}). "
+                        "Remove some documents or switch to a larger model."
+                    ),
+                )
+            )
+            break
+
+        raw = count_tokens(candidate.text, model_name)
+        target = raw - overflow - 8  # shave 8 extra tokens of slack
+        if target < _MIN_USEFUL_TOKENS:
+            # Not worth keeping a tiny sliver — drop the segment entirely.
+            container.remove(candidate)
+            actions.append(
+                CompactionAction(
+                    kind=f"{bucket_name}_trimmed",
+                    detail=f"Dropped '{candidate.label}' to fit budget ({raw} tokens).",
+                    tokens_dropped=raw,
+                )
+            )
+        else:
+            new_text, loss = _truncate_text_to_tokens(
+                candidate.text, target, model_name
+            )
+            if loss <= 0:
+                # No forward progress possible on this segment; drop it.
+                container.remove(candidate)
+                actions.append(
+                    CompactionAction(
+                        kind=f"{bucket_name}_trimmed",
+                        detail=f"Dropped '{candidate.label}' to fit budget ({raw} tokens).",
+                        tokens_dropped=raw,
+                    )
+                )
+            else:
+                candidate.text = new_text
+                actions.append(
+                    CompactionAction(
+                        kind=f"{bucket_name}_trimmed",
+                        detail=(
+                            f"Additional trim of {loss} tokens from "
+                            f"'{candidate.label}' to fit budget."
+                        ),
+                        tokens_dropped=loss,
+                    )
+                )
+        plan.documents_tokens = sum(
+            count_tokens(d.text, model_name) for d in documents
+        )
+        plan.attachments_tokens = sum(
+            count_tokens(a.text, model_name) for a in attachments
+        )
+
+    return CompactedContext(
+        documents=documents,
+        attachments=attachments,
+        history=history,
+        plan=plan,
+        actions=actions,
+    )

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
     "croniter>=1.3,<3",
     "prometheus-fastapi-instrumentator>=7.0,<8",
     "pymupdf>=1.27.2",
+    "tiktoken>=0.9,<1",
 ]
 
 [project.optional-dependencies]

--- a/backend/tests/test_context_budget.py
+++ b/backend/tests/test_context_budget.py
@@ -1,0 +1,230 @@
+"""Tests for the chat context-budget planner."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from app.services.context_budget import (
+    DEFAULT_CONTEXT_WINDOW,
+    DocumentSegment,
+    count_message_tokens,
+    count_tokens,
+    plan_and_compact_context,
+    resolve_context_window,
+)
+
+
+# ---------------------------------------------------------------------------
+# Test doubles
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakePart:
+    content: str
+
+
+@dataclass
+class _FakeMessage:
+    parts: list = field(default_factory=list)
+
+
+def _msg(text: str) -> _FakeMessage:
+    return _FakeMessage(parts=[_FakePart(content=text)])
+
+
+# ---------------------------------------------------------------------------
+# Tokenization
+# ---------------------------------------------------------------------------
+
+
+def test_count_tokens_basic():
+    assert count_tokens("") == 0
+    assert count_tokens("hello world") > 0
+    assert count_tokens("the same " * 100) > count_tokens("the same")
+
+
+def test_count_message_tokens_adds_overhead():
+    m = _msg("hi")
+    assert count_message_tokens(m) >= count_tokens("hi") + 1
+
+
+# ---------------------------------------------------------------------------
+# Context window resolution
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_window_prefers_config_override():
+    assert resolve_context_window("whatever", {"context_window": 12345}) == 12345
+
+
+def test_resolve_window_ignores_zero_or_invalid_override():
+    assert resolve_context_window("claude-sonnet-4-6", {"context_window": 0}) == 200_000
+    assert resolve_context_window("claude-sonnet-4-6", {"context_window": "bad"}) == 200_000
+
+
+def test_resolve_window_uses_registry():
+    assert resolve_context_window("gpt-4o") == 128_000
+    assert resolve_context_window("claude-opus-4-7") == 200_000
+    assert resolve_context_window("llama-3.1-70b") == 131_072
+
+
+def test_resolve_window_fallback_default():
+    assert resolve_context_window("some-mystery-model") == DEFAULT_CONTEXT_WINDOW
+
+
+# ---------------------------------------------------------------------------
+# No compaction when within budget
+# ---------------------------------------------------------------------------
+
+
+def test_plan_no_compaction_when_under_budget():
+    result = plan_and_compact_context(
+        model_name="claude-sonnet-4-6",
+        model_config=None,
+        system_prompt="You are helpful.",
+        user_message="Tell me a joke.",
+        history=[_msg("hi"), _msg("hello")],
+        documents=[DocumentSegment(label="doc1", text="small doc body")],
+        attachments=[],
+    )
+    assert result.actions == []
+    assert len(result.documents) == 1
+    assert len(result.history) == 2
+    assert not result.fatal
+
+
+# ---------------------------------------------------------------------------
+# Compaction paths
+# ---------------------------------------------------------------------------
+
+
+def test_history_trimmed_when_over_budget():
+    # Tight 1,024-token budget (config override) with a lot of history.
+    long_msg = _msg("abcdefg " * 200)  # ~400 tokens
+    history = [long_msg for _ in range(10)]
+    result = plan_and_compact_context(
+        model_name="test-model",
+        model_config={"context_window": 1_500},
+        system_prompt="sys",
+        user_message="hi",
+        history=history,
+        documents=[],
+        attachments=[],
+        response_reserve=256,
+    )
+    assert len(result.history) < len(history)
+    assert any(a.kind == "history_trimmed" for a in result.actions)
+
+
+def test_documents_trimmed_when_over_budget():
+    big_doc = DocumentSegment(label="big", text="alpha beta " * 2_000)  # ~4k tokens
+    result = plan_and_compact_context(
+        model_name="test-model",
+        model_config={"context_window": 1_500},
+        system_prompt="sys",
+        user_message="hi",
+        history=[],
+        documents=[big_doc],
+        attachments=[],
+        response_reserve=256,
+    )
+    assert any(a.kind == "documents_trimmed" for a in result.actions)
+    # The big doc should have been shrunk.
+    assert len(result.documents[0].text) < len(big_doc.text)
+
+
+def test_required_segment_is_not_trimmed():
+    required_doc = DocumentSegment(
+        label="must-keep", text="important " * 1_500, required=True
+    )
+    result = plan_and_compact_context(
+        model_name="test-model",
+        model_config={"context_window": 1_200},
+        system_prompt="sys",
+        user_message="hi",
+        history=[],
+        documents=[required_doc],
+        attachments=[],
+        response_reserve=128,
+    )
+    # The required doc is preserved verbatim.
+    assert result.documents[0].text == required_doc.text
+    # And we should see an over_budget action since we couldn't trim it.
+    assert any(a.kind == "over_budget" for a in result.actions)
+    assert result.fatal
+
+
+def test_attachments_trimmed_when_over_budget():
+    big_att = DocumentSegment(label="att", text="data " * 3_000)
+    result = plan_and_compact_context(
+        model_name="test-model",
+        model_config={"context_window": 1_200},
+        system_prompt="sys",
+        user_message="hi",
+        history=[],
+        documents=[],
+        attachments=[big_att],
+        response_reserve=200,
+    )
+    assert any(
+        a.kind in ("attachments_trimmed", "documents_trimmed") for a in result.actions
+    )
+    assert len(result.attachments[0].text) < len(big_att.text)
+
+
+def test_fatal_when_floor_exceeds_budget():
+    # System prompt alone blows the budget.
+    huge_system = "x " * 5_000
+    result = plan_and_compact_context(
+        model_name="test-model",
+        model_config={"context_window": 500},
+        system_prompt=huge_system,
+        user_message="hi",
+        history=[],
+        documents=[],
+        attachments=[],
+        response_reserve=100,
+    )
+    assert result.fatal
+    assert any(a.kind == "over_budget" for a in result.actions)
+
+
+def test_plan_dict_shape():
+    result = plan_and_compact_context(
+        model_name="claude-sonnet-4-6",
+        model_config=None,
+        system_prompt="sys",
+        user_message="hi",
+        history=[],
+        documents=[],
+        attachments=[],
+    )
+    plan = result.plan.to_dict()
+    expected_keys = {
+        "model", "context_window", "response_reserve", "input_budget",
+        "total_input_tokens", "system_tokens", "user_message_tokens",
+        "history_tokens", "documents_tokens", "attachments_tokens",
+        "headroom_tokens",
+    }
+    assert expected_keys.issubset(plan.keys())
+    assert plan["headroom_tokens"] == plan["input_budget"] - plan["total_input_tokens"]
+
+
+def test_last_ditch_trim_handles_multiple_rounds():
+    # Many mid-size docs that individually fit but collectively overflow even
+    # after proportional scaling — exercises the last-ditch while loop.
+    docs = [DocumentSegment(label=f"d{i}", text="word " * 500) for i in range(6)]
+    result = plan_and_compact_context(
+        model_name="test-model",
+        model_config={"context_window": 1_500},
+        system_prompt="sys",
+        user_message="hi",
+        history=[],
+        documents=docs,
+        attachments=[],
+        response_reserve=200,
+    )
+    # Should not be fatal — we should have compacted enough to fit.
+    assert not result.fatal
+    assert result.plan.total_input_tokens <= result.plan.input_budget

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -3239,6 +3239,7 @@ dependencies = [
     { name = "reportlab" },
     { name = "sentry-sdk", extra = ["celery", "fastapi"] },
     { name = "slowapi" },
+    { name = "tiktoken" },
     { name = "uvicorn", extra = ["standard"] },
     { name = "werkzeug" },
 ]
@@ -3300,6 +3301,7 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.11,<1" },
     { name = "sentry-sdk", extras = ["fastapi", "celery"], specifier = ">=2.0,<3" },
     { name = "slowapi", specifier = ">=0.1,<1" },
+    { name = "tiktoken", specifier = ">=0.9,<1" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.34,<1" },
     { name = "werkzeug", specifier = ">=3.1,<4" },
 ]

--- a/frontend/src/components/chat/ChatPanel.tsx
+++ b/frontend/src/components/chat/ChatPanel.tsx
@@ -68,6 +68,7 @@ export function ChatPanel({ conversationToLoad, pendingMessage, onPendingMessage
     contextTokens,
     contextMode,
     contextCutoffIndex,
+    contextNotices,
     setContextTokens,
     setContextMode,
     setContextCutoffIndex,
@@ -768,6 +769,17 @@ export function ChatPanel({ conversationToLoad, pendingMessage, onPendingMessage
 
         {error && (
           <div className="mt-2 rounded-md bg-red-50 px-3 py-2 text-sm text-red-600">{error}</div>
+        )}
+
+        {contextNotices.length > 0 && (
+          <div className="mt-2 rounded-md bg-amber-50 px-3 py-2 text-xs text-amber-800 border border-amber-200">
+            <div className="font-medium mb-1">Context was compacted to fit the model:</div>
+            <ul className="list-disc pl-4 space-y-0.5">
+              {contextNotices.map((n, i) => (
+                <li key={i}>{n.detail}</li>
+              ))}
+            </ul>
+          </div>
         )}
         </div>{/* end centering wrapper */}
 

--- a/frontend/src/hooks/useChat.ts
+++ b/frontend/src/hooks/useChat.ts
@@ -1,6 +1,12 @@
 import { useState, useCallback, useRef } from 'react'
 import { streamChat, getHistory } from '../api/chat'
-import type { ChatMessage, StreamChunk } from '../types/chat'
+import type { ChatMessage, ContextBudgetPlan, StreamChunk } from '../types/chat'
+
+export interface ContextNotice {
+  action: string
+  detail: string
+  tokens_dropped: number
+}
 
 const THINK_BLOCK_RE = /<think(?:ing)?>[\s\S]*?<\/think(?:ing)?>\n?/g
 const THINK_TRAILING_RE = /<think(?:ing)?>[\s\S]*$/
@@ -17,6 +23,8 @@ export function useChat() {
   const [contextTokens, setContextTokens] = useState(0)
   const [contextMode, setContextMode] = useState<'full' | 'truncated' | 'compacted'>('full')
   const [contextCutoffIndex, setContextCutoffIndex] = useState(0)
+  const [contextPlan, setContextPlan] = useState<ContextBudgetPlan | null>(null)
+  const [contextNotices, setContextNotices] = useState<ContextNotice[]>([])
 
   const streamingRef = useRef('')
   const thinkingRef = useRef('')
@@ -29,6 +37,8 @@ export function useChat() {
       setStreamingContent('')
       setThinkingContent('')
       setThinkingDuration(null)
+      setContextPlan(null)
+      setContextNotices([])
       streamingRef.current = ''
       thinkingRef.current = ''
       thinkingDurationRef.current = null
@@ -57,6 +67,23 @@ export function useChat() {
               setThinkingDuration(chunk.duration ?? null)
             } else if (chunk.kind === 'usage') {
               setContextTokens(chunk.request_tokens ?? 0)
+            } else if (chunk.kind === 'context_budget') {
+              if (chunk.plan) {
+                setContextPlan(chunk.plan)
+                // Use the planner's estimate until the real usage chunk arrives.
+                if (chunk.plan.total_input_tokens) {
+                  setContextTokens(chunk.plan.total_input_tokens)
+                }
+              }
+            } else if (chunk.kind === 'context_notice') {
+              setContextNotices((prev) => [
+                ...prev,
+                {
+                  action: chunk.action ?? 'notice',
+                  detail: chunk.content,
+                  tokens_dropped: chunk.tokens_dropped ?? 0,
+                },
+              ])
             } else if (chunk.kind === 'error') {
               setError(chunk.content)
             }
@@ -122,6 +149,8 @@ export function useChat() {
     setContextTokens(0)
     setContextMode('full')
     setContextCutoffIndex(0)
+    setContextPlan(null)
+    setContextNotices([])
   }, [])
 
   const setActivity = useCallback((newActivityId: string, newConversationUuid: string) => {
@@ -142,6 +171,8 @@ export function useChat() {
     contextTokens,
     contextMode,
     contextCutoffIndex,
+    contextPlan,
+    contextNotices,
     setContextTokens,
     setContextMode,
     setContextCutoffIndex,

--- a/frontend/src/types/chat.ts
+++ b/frontend/src/types/chat.ts
@@ -47,11 +47,35 @@ export interface ActivityEvent {
   result_snapshot: Record<string, unknown>
 }
 
+export interface ContextBudgetPlan {
+  model: string
+  context_window: number
+  response_reserve: number
+  input_budget: number
+  total_input_tokens: number
+  system_tokens: number
+  user_message_tokens: number
+  history_tokens: number
+  documents_tokens: number
+  attachments_tokens: number
+  headroom_tokens: number
+}
+
 export interface StreamChunk {
-  kind: 'text' | 'thinking' | 'thinking_done' | 'error' | 'usage'
+  kind:
+    | 'text'
+    | 'thinking'
+    | 'thinking_done'
+    | 'error'
+    | 'usage'
+    | 'context_budget'
+    | 'context_notice'
   content: string
   duration?: number
   request_tokens?: number
   response_tokens?: number
   total_tokens?: number
+  plan?: ContextBudgetPlan
+  action?: string
+  tokens_dropped?: number
 }


### PR DESCRIPTION
## Summary
Chat was sending full document text directly into the LLM with no size check, so requests with a handful of large docs hit 400 errors from the provider (e.g. 67,187 tokens vs a 65,536-token window). This adds proper context-window monitoring and automatic compaction.

### Backend
- **New** `app/services/context_budget.py` — token counting (tiktoken with char/4 fallback), per-model context-window resolution (admin SystemConfig override → pattern registry → 65,536 floor), and a 4-stage compactor: trim oldest history → proportional attachment trim → proportional document trim → last-ditch shrink-or-drop.
- **Edited** `app/services/chat_service.py` — builds per-item `DocumentSegment`s (one per doc, KB block, attachment), calls the planner, emits two new stream events (`context_budget`, `context_notice`), and short-circuits with a clear user-facing error plus a FAILED activity record when the input is unavoidably too large (no more 500s).
- **New** `tests/test_context_budget.py` — 14 unit tests covering tokenization, window resolution priority, no-op path, every compaction branch, required-segment preservation, fatal floor, and multi-round last-ditch.
- **Edited** `pyproject.toml` / `uv.lock` — added `tiktoken` as a direct dep.

### Frontend
- **Edited** `types/chat.ts` — new `ContextBudgetPlan` type and stream event kinds.
- **Edited** `hooks/useChat.ts` — captures plan + notices during streaming, clears between messages, seeds `contextTokens` from the planner's estimate until the authoritative usage chunk arrives.
- **Edited** `components/chat/ChatPanel.tsx` — renders an amber inline notice box listing what was compacted.

### Design choices
- Compaction is silent-but-visible: we never drop content without emitting a `context_notice` the UI can show.
- Budget allocation among compactable buckets: 65% documents, 25% history, 10% attachments of remaining budget after system prompt + user message.
- Trimming preserves head (~75%) and tail (~25%) so start-of-doc context and summaries/conclusions both survive.
- `required=True` segments are never trimmed; if they overflow the budget the request is marked fatal.

## Test plan
- [ ] Backend: `cd backend && uv run pytest tests/test_context_budget.py tests/test_chat_service.py -v` — all pass.
- [ ] Reproduce the original error: open chat with 5 large docs against a 65k-window model, send a prompt. Before this change: 500 with `Input length (X) exceeds model's maximum context length`. After: request succeeds with an amber notice listing what was trimmed.
- [ ] Verify admin-set `context_window` per model takes precedence over the registry.
- [ ] Verify a single doc larger than the entire window returns a clean error (no 500, activity marked FAILED) instead of hitting the provider.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
