### PR TITLE
Pass selected docs through when launching a prompt task from the library

### DIFF
--- a/frontend/src/components/chat/ChatPanel.tsx
+++ b/frontend/src/components/chat/ChatPanel.tsx
@@ -8,7 +8,7 @@ import { ContextMeter } from './ContextMeter'
 import { ContextLimitDialog } from './ContextLimitDialog'
 import { useChat } from '../../hooks/useChat'
 import { useOnboarding } from '../../hooks/useOnboarding'
-import { useWorkspace } from '../../contexts/WorkspaceContext'
+import { useWorkspace, type PendingChatMessage } from '../../contexts/WorkspaceContext'
 import { useToast } from '../../contexts/ToastContext'
 import { addLink, removeDocument, removeLink, truncateContext, compactContext, clearContext } from '../../api/chat'
 import { uploadFile } from '../../api/files'
@@ -50,7 +50,7 @@ function StreamingLabel() {
 
 interface ChatPanelProps {
   conversationToLoad?: string | null
-  pendingMessage?: string | null
+  pendingMessage?: PendingChatMessage | null
   onPendingMessageConsumed?: () => void
 }
 
@@ -255,11 +255,13 @@ export function ChatPanel({ conversationToLoad, pendingMessage, onPendingMessage
     }
   }, [conversationToLoad, loadHistory])
 
-  const pendingHandled = useRef<string | null>(null)
+  const pendingHandled = useRef<PendingChatMessage | null>(null)
   useEffect(() => {
     if (pendingMessage && pendingMessage !== pendingHandled.current && !isStreaming) {
       pendingHandled.current = pendingMessage
-      send(pendingMessage, selectedDocUuids, undefined, undefined, undefined, selectedFolderUuids)
+      const docs = pendingMessage.documentUuids ?? selectedDocUuids
+      const folders = pendingMessage.folderUuids ?? selectedFolderUuids
+      send(pendingMessage.message, docs, undefined, undefined, undefined, folders)
       onPendingMessageConsumed?.()
     }
   }, [pendingMessage, isStreaming, send, onPendingMessageConsumed])

--- a/frontend/src/components/workspace/LibraryTab.tsx
+++ b/frontend/src/components/workspace/LibraryTab.tsx
@@ -35,7 +35,7 @@ type KindFilter = 'all' | 'workflow' | 'search_set'
 type SortOption = 'recent' | 'az'
 
 export function LibraryTab() {
-  const { openWorkflow, openExtraction, sendChatMessage } = useWorkspace()
+  const { openWorkflow, openExtraction, sendChatMessage, selectedDocUuids, selectedFolderUuids } = useWorkspace()
   const { user } = useAuth()
   const teamId = user?.current_team ?? undefined
   const { libraries, loading: libLoading, error, refresh } = useLibraries(teamId)
@@ -985,7 +985,10 @@ export function LibraryTab() {
                       openWorkflow(it.item_id)
                     } else if (it.set_type === 'prompt' || it.set_type === 'formatter') {
                       const content = it.description || it.name
-                      sendChatMessage(content)
+                      sendChatMessage(content, {
+                        documentUuids: selectedDocUuids,
+                        folderUuids: selectedFolderUuids,
+                      })
                     } else if (it.set_type === 'extraction' && it.item_uuid) {
                       openExtraction(it.item_uuid)
                     }

--- a/frontend/src/contexts/WorkspaceContext.tsx
+++ b/frontend/src/contexts/WorkspaceContext.tsx
@@ -33,13 +33,22 @@ const NavigationContext = createContext<NavigationContextValue | null>(null)
 // 2. Chat State Context — conversation, KB, messages, signals
 // ---------------------------------------------------------------------------
 
+export interface PendingChatMessage {
+  message: string
+  documentUuids?: string[]
+  folderUuids?: string[]
+}
+
 interface ChatStateContextValue {
   loadConversationId: string | null
   setLoadConversationId: (id: string | null) => void
   newChatSignal: number
   triggerNewChat: () => void
-  pendingChatMessage: string | null
-  sendChatMessage: (message: string) => void
+  pendingChatMessage: PendingChatMessage | null
+  sendChatMessage: (
+    message: string,
+    options?: { documentUuids?: string[]; folderUuids?: string[] },
+  ) => void
   clearPendingChatMessage: () => void
   activeKBUuid: string | null
   activeKBTitle: string | null
@@ -158,7 +167,7 @@ export function WorkspaceProvider({ children }: { children: ReactNode }) {
   const [panelSplit, _setPanelSplit] = useState(() => getStoredNumber('workspace:panelSplit', 60))
   const [loadConversationId, setLoadConversationId] = useState<string | null>(null)
   const [newChatSignal, setNewChatSignal] = useState(0)
-  const [pendingChatMessage, setPendingChatMessage] = useState<string | null>(null)
+  const [pendingChatMessage, setPendingChatMessage] = useState<PendingChatMessage | null>(null)
   const [highlightTerms, setHighlightTerms] = useState<string[]>([])
   const [activitySignal, setActivitySignal] = useState(0)
   const [processingDoc, setProcessingDoc] = useState<{ title: string; status: string | null } | null>(null)
@@ -246,9 +255,16 @@ export function WorkspaceProvider({ children }: { children: ReactNode }) {
     updateSearch((prev) => ({ ...prev, workflow: undefined, extraction: undefined, automation: undefined, tab: undefined }))
   }, [updateSearch])
 
-  const sendChatMessage = useCallback((message: string) => {
+  const sendChatMessage = useCallback((
+    message: string,
+    options?: { documentUuids?: string[]; folderUuids?: string[] },
+  ) => {
     updateSearch((prev) => ({ ...prev, workflow: undefined, extraction: undefined, automation: undefined, tab: undefined }))
-    setPendingChatMessage(message)
+    setPendingChatMessage({
+      message,
+      documentUuids: options?.documentUuids,
+      folderUuids: options?.folderUuids,
+    })
   }, [updateSearch])
 
   const clearPendingChatMessage = useCallback(() => {


### PR DESCRIPTION
## Summary
- When the user had documents selected and clicked a Prompt or Formatter task in the Library tab, the docs were not reaching the chat request — the activity got created and the prompt was sent, but with no document context.
- Root cause: `sendChatMessage` only stored the message string, leaving `ChatPanel` to read `selectedDocUuids` from workspace state at the moment it consumed the pending message. The Library → Assistant tab swap remounts `ChatPanel`, and the selection wasn't reliably in scope by the time the effect ran.
- Fix: extend `sendChatMessage` to accept explicit `documentUuids` / `folderUuids`, capture the current selection at click time in `LibraryTab`, and have `ChatPanel` prefer those over its own workspace lookup when present.

## Test plan
- [ ] Select one or more documents in the file browser
- [ ] Open the Library tab and click a Prompt task
- [ ] Verify the assistant tab opens and the conversation includes the prompt + the selected documents as context
- [ ] Repeat for a Formatter task — should behave the same
- [ ] Click a Prompt task with no documents selected — should still send the prompt as a plain chat message
- [ ] Confirm clicking a workflow / extraction in the Library still opens the editor (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)