### PR TITLE
Surface clearer errors when adding a workflow task fails

### DIFF
--- a/backend/app/routers/workflows.py
+++ b/backend/app/routers/workflows.py
@@ -545,8 +545,33 @@ async def delete_step(step_id: str, user: User = Depends(get_current_user)):
 async def add_task(step_id: str, req: AddTaskRequest, user: User = Depends(get_current_user)):
     task = await svc.add_task(step_id, req.name, user=user, data=req.data)
     if not task:
-        raise HTTPException(status_code=404, detail="Step not found")
+        status_code, detail = await _diagnose_step_mutation_failure(step_id, user)
+        raise HTTPException(status_code=status_code, detail=detail)
     return task
+
+
+async def _diagnose_step_mutation_failure(step_id: str, user: User) -> tuple[int, str]:
+    """Why did a step-scoped mutation return None?
+
+    The service collapses "step missing", "orphan workflow", and "user lacks
+    permission" into the same `None` return. This walks the same lookups to
+    pick a clearer status + detail for the client.
+    """
+    from app.models.workflow import WorkflowStep
+
+    try:
+        step = await WorkflowStep.get(PydanticObjectId(step_id))
+    except Exception:
+        return 404, "Step not found"
+    if not step:
+        return 404, "Step not found"
+    parent = await svc._get_workflow_for_step(step.id)
+    if not parent:
+        return 404, "Step's workflow not found"
+    team_access = await access_control.get_team_access_context(user)
+    if not access_control.can_manage_workflow(parent, user, team_access):
+        return 403, "You don't have permission to edit this workflow"
+    return 500, "Failed to update step"
 
 
 @router.patch("/tasks/{task_id}")

--- a/backend/app/schemas/workflows.py
+++ b/backend/app/schemas/workflows.py
@@ -27,6 +27,7 @@ class WorkflowResponse(BaseModel):
     num_executions: int = 0
     steps: list[dict] = []  # Dereferenced step objects
     input_config: dict = {}
+    can_manage: bool = True
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/services/workflow_service.py
+++ b/backend/app/services/workflow_service.py
@@ -21,6 +21,7 @@ from app.models.workflow import (
     WorkflowStepTask,
 )
 from app.services.access_control import (
+    can_manage_workflow,
     can_view_workflow,
     get_authorized_document,
     get_authorized_workflow,
@@ -105,10 +106,15 @@ async def get_workflow(workflow_id: str, user: User | None = None) -> dict | Non
         wf = await get_authorized_workflow(workflow_id, user)
         if not wf:
             return None
+        team_access = await get_team_access_context(user)
+        can_manage = can_manage_workflow(wf, user, team_access)
     else:
         wf = await Workflow.get(PydanticObjectId(workflow_id))
         if not wf:
             return None
+        # Without a user (e.g. internal export), assume manage to preserve
+        # existing behavior — callers that gate on this pass a user.
+        can_manage = True
 
     steps = []
     for step_id in wf.steps:
@@ -142,6 +148,7 @@ async def get_workflow(workflow_id: str, user: User | None = None) -> dict | Non
         "input_config": _sanitize_for_json(wf.input_config),
         "validation_plan": _sanitize_for_json(wf.validation_plan),
         "validation_inputs": _sanitize_for_json(wf.validation_inputs),
+        "can_manage": can_manage,
     }
 
 

--- a/frontend/src/components/workspace/WorkflowEditorPanel.tsx
+++ b/frontend/src/components/workspace/WorkflowEditorPanel.tsx
@@ -19,7 +19,7 @@ import {
   getWorkflowQualityHistory, getWorkflowImprovementSuggestions, getWorkflowQualityStatus,
   getValidationPlan, updateValidationPlan, generateValidationPlan,
   getValidationInputs, updateValidationInputs,
-  exportWorkflowUrl, importWorkflow, getWorkflowHistory,
+  exportWorkflowUrl, importWorkflow, getWorkflowHistory, duplicateWorkflow,
 } from '../../api/workflows'
 import { RunHistoryTab } from './RunHistoryTab'
 import type { ValidationCheck, ValidationCheckDefinition, ValidationInputDefinition, QualityHistoryRun, BatchStatus, WorkflowQualityStatus } from '../../api/workflows'
@@ -246,11 +246,22 @@ export function WorkflowEditorPanel() {
 
   const handleAddStep = async () => {
     if (!openWorkflowId || !newStepName.trim()) return
-    const result = (await addStep(openWorkflowId, { name: newStepName.trim() })) as { id?: string }
-    setShowNewStepModal(false)
-    setNewStepName('')
-    await refresh()
-    if (result?.id) setEditingStepId(result.id)
+    if (workflow?.can_manage === false) {
+      toast('Make a copy to edit this workflow', 'error')
+      setShowNewStepModal(false)
+      return
+    }
+    try {
+      const result = (await addStep(openWorkflowId, { name: newStepName.trim() })) as { id?: string }
+      setShowNewStepModal(false)
+      setNewStepName('')
+      await refresh()
+      if (result?.id) setEditingStepId(result.id)
+    } catch (err) {
+      toast(err instanceof Error ? err.message : 'Failed to add step', 'error')
+      setShowNewStepModal(false)
+      refresh()
+    }
   }
 
   const handleDeleteStep = async (stepId: string) => {
@@ -262,6 +273,11 @@ export function WorkflowEditorPanel() {
 
   const handleAddTask = async (taskType: TaskTypeDef) => {
     if (!editingStepId) return
+    if (workflow?.can_manage === false) {
+      toast('Make a copy to edit this workflow', 'error')
+      setShowTaskPicker(false)
+      return
+    }
     try {
       await addTask(editingStepId, { name: taskType.name })
       setShowTaskPicker(false)
@@ -332,6 +348,28 @@ export function WorkflowEditorPanel() {
       if (uuids.length === 0) return
       setActiveTab('design')
       await runner.start(openWorkflowId, uuids, undefined, batchMode)
+    }
+  }
+
+  const canManage = workflow?.can_manage !== false
+  const [duplicating, setDuplicating] = useState(false)
+
+  const handleMakeCopy = async () => {
+    if (!openWorkflowId || duplicating) return
+    setDuplicating(true)
+    try {
+      const copy = (await duplicateWorkflow(openWorkflowId)) as { id?: string }
+      if (copy?.id) {
+        toast('Copied workflow — opening your editable version', 'success')
+        openWorkflow(copy.id)
+      } else {
+        toast('Failed to copy workflow', 'error')
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Failed to copy workflow'
+      toast(msg, 'error')
+    } finally {
+      setDuplicating(false)
     }
   }
 
@@ -458,6 +496,37 @@ export function WorkflowEditorPanel() {
         )}
       </div>
 
+      {/* ===== READ-ONLY BANNER (shared workflow you don't own) ===== */}
+      {!canManage && (
+        <div style={{
+          display: 'flex', alignItems: 'center', gap: 12,
+          padding: '10px 24px',
+          backgroundColor: '#fffbeb',
+          borderBottom: '1px solid #fde68a',
+          fontSize: 13,
+          color: '#78350f',
+          flexShrink: 0,
+        }}>
+          <ShieldCheck style={{ width: 16, height: 16, color: '#b45309', flexShrink: 0 }} />
+          <span style={{ flex: 1 }}>
+            This workflow is shared with you. Make a copy to edit it — your copy will be saved to your team.
+          </span>
+          <button
+            onClick={handleMakeCopy}
+            disabled={duplicating}
+            style={{
+              padding: '6px 14px', fontSize: 12, fontWeight: 700, fontFamily: 'inherit',
+              borderRadius: 6, border: '1px solid var(--highlight-color, #eab308)',
+              backgroundColor: 'var(--highlight-color, #eab308)',
+              color: 'var(--highlight-text-color, #000)', cursor: 'pointer',
+              whiteSpace: 'nowrap', opacity: duplicating ? 0.6 : 1,
+            }}
+          >
+            {duplicating ? 'Copying...' : 'Make a copy to edit'}
+          </button>
+        </div>
+      )}
+
       {/* ===== TAB BAR ===== */}
       <div style={{ display: 'flex', borderBottom: '1px solid #e5e7eb', padding: '0 24px', backgroundColor: '#fff', flexShrink: 0 }}>
         {TABS.map(tab => {
@@ -530,6 +599,7 @@ export function WorkflowEditorPanel() {
               onClickStep={setEditingStepId}
               onAddStep={() => { setNewStepName(''); setShowNewStepModal(true) }}
               onMoveStep={handleMoveStep}
+              canManage={canManage}
             />
             {/* Quality Pulse card */}
             {qualityStatus && openWorkflowId && (
@@ -740,6 +810,7 @@ export function WorkflowEditorPanel() {
           setTaskPickerCategory={setTaskPickerCategory}
           onSelectTaskType={handleAddTask}
           onCloseTaskPicker={() => setShowTaskPicker(false)}
+          canManage={canManage}
         />
       )}
 
@@ -865,6 +936,7 @@ function DesignCanvas({
   onClickStep,
   onAddStep,
   onMoveStep,
+  canManage,
 }: {
   workflow: Workflow
   selectedDocCount: number
@@ -878,6 +950,7 @@ function DesignCanvas({
   onClickStep: (stepId: string) => void
   onAddStep: () => void
   onMoveStep: (stepIndex: number, direction: 'up' | 'down') => void
+  canManage: boolean
 }) {
   return (
     <div style={{
@@ -949,8 +1022,8 @@ function DesignCanvas({
         ))
       })()}
 
-      {/* +ADD STEP — hidden when the last step is an output step */}
-      {!(workflow.steps.length > 0 && workflow.steps[workflow.steps.length - 1].is_output) && (
+      {/* +ADD STEP — hidden when read-only or when the last step is an output step */}
+      {canManage && !(workflow.steps.length > 0 && workflow.steps[workflow.steps.length - 1].is_output) && (
         <>
           <ConnectionLine />
           <div style={{ display: 'flex', justifyContent: 'center' }}>
@@ -1141,6 +1214,7 @@ function EditStepOverlay({
   onStepNameSave, onToggleOutput,
   showTaskPicker, taskPickerCategory, setTaskPickerCategory,
   onSelectTaskType, onCloseTaskPicker,
+  canManage,
 }: {
   step: WorkflowStep
   onClose: () => void
@@ -1155,6 +1229,7 @@ function EditStepOverlay({
   setTaskPickerCategory: (cat: TaskCategory) => void
   onSelectTaskType: (type: TaskTypeDef) => void
   onCloseTaskPicker: () => void
+  canManage: boolean
 }) {
   const [editingName, setEditingName] = useState(false)
   const [nameValue, setNameValue] = useState(step.name)
@@ -1307,22 +1382,24 @@ function EditStepOverlay({
             )
           })}
 
-          {/* Add task button */}
-          <div
-            onClick={onAddTask}
-            style={{
-              backgroundColor: '#191919', color: '#fff',
-              borderRadius: 'var(--ui-radius, 8px)',
-              padding: 16, cursor: 'pointer',
-              display: 'flex', alignItems: 'center', gap: 10,
-              marginTop: step.tasks.length > 0 ? 8 : 0,
-            }}
-          >
-            <Plus style={{ width: 18, height: 18 }} />
-            <span style={{ fontSize: 13, fontWeight: 600 }}>
-              {step.tasks.length > 0 ? 'ADD A TASK' : 'ADD YOUR FIRST TASK'}
-            </span>
-          </div>
+          {/* Add task button — hidden when the workflow is read-only */}
+          {canManage && (
+            <div
+              onClick={onAddTask}
+              style={{
+                backgroundColor: '#191919', color: '#fff',
+                borderRadius: 'var(--ui-radius, 8px)',
+                padding: 16, cursor: 'pointer',
+                display: 'flex', alignItems: 'center', gap: 10,
+                marginTop: step.tasks.length > 0 ? 8 : 0,
+              }}
+            >
+              <Plus style={{ width: 18, height: 18 }} />
+              <span style={{ fontSize: 13, fontWeight: 600 }}>
+                {step.tasks.length > 0 ? 'ADD A TASK' : 'ADD YOUR FIRST TASK'}
+              </span>
+            </div>
+          )}
         </div>
       </div>
 

--- a/frontend/src/components/workspace/WorkflowEditorPanel.tsx
+++ b/frontend/src/components/workspace/WorkflowEditorPanel.tsx
@@ -11,6 +11,7 @@ import {
   Upload, Clock,
 } from 'lucide-react'
 import { useWorkspace } from '../../contexts/WorkspaceContext'
+import { useToast } from '../../contexts/ToastContext'
 import {
   getWorkflow, addStep, deleteStep, addTask, deleteTask, updateTask,
   updateWorkflow, updateStep, downloadResults, testStep, getTestStepStatus,
@@ -138,6 +139,7 @@ const TEST_MESSAGES = [
 
 export function WorkflowEditorPanel() {
   const queryClient = useQueryClient()
+  const { toast } = useToast()
   const { openWorkflowId, openWorkflow, closeWorkflow, consumeWorkflowSession, selectedDocUuids, bumpActivitySignal } = useWorkspace()
   const [workflow, setWorkflow] = useState<Workflow | null>(null)
   const [loading, setLoading] = useState(true)
@@ -260,9 +262,19 @@ export function WorkflowEditorPanel() {
 
   const handleAddTask = async (taskType: TaskTypeDef) => {
     if (!editingStepId) return
-    await addTask(editingStepId, { name: taskType.name })
-    setShowTaskPicker(false)
-    refresh()
+    try {
+      await addTask(editingStepId, { name: taskType.name })
+      setShowTaskPicker(false)
+      refresh()
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Failed to add task'
+      toast(msg, 'error')
+      // Recover: close the picker, drop the (likely stale) step selection,
+      // and reload the workflow so the editor matches server state.
+      setShowTaskPicker(false)
+      setEditingStepId(null)
+      refresh()
+    }
   }
 
   const handleDeleteTask = async (taskId: string) => {

--- a/frontend/src/types/workflow.ts
+++ b/frontend/src/types/workflow.ts
@@ -51,6 +51,7 @@ export interface Workflow {
   num_executions: number;
   steps: WorkflowStep[];
   input_config?: { trigger_type?: string };
+  can_manage?: boolean;
 }
 
 export interface WorkflowStatus {


### PR DESCRIPTION
## Summary
Adding a workflow from the Explore tab creates a *reference* (a `LibraryItem` pointing at the published workflow), not a copy — so the workflow still belongs to its publisher. The user can view it (`get_workflow` allows view) but cannot manage it, and `add_task` requires manage. The original failure mode: a 404 "Step not found" with no UI feedback when clicking a task type, encouraging repeat clicks.

This PR makes that state explicit instead of letting it surface as a confusing 404.

## Changes
### Backend
- `WorkflowResponse` now includes `can_manage: bool`.
- `workflow_service.get_workflow` computes `can_manage` for the requesting user via `can_manage_workflow(...)`.
- `POST /workflows/steps/{step_id}/tasks`: when the service returns `None`, a helper (`_diagnose_step_mutation_failure`) walks the same lookups and raises 403 ("You don't have permission to edit this workflow") for the auth case, or distinguishes "Step not found" from "Step's workflow not found" for the orphan case — instead of all paths flattening to 404.

### Frontend
- New `Workflow.can_manage?: boolean` flag on the type.
- Editor reads it as `canManage`. When false:
  - Yellow banner above the editor: "This workflow is shared with you. Make a copy to edit it — your copy will be saved to your team." with a **Make a copy to edit** action.
  - The action calls `duplicateWorkflow`, then `openWorkflow(newId)` so the user lands directly in their editable copy.
  - +Add Step and +Add Task affordances are hidden (instead of clickable buttons that produce 403s).
- `handleAddTask` and `handleAddStep` are wrapped in try/catch with `useToast` for errors, and clear stale `editingStepId` + refresh on failure so the picker can't get stuck open.

## Test plan
- [ ] **Owner path:** open a workflow you created → no banner; +Add Step / +Add Task work as before.
- [ ] **Library reference path:** add a verified workflow from the Explore tab via "Add to Library", open it → banner appears; +Add Step / +Add Task affordances are hidden.
- [ ] Click **Make a copy to edit** → success toast; the editor reopens on the new `(Copy)` workflow you can fully edit.
- [ ] **Team member (view-only) path:** as a non-manage team member viewing a teammate's workflow → same banner + Make-a-copy flow.
- [ ] **Stale step path:** delete a step in another tab, then try to add a task in the first tab → toast shows "Step not found"; picker closes; workflow reloads.
- [ ] Run `make backend-static` and `npx tsc --noEmit` in `frontend/` — both clean locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)