### PR TITLE
Allow attachments when creating a support ticket

### DIFF
--- a/backend/app/routers/support.py
+++ b/backend/app/routers/support.py
@@ -3,7 +3,7 @@
 import base64
 import logging
 
-from fastapi import APIRouter, Depends, HTTPException, UploadFile, File
+from fastapi import APIRouter, Depends, HTTPException, UploadFile, File, Form
 from fastapi.responses import Response
 from pydantic import BaseModel
 
@@ -19,12 +19,6 @@ router = APIRouter()
 # ---------------------------------------------------------------------------
 # Schemas
 # ---------------------------------------------------------------------------
-
-class CreateTicketRequest(BaseModel):
-    subject: str
-    message: str
-    priority: str = "normal"
-
 
 class AddMessageRequest(BaseModel):
     content: str
@@ -55,17 +49,48 @@ async def _is_support_user(user: User) -> bool:
 
 @router.post("/tickets")
 async def create_ticket(
-    body: CreateTicketRequest,
+    subject: str = Form(...),
+    message: str = Form(...),
+    priority: str = Form("normal"),
+    files: list[UploadFile] = File(default=[]),
     user: User = Depends(get_current_user),
 ):
+    # Validate all file sizes up-front so we don't create a ticket and then fail
+    file_payloads: list[tuple[str, str | None, bytes]] = []
+    for f in files:
+        data = await f.read()
+        if len(data) > 10 * 1024 * 1024:
+            raise HTTPException(
+                status_code=413,
+                detail=f"File '{f.filename}' must be under 10MB",
+            )
+        file_payloads.append((f.filename or "attachment", f.content_type, data))
+
     team_id = str(user.current_team) if user.current_team else None
     ticket = await support_service.create_ticket(
         user=user,
-        subject=body.subject,
-        message=body.message,
-        priority=body.priority,
+        subject=subject,
+        message=message,
+        priority=priority,
         team_id=team_id,
     )
+
+    if not file_payloads:
+        return ticket
+
+    initial_message_uuid = ticket["messages"][0]["uuid"] if ticket.get("messages") else None
+    for filename, content_type, data in file_payloads:
+        result = await support_service.add_attachment(
+            ticket_uuid=ticket["uuid"],
+            user=user,
+            filename=filename,
+            file_type=content_type,
+            file_bytes=data,
+            message_uuid=initial_message_uuid,
+        )
+        if result is not None:
+            ticket = result
+
     return ticket
 
 

--- a/frontend/src/api/support.ts
+++ b/frontend/src/api/support.ts
@@ -1,11 +1,29 @@
 import { apiFetch, ApiError, csrfHeaders } from './client'
 import type { SupportTicket, SupportTicketSummary, SupportContact } from '../types/support'
 
-export function createTicket(subject: string, message: string, priority = 'normal') {
-  return apiFetch<SupportTicket>('/api/support/tickets', {
+export async function createTicket(
+  subject: string,
+  message: string,
+  priority = 'normal',
+  files: File[] = [],
+) {
+  const form = new FormData()
+  form.append('subject', subject)
+  form.append('message', message)
+  form.append('priority', priority)
+  for (const f of files) form.append('files', f)
+
+  const res = await fetch('/api/support/tickets', {
     method: 'POST',
-    body: JSON.stringify({ subject, message, priority }),
+    credentials: 'include',
+    headers: csrfHeaders(),
+    body: form,
   })
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({ detail: 'Failed to create ticket' }))
+    throw new ApiError(res.status, body.detail || 'Failed to create ticket')
+  }
+  return res.json() as Promise<SupportTicket>
 }
 
 export function listTickets(status?: string, limit = 50, offset = 0) {

--- a/frontend/src/components/support/SupportChatPanel.tsx
+++ b/frontend/src/components/support/SupportChatPanel.tsx
@@ -190,18 +190,46 @@ function NewTicketView({
   const [subject, setSubject] = useState('')
   const [message, setMessage] = useState('')
   const [priority, setPriority] = useState('normal')
+  const [files, setFiles] = useState<File[]>([])
   const [submitting, setSubmitting] = useState(false)
+  const fileInputRef = useRef<HTMLInputElement>(null)
   const { toast } = useToast()
+
+  const MAX_BYTES = 10 * 1024 * 1024
+
+  const handleFilesPicked = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const picked = Array.from(e.target.files ?? [])
+    if (fileInputRef.current) fileInputRef.current.value = ''
+    const accepted: File[] = []
+    for (const f of picked) {
+      if (f.size > MAX_BYTES) {
+        toast(`${f.name} is over 10MB`, 'error')
+        continue
+      }
+      accepted.push(f)
+    }
+    if (accepted.length) setFiles((prev) => [...prev, ...accepted])
+  }
+
+  const removeFile = (idx: number) => {
+    setFiles((prev) => prev.filter((_, i) => i !== idx))
+  }
 
   const handleSubmit = async () => {
     if (!subject.trim() || !message.trim()) return
     setSubmitting(true)
     try {
-      const ticket = await supportApi.createTicket(subject.trim(), message.trim(), priority)
+      const ticket = await supportApi.createTicket(
+        subject.trim(),
+        message.trim(),
+        priority,
+        files,
+      )
       toast('Ticket created', 'success')
       onCreated(ticket)
-    } catch {
-      toast('Failed to create ticket', 'error')
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Failed to create ticket'
+      toast(msg, 'error')
     } finally {
       setSubmitting(false)
     }
@@ -247,6 +275,46 @@ function NewTicketView({
             className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
             placeholder="Describe your issue..."
           />
+        </div>
+        <div>
+          <div className="flex items-center justify-between">
+            <label className="text-xs font-medium text-gray-600">Attachments</label>
+            <button
+              type="button"
+              onClick={() => fileInputRef.current?.click()}
+              className="inline-flex items-center gap-1 rounded p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-600"
+              title="Attach file"
+            >
+              <Paperclip className="h-4 w-4" />
+            </button>
+            <input
+              ref={fileInputRef}
+              type="file"
+              multiple
+              className="hidden"
+              onChange={handleFilesPicked}
+            />
+          </div>
+          {files.length > 0 && (
+            <ul className="mt-1 space-y-1">
+              {files.map((f, i) => (
+                <li
+                  key={`${f.name}-${i}`}
+                  className="flex items-center justify-between gap-2 rounded border border-gray-200 bg-gray-50 px-2 py-1 text-xs"
+                >
+                  <span className="truncate text-gray-700" title={f.name}>{f.name}</span>
+                  <button
+                    type="button"
+                    onClick={() => removeFile(i)}
+                    className="shrink-0 rounded p-0.5 text-gray-400 hover:bg-gray-200 hover:text-gray-600"
+                    title="Remove"
+                  >
+                    <X className="h-3 w-3" />
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
         </div>
       </div>
       <div className="border-t p-3">


### PR DESCRIPTION
## Summary
- The paperclip in the support panel was only rendered inside an active ticket chat, so first-time tickets couldn't include screenshots/logs at submission. Users had to submit, then chase the ticket in a second step.
- `POST /api/support/tickets` now accepts `multipart/form-data` with `subject`, `message`, `priority`, and optional `files[]`. Sizes are validated up-front (10MB/file) so the ticket is never created when an attachment is rejected; uploaded files attach to the initial message via `message_uuid`.
- `NewTicketView` gains a paperclip button, a staged file list, per-file remove buttons, and client-side 10MB validation.

## Test plan
- [ ] Open the support panel, click **New Ticket**, attach one or more files (mix of images and non-images), submit — ticket appears with attachments rendered under the first message.
- [ ] Submit a new ticket with no attachments — still works.
- [ ] Try attaching a file > 10MB — client rejects with toast; if bypassed, server returns 413 and no ticket is created.
- [ ] Existing in-chat paperclip flow still adds attachments to an existing ticket.
- [ ] `make backend-static` and frontend `tsc`/lint clean (verified locally on touched files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)