### PR TITLE
Refresh sidebar after importing workflows or extractions

### DIFF
--- a/frontend/src/components/workspace/ExtractionEditorPanel.tsx
+++ b/frontend/src/components/workspace/ExtractionEditorPanel.tsx
@@ -1,4 +1,5 @@
 import React, { Fragment, useCallback, useEffect, useRef, useState } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
 import { ExtractionTutorial } from './ExtractionTutorial'
 import { X, Pencil, Loader2, Copy, Trash2, GripVertical, Plus, ChevronDown, ChevronRight, Play, TrendingUp, Sparkles, FileText, AlertTriangle, Eye, Shield, ShieldCheck, Download, Check } from 'lucide-react'
 import { useWorkspace } from '../../contexts/WorkspaceContext'
@@ -60,6 +61,7 @@ interface ExtractionConfig {
 }
 
 export function ExtractionEditorPanel() {
+  const queryClient = useQueryClient()
   const { openExtractionId, openExtraction, closeExtraction, selectedDocUuids, setHighlightTerms, bumpActivitySignal, consumeExtractionResults } = useWorkspace()
   const { toast } = useToast()
   const [searchSet, setSearchSet] = useState<SearchSet | null>(null)
@@ -528,6 +530,7 @@ export function ExtractionEditorPanel() {
               e.target.value = ''
               try {
                 const result = await importSearchSet(f, openExtractionId ?? undefined)
+                await queryClient.invalidateQueries({ queryKey: ['searchSets'] })
                 if (openExtractionId) {
                   await refresh()
                   await refreshItems()

--- a/frontend/src/components/workspace/WorkflowEditorPanel.tsx
+++ b/frontend/src/components/workspace/WorkflowEditorPanel.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState, type CSSProperties } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
 import {
   X, Play, Loader2, Plus, Trash2, Pencil, SlidersHorizontal,
   FileText, Filter, Outdent, Globe, Image, Code,
@@ -136,6 +137,7 @@ const TEST_MESSAGES = [
 // ---------------------------------------------------------------------------
 
 export function WorkflowEditorPanel() {
+  const queryClient = useQueryClient()
   const { openWorkflowId, openWorkflow, closeWorkflow, consumeWorkflowSession, selectedDocUuids, bumpActivitySignal } = useWorkspace()
   const [workflow, setWorkflow] = useState<Workflow | null>(null)
   const [loading, setLoading] = useState(true)
@@ -425,6 +427,7 @@ export function WorkflowEditorPanel() {
               e.target.value = ''
               try {
                 const result = await importWorkflow(f)
+                await queryClient.invalidateQueries({ queryKey: ['workflows'] })
                 openWorkflow(result.id)
               } catch (err: unknown) {
                 alert(err instanceof Error ? err.message : 'Import failed')


### PR DESCRIPTION
## Summary
- Imported workflows and extractions were persisted to MongoDB and runnable, but didn't show up in the sidebar list until the page was reloaded.
- Root cause: the import file-input handlers in `WorkflowEditorPanel.tsx` and `ExtractionEditorPanel.tsx` called the API directly instead of going through TanStack Query mutations, so the `['workflows']` / `['searchSets']` list caches were never invalidated.
- Fix: invalidate the relevant query key right after a successful import so the sidebar updates immediately.

## Test plan
- [ ] Import a workflow `.json` — new "(Imported)" workflow appears in the workflow sidebar without reload
- [ ] Import an extraction `.json` (new) — new "(Imported)" extraction appears in the extraction sidebar without reload
- [ ] Import an extraction into an existing extraction (target_uuid set) — items still merge as before
- [ ] Reload the page — imported items are still present (confirms persistence)

🤖 Generated with [Claude Code](https://claude.com/claude-code)