### PR TITLE
Auto-grow chat input textarea and add highlight focus ring

### DIFF
--- a/frontend/src/components/chat/ChatInput.tsx
+++ b/frontend/src/components/chat/ChatInput.tsx
@@ -33,6 +33,15 @@ export function ChatInput({
   const addMenuRef = useRef<HTMLDivElement>(null)
   const modelMenuRef = useRef<HTMLDivElement>(null)
   const exportMenuRef = useRef<HTMLDivElement>(null)
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+
+  // Auto-grow the textarea to fit its content, capped by max-height (CSS).
+  useEffect(() => {
+    const ta = textareaRef.current
+    if (!ta) return
+    ta.style.height = 'auto'
+    ta.style.height = `${ta.scrollHeight}px`
+  }, [message])
 
   useEffect(() => {
     const handler = (e: MouseEvent) => {
@@ -122,23 +131,25 @@ export function ChatInput({
 
       {/* Ask question container */}
       <div
-        className="flex flex-col rounded-[var(--ui-radius)] p-2.5"
+        className="flex flex-col rounded-[var(--ui-radius)] p-2.5 ring-1 ring-transparent focus-within:ring-2 focus-within:ring-highlight transition-shadow"
         style={{ backgroundColor: '#19191913' }}
       >
         {/* Text input area */}
         <div
-          className="overflow-y-auto cursor-text"
-          style={{ maxHeight: '25vh', padding: '8px 6px 12px 6px' }}
+          className="cursor-text"
+          style={{ padding: '8px 6px 12px 6px' }}
+          onClick={() => textareaRef.current?.focus()}
         >
           <textarea
+            ref={textareaRef}
             value={message}
             onChange={(e) => setMessage(e.target.value)}
             onKeyDown={handleKeyDown}
             placeholder={hasDocuments ? "Ask anything about this document..." : "Ask Vandalizer anything..."}
             aria-label="Message input"
             rows={1}
-            className="w-full resize-none border-0 bg-transparent text-base font-medium placeholder:text-[#8a8f98] placeholder:font-medium focus:outline-none"
-            style={{ fontSize: 16 }}
+            className="block w-full resize-none border-0 bg-transparent text-base font-medium caret-highlight placeholder:text-[#8a8f98] placeholder:font-medium focus:outline-none overflow-y-auto"
+            style={{ fontSize: 16, maxHeight: '25vh' }}
             disabled={disabled}
           />
         </div>


### PR DESCRIPTION
## Summary
- Chat input textarea now auto-grows with content (up to 25vh, then scrolls internally) instead of staying a fixed single row, so multi-line messages stop appearing truncated.
- Added a `focus-within` ring on the input box and a `caret-highlight` color on the textarea so the input visibly responds to focus, using the existing `--color-highlight` token.

## Test plan
- [ ] Open a chat and type a long, multi-line message — textarea should grow line by line.
- [ ] Once the message exceeds ~25% of viewport height, internal scroll should engage instead of pushing the toolbar.
- [ ] Send the message — textarea should snap back to a single row.
- [ ] Shift+Enter still inserts a newline; Enter still sends.
- [ ] Focus the input — yellow (highlight color) ring appears around the box; caret is yellow.
- [ ] Click inside the gray padding (not directly on the textarea) — focus still lands on the textarea.

🤖 Generated with [Claude Code](https://claude.com/claude-code)