### PR TITLE
Make folder breadcrumb navigation more discoverable

### DIFF
--- a/frontend/src/components/files/Breadcrumbs.tsx
+++ b/frontend/src/components/files/Breadcrumbs.tsx
@@ -1,36 +1,74 @@
+import { ArrowLeft } from 'lucide-react'
+
 interface BreadcrumbsProps {
   items: Array<{ uuid: string; title: string }>
   onNavigate: (folderId: string | null) => void
 }
 
 export function Breadcrumbs({ items, onNavigate }: BreadcrumbsProps) {
+  const atRoot = items.length === 0
+  const parentId = items.length >= 2 ? items[items.length - 2].uuid : null
+  const currentTitle = items.length > 0 ? items[items.length - 1].title : null
+  const ancestors = items.slice(0, -1)
+
+  const handleUp = () => {
+    if (atRoot) return
+    onNavigate(parentId)
+  }
+
   return (
     <nav
-      className="overflow-x-auto whitespace-nowrap"
+      aria-label="Folder navigation"
+      className="overflow-x-auto whitespace-nowrap flex items-center gap-2"
       style={{ padding: '20px 30px 0px 0px' }}
     >
+      {!atRoot && (
+        <button
+          type="button"
+          onClick={handleUp}
+          aria-label="Go to parent folder"
+          title="Go to parent folder"
+          className="inline-flex items-center justify-center rounded-md border border-gray-200 bg-white text-gray-600 hover:bg-gray-50 hover:text-gray-900 transition-colors"
+          style={{ width: 28, height: 28 }}
+        >
+          <ArrowLeft className="h-4 w-4" />
+        </button>
+      )}
+
       <ol className="inline-flex items-center gap-1 list-none m-0 p-0">
-        <li className="inline-flex items-center text-sm" style={{ fontWeight: 200 }}>
-          <button
-            onClick={() => onNavigate(null)}
-            className="bg-transparent border-0 cursor-pointer p-0"
-            style={{ color: '#c6c6c6', textDecoration: 'none' }}
-          >
-            Home
-          </button>
-        </li>
-        {items.map((item) => (
-          <li key={item.uuid} className="inline-flex items-center text-sm" style={{ fontWeight: 200 }}>
-            <span className="mx-[7.5px] opacity-60" aria-hidden="true">›</span>
+        <li className="inline-flex items-center text-sm">
+          {atRoot ? (
+            <span style={{ color: '#111', fontWeight: 600 }}>Home</span>
+          ) : (
             <button
+              type="button"
+              onClick={() => onNavigate(null)}
+              className="bg-transparent border-0 cursor-pointer p-0 text-gray-600 hover:text-gray-900 hover:underline"
+              style={{ fontWeight: 400 }}
+            >
+              Home
+            </button>
+          )}
+        </li>
+        {ancestors.map((item) => (
+          <li key={item.uuid} className="inline-flex items-center text-sm">
+            <span className="mx-[7.5px] text-gray-400" aria-hidden="true">›</span>
+            <button
+              type="button"
               onClick={() => onNavigate(item.uuid)}
-              className="bg-transparent border-0 cursor-pointer p-0"
-              style={{ color: '#a2a2a2', fontWeight: 300 }}
+              className="bg-transparent border-0 cursor-pointer p-0 text-gray-600 hover:text-gray-900 hover:underline"
+              style={{ fontWeight: 400 }}
             >
               {item.title}
             </button>
           </li>
         ))}
+        {currentTitle && (
+          <li className="inline-flex items-center text-sm" aria-current="page">
+            <span className="mx-[7.5px] text-gray-400" aria-hidden="true">›</span>
+            <span style={{ color: '#111', fontWeight: 600 }}>{currentTitle}</span>
+          </li>
+        )}
       </ol>
     </nav>
   )


### PR DESCRIPTION
## Summary
- Bumps the file-browser breadcrumb from faint extra-light gray (`#c6c6c6` / `#a2a2a2`, fontWeight 200) to standard contrast with hover/underline affordances on each crumb.
- Renders the current folder as bold plain text with `aria-current="page"`, instead of a no-op button styled the same as ancestors.
- Adds a parent-folder arrow button to the left of the breadcrumb (hidden when at the root) so going up one level is a single obvious click.

## Test plan
- [ ] At the root, only the bold "Home" label shows (no back arrow).
- [ ] Inside a folder, the back arrow appears and navigates to the parent (or Home, if the parent is root).
- [ ] Each ancestor crumb is visibly clickable (darkens + underlines on hover) and navigates correctly.
- [ ] The current folder is shown bold and is not clickable.
- [ ] Keyboard / screen-reader users see "Folder navigation" landmark, "Go to parent folder" on the up button, and `aria-current="page"` on the current crumb.

🤖 Generated with [Claude Code](https://claude.com/claude-code)