### PR TITLE
Surface import/export at the top of the extraction Tools tab

### DIFF
--- a/frontend/src/components/workspace/ExtractionEditorPanel.tsx
+++ b/frontend/src/components/workspace/ExtractionEditorPanel.tsx
@@ -1346,6 +1346,30 @@ function ToolsTab({
           gap: 16,
         }}
       >
+        {/* Import Definition */}
+        <ToolCard
+          title="Import Definition"
+          description="Create a new extraction from an exported JSON file"
+          onClick={onImportDefinition}
+        />
+        {/* Export Definition */}
+        <ToolCard
+          title="Export Definition"
+          description="Download as a shareable JSON file"
+          onClick={onExportDefinition}
+        />
+        {/* Export PDF */}
+        <ToolCard
+          title={exportingPdf ? 'Exporting...' : 'Export PDF'}
+          description={
+            hasTemplate
+              ? 'Download a filled copy of the PDF template with extracted values'
+              : 'Download extraction results as a PDF report'
+          }
+          onClick={onExportPdf}
+          disabled={exportingPdf || !hasResults}
+          style={{ gridColumn: '1 / -1' }}
+        />
         {/* From Document */}
         <ToolCard
           title={buildingFromDoc ? 'Building...' : 'From Document'}
@@ -1378,29 +1402,7 @@ function ToolsTab({
             onClick: onGenerateTemplate,
             disabled: generatingTemplate || attachingTemplate || !hasItems,
           }}
-        />
-        {/* Export PDF */}
-        <ToolCard
-          title={exportingPdf ? 'Exporting...' : 'Export PDF'}
-          description={
-            hasTemplate
-              ? 'Download a filled copy of the PDF template with extracted values'
-              : 'Download extraction results as a PDF report'
-          }
-          onClick={onExportPdf}
-          disabled={exportingPdf || !hasResults}
-        />
-        {/* Export Definition */}
-        <ToolCard
-          title="Export Definition"
-          description="Download as a shareable JSON file"
-          onClick={onExportDefinition}
-        />
-        {/* Import Definition */}
-        <ToolCard
-          title="Import Definition"
-          description="Create a new extraction from an exported JSON file"
-          onClick={onImportDefinition}
+          style={{ gridColumn: '1 / -1' }}
         />
         {/* Delete */}
         <ToolCard


### PR DESCRIPTION
## Summary
- Reorders the cards in the extraction editor Tools tab so Import Definition, Export Definition, and Export PDF appear first
- Export PDF and Attach Template now span full width so the import/export pair sits side-by-side on the first row
- Other tools (From Document, Clone, Attach Template, Delete) keep their previous order below

## Why
Import/export are common actions but were buried below From Document, Clone, and Attach Template, requiring a scroll to reach. Surfacing them at the top makes them visible without scrolling.

## Test plan
- [ ] Open an extraction editor and switch to the Tools tab — verify Import Definition, Export Definition, and Export PDF render at the top
- [ ] Confirm Export PDF spans full width and remains disabled until results exist
- [ ] Confirm Import/Export Definition still trigger the existing JSON import/export flows
- [ ] Confirm From Document, Clone, Attach Template (with Generate Template secondary), and Delete still work and render below

🤖 Generated with [Claude Code](https://claude.com/claude-code)