### PR TITLE
Expand file-browser checkbox hit target to whole cell

### DIFF
--- a/frontend/src/components/files/FileRow.tsx
+++ b/frontend/src/components/files/FileRow.tsx
@@ -47,16 +47,20 @@ export function FileRow({ doc, onClick, onContextMenu, selected, onToggleSelect,
       style={{ borderBottom: '1px solid #dddddd', cursor: 'pointer' }}
     >
       {/* Checkbox */}
-      <td style={{ padding: '12px 0 12px 15px', width: 32 }}>
+      <td style={{ padding: 0, width: 32 }} onClick={(e) => e.stopPropagation()}>
         {onToggleSelect && (
-          <input
-            type="checkbox"
-            checked={!!selected}
-            onChange={() => onToggleSelect(doc.uuid)}
-            onClick={(e) => e.stopPropagation()}
-            aria-label={`Select ${doc.title}`}
-            className="h-4 w-4 cursor-pointer accent-[var(--highlight-color)]"
-          />
+          <label
+            className="flex items-center cursor-pointer"
+            style={{ padding: '12px 4px 12px 15px' }}
+          >
+            <input
+              type="checkbox"
+              checked={!!selected}
+              onChange={() => onToggleSelect(doc.uuid)}
+              aria-label={`Select ${doc.title}`}
+              className="h-4 w-4 cursor-pointer accent-[var(--highlight-color)]"
+            />
+          </label>
         )}
       </td>
 

--- a/frontend/src/components/files/FolderRow.tsx
+++ b/frontend/src/components/files/FolderRow.tsx
@@ -72,16 +72,20 @@ export function FolderRow({ folder, onClick, onContextMenu, selected, onToggleSe
       }}
     >
       {/* Checkbox */}
-      <td style={{ padding: '12px 0 12px 15px', width: 32 }}>
+      <td style={{ padding: 0, width: 32 }} onClick={(e) => e.stopPropagation()}>
         {onToggleSelect && (
-          <input
-            type="checkbox"
-            checked={!!selected}
-            onChange={() => onToggleSelect(folder.uuid)}
-            onClick={(e) => e.stopPropagation()}
-            aria-label={`Select ${folder.title}`}
-            className="h-4 w-4 cursor-pointer accent-[var(--highlight-color)]"
-          />
+          <label
+            className="flex items-center cursor-pointer"
+            style={{ padding: '12px 4px 12px 15px' }}
+          >
+            <input
+              type="checkbox"
+              checked={!!selected}
+              onChange={() => onToggleSelect(folder.uuid)}
+              aria-label={`Select ${folder.title}`}
+              className="h-4 w-4 cursor-pointer accent-[var(--highlight-color)]"
+            />
+          </label>
         )}
       </td>
 


### PR DESCRIPTION
## Summary
- Wraps the checkbox in `FileRow` and `FolderRow` in a `<label>` that fills the entire cell, and stops click propagation on the `<td>`
- A click anywhere in the 32px-wide × full-row-height checkbox cell now toggles selection instead of opening the document preview when the user just barely misses the 16px input

## Test plan
- [ ] Click directly on the checkbox — toggles selection, does not open preview
- [ ] Click 1–2 px outside the checkbox but still inside the leftmost column — toggles selection, does not open preview
- [ ] Click on the document name / row body — opens preview as before
- [ ] Click on the row's "more options" (⋮) button — opens menu, does not open preview
- [ ] Same checks for folder rows (toggle selection vs. navigate into folder)
- [ ] Keyboard: Enter / Space on a focused row still opens preview / navigates folder

🤖 Generated with [Claude Code](https://claude.com/claude-code)