### PR TITLE
Add Improve button to Prompt task editor

### DIFF
--- a/backend/app/routers/workflows.py
+++ b/backend/app/routers/workflows.py
@@ -10,6 +10,7 @@ import re
 from beanie import PydanticObjectId
 from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, Request, UploadFile
 from fastapi.responses import StreamingResponse
+from pydantic import BaseModel
 
 from app.dependencies import get_api_key_user, get_current_user
 from app.models.user import User
@@ -756,6 +757,35 @@ async def get_workflow_suggestions(
     result_snapshot = latest.get("result_snapshot", latest)
     suggestions = await generate_improvement_suggestions("workflow", workflow_id, result_snapshot)
     return {"suggestions": suggestions}
+
+
+class ImprovePromptRequest(BaseModel):
+    prompt: str
+    input_source: str | None = None
+    prev_step_name: str | None = None
+    sample_input: str | None = None
+
+
+@router.post("/improve-prompt")
+@limiter.limit("10/minute")
+async def improve_prompt_endpoint(
+    request: Request,
+    body: ImprovePromptRequest,
+    user: User = Depends(get_current_user),
+):
+    """LLM-suggested rewrite of a Prompt task's prompt, with rationale."""
+    if not body.prompt.strip():
+        raise HTTPException(status_code=400, detail="Prompt is required")
+    from app.services.prompt_improvement_service import improve_prompt
+    try:
+        return await improve_prompt(
+            prompt=body.prompt,
+            input_source=body.input_source,
+            prev_step_name=body.prev_step_name,
+            sample_input=body.sample_input,
+        )
+    except Exception as exc:
+        raise HTTPException(status_code=502, detail=f"Failed to generate suggestion: {exc}")
 
 
 @router.get("/{workflow_id}/quality-status")

--- a/backend/app/services/prompt_improvement_service.py
+++ b/backend/app/services/prompt_improvement_service.py
@@ -1,0 +1,86 @@
+"""LLM-powered suggestions to improve a user's prompt.
+
+Used by the Prompt task editor to let users one-click rewrite their prompt
+with a short rationale explaining each change.
+"""
+
+import logging
+
+from pydantic import BaseModel, Field
+from pydantic_ai import Agent
+
+from app.models.system_config import SystemConfig
+
+logger = logging.getLogger(__name__)
+
+
+class PromptImprovement(BaseModel):
+    improved_prompt: str = Field(description="The rewritten prompt, ready to use as a drop-in replacement.")
+    rationale: list[str] = Field(description="3-5 short bullets, each describing one specific change and why it helps.")
+
+
+_SYSTEM_PROMPT = """You are an expert at improving LLM prompts for document-processing workflows.
+
+You are given:
+- An original prompt the user wrote for a "Prompt" task in a workflow.
+- The task's input source (where the prompt's input data comes from).
+- (Optional) the upstream step's name.
+- (Optional) a sample of the typical input.
+
+Rewrite the prompt to be clearer, more specific, and more likely to produce reliable, well-formatted output. Preserve the user's original intent. Do not invent domain knowledge, output requirements, or constraints the user did not ask for.
+
+Common improvements:
+- Replace vague verbs ("look at", "process", "handle") with concrete instructions ("extract", "summarize into 3 bullets", "compare X and Y").
+- Specify an output format if the user implied one (bullet list, table, JSON, plain prose).
+- Acknowledge whether the input is multiple documents, a single document, or upstream step output — and refer to it correctly (don't say "this document" when the input is upstream text from a Formatter step).
+- Remove filler, ambiguous pronouns, and conversational scaffolding ("Hey, I was wondering if you could...").
+
+If the original prompt is already well-written, return it essentially unchanged with one rationale bullet saying so.
+
+Do NOT add boilerplate like "You are a helpful assistant" — the system prompt is handled separately. The user's prompt should describe the *task*, not the persona.
+"""
+
+
+def _format_input_source(input_source: str | None) -> str | None:
+    if not input_source:
+        return None
+    return {
+        "step_input": "the text output of the previous workflow step",
+        "select_document": "a specific document selected by the user",
+        "workflow_documents": "the document(s) the workflow is being run on (may be multiple)",
+    }.get(input_source, input_source)
+
+
+async def improve_prompt(
+    prompt: str,
+    input_source: str | None = None,
+    prev_step_name: str | None = None,
+    sample_input: str | None = None,
+) -> dict:
+    """Return a rewritten prompt and a list of rationale bullets."""
+    from app.services.config_service import get_default_model_name
+    from app.services.llm_service import get_agent_model
+
+    sys_cfg = await SystemConfig.get_config()
+    sys_config_doc = sys_cfg.model_dump() if sys_cfg else {}
+
+    default_model = await get_default_model_name() or "gpt-4o-mini"
+
+    parts = [f"Original prompt:\n```\n{prompt}\n```"]
+    readable_source = _format_input_source(input_source)
+    if readable_source:
+        parts.append(f"\nInput source: {readable_source}")
+    if prev_step_name and input_source == "step_input":
+        parts.append(f"Previous step name: {prev_step_name}")
+    if sample_input:
+        excerpt = sample_input[:1500]
+        parts.append(f"\nSample of typical input:\n```\n{excerpt}\n```")
+
+    model = get_agent_model(default_model, system_config_doc=sys_config_doc)
+    agent = Agent(model, system_prompt=_SYSTEM_PROMPT, output_type=PromptImprovement)
+
+    result = await agent.run("\n".join(parts))
+    return {
+        "improved_prompt": result.output.improved_prompt,
+        "rationale": result.output.rationale,
+    }

--- a/frontend/src/api/workflows.ts
+++ b/frontend/src/api/workflows.ts
@@ -48,7 +48,10 @@ export function deleteStep(stepId: string) {
 // Tasks
 
 export function addTask(stepId: string, data: { name: string; data?: Record<string, unknown> }) {
-  return apiFetch(`/api/workflows/steps/${stepId}/tasks`, { method: 'POST', body: JSON.stringify(data) })
+  return apiFetch<{ id: string; name: string; data: Record<string, unknown> }>(
+    `/api/workflows/steps/${stepId}/tasks`,
+    { method: 'POST', body: JSON.stringify(data) },
+  )
 }
 
 export function updateTask(taskId: string, data: { name?: string; data?: Record<string, unknown> }) {
@@ -60,6 +63,26 @@ export function updateTask(taskId: string, data: { name?: string; data?: Record<
 
 export function deleteTask(taskId: string) {
   return apiFetch<{ ok: boolean }>(`/api/workflows/tasks/${taskId}`, { method: 'DELETE' })
+}
+
+// Prompt improvement
+
+export interface PromptImprovement {
+  improved_prompt: string
+  rationale: string[]
+}
+
+export function improvePrompt(data: {
+  prompt: string
+  input_source?: string
+  prev_step_name?: string
+  sample_input?: string
+}) {
+  return apiFetch<PromptImprovement>('/api/workflows/improve-prompt', {
+    method: 'POST',
+    body: JSON.stringify(data),
+    timeoutMs: 90_000,
+  })
 }
 
 // Execution

--- a/frontend/src/components/workspace/WorkflowEditorPanel.tsx
+++ b/frontend/src/components/workspace/WorkflowEditorPanel.tsx
@@ -20,9 +20,10 @@ import {
   getValidationPlan, updateValidationPlan, generateValidationPlan,
   getValidationInputs, updateValidationInputs,
   exportWorkflowUrl, importWorkflow, getWorkflowHistory, duplicateWorkflow,
+  improvePrompt,
 } from '../../api/workflows'
 import { RunHistoryTab } from './RunHistoryTab'
-import type { ValidationCheck, ValidationCheckDefinition, ValidationInputDefinition, QualityHistoryRun, BatchStatus, WorkflowQualityStatus } from '../../api/workflows'
+import type { ValidationCheck, ValidationCheckDefinition, ValidationInputDefinition, QualityHistoryRun, BatchStatus, WorkflowQualityStatus, PromptImprovement } from '../../api/workflows'
 import { ItemPickerModal } from './ItemPickerModal'
 import { getModels } from '../../api/config'
 import { searchDocuments } from '../../api/documents'
@@ -279,9 +280,12 @@ export function WorkflowEditorPanel() {
       return
     }
     try {
-      await addTask(editingStepId, { name: taskType.name })
+      const created = await addTask(editingStepId, { name: taskType.name })
       setShowTaskPicker(false)
-      refresh()
+      await refresh()
+      if (created?.id) {
+        setEditingTask({ id: created.id, name: created.name, data: { ...(created.data || {}) } })
+      }
     } catch (err) {
       const msg = err instanceof Error ? err.message : 'Failed to add task'
       toast(msg, 'error')
@@ -1952,6 +1956,44 @@ function TaskEditModal({ task, selectedDocUuids, workflow, workflowId, onClose, 
     setTaskData(prev => ({ ...prev, [key]: value }))
   }
 
+  // Prompt improvement (Prompt task)
+  const [improving, setImproving] = useState(false)
+  const [improvement, setImprovement] = useState<PromptImprovement | null>(null)
+  const [improveError, setImproveError] = useState<string | null>(null)
+
+  const handleImprovePrompt = async () => {
+    const currentPrompt = getTextValue('prompt')
+    if (!currentPrompt.trim()) {
+      setImproveError('Write a prompt first.')
+      return
+    }
+    setImproving(true)
+    setImproveError(null)
+    setImprovement(null)
+    try {
+      const result = await improvePrompt({
+        prompt: currentPrompt,
+        input_source: inputSource,
+      })
+      setImprovement(result)
+    } catch (err) {
+      setImproveError(err instanceof Error ? err.message : 'Failed to generate suggestion')
+    } finally {
+      setImproving(false)
+    }
+  }
+
+  const acceptImprovement = () => {
+    if (improvement) setTextValue('prompt', improvement.improved_prompt)
+    setImprovement(null)
+    setImproveError(null)
+  }
+
+  const rejectImprovement = () => {
+    setImprovement(null)
+    setImproveError(null)
+  }
+
   const handleSelectSavedSet = (id: string, name: string) => {
     setTaskData(prev => ({ ...prev, search_set_uuid: id, name: name || prev.name }))
     setShowSetPicker(false)
@@ -2125,11 +2167,31 @@ function TaskEditModal({ task, selectedDocUuids, workflow, workflowId, onClose, 
                   />
                 </div>
                 <div>
-                  <label style={{
-                    display: 'block', fontSize: 13, fontWeight: 600, color: '#374151', marginBottom: 8,
-                  }}>
-                    Prompt
-                  </label>
+                  <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 8 }}>
+                    <label style={{ fontSize: 13, fontWeight: 600, color: '#374151' }}>
+                      Prompt
+                    </label>
+                    <button
+                      type="button"
+                      onClick={handleImprovePrompt}
+                      disabled={improving || !getTextValue('prompt').trim()}
+                      style={{
+                        display: 'inline-flex', alignItems: 'center', gap: 4,
+                        padding: '4px 10px', fontSize: 12, fontWeight: 500,
+                        border: '1px solid #d1d5db', borderRadius: 6,
+                        background: improving ? '#f3f4f6' : 'white',
+                        color: '#374151',
+                        cursor: improving || !getTextValue('prompt').trim() ? 'not-allowed' : 'pointer',
+                        opacity: !getTextValue('prompt').trim() ? 0.5 : 1,
+                      }}
+                      title="Have the LLM suggest an improved version of this prompt"
+                    >
+                      {improving
+                        ? <Loader2 size={12} style={{ animation: 'spin 1s linear infinite' }} />
+                        : <Sparkles size={12} />}
+                      {improving ? 'Thinking…' : 'Improve'}
+                    </button>
+                  </div>
                   <textarea
                     value={getTextValue('prompt')}
                     onChange={e => setTextValue('prompt', e.target.value)}
@@ -2142,6 +2204,81 @@ function TaskEditModal({ task, selectedDocUuids, workflow, workflowId, onClose, 
                       lineHeight: 1.5,
                     }}
                   />
+                  {improveError && (
+                    <div style={{
+                      marginTop: 8, padding: '8px 12px', background: '#fef2f2',
+                      border: '1px solid #fecaca', borderRadius: 6, fontSize: 12, color: '#991b1b',
+                    }}>
+                      {improveError}
+                    </div>
+                  )}
+                  {improvement && (
+                    <div style={{
+                      marginTop: 12, border: '1px solid #c7d2fe', background: '#eef2ff',
+                      borderRadius: 8, overflow: 'hidden',
+                    }}>
+                      <div style={{
+                        padding: '10px 12px', borderBottom: '1px solid #c7d2fe',
+                        display: 'flex', alignItems: 'center', gap: 6,
+                        fontSize: 12, fontWeight: 600, color: '#3730a3',
+                      }}>
+                        <Sparkles size={14} />
+                        Suggested rewrite
+                      </div>
+                      <div style={{ padding: 12, background: 'white' }}>
+                        <pre style={{
+                          margin: 0, padding: 10, background: '#f9fafb',
+                          border: '1px solid #e5e7eb', borderRadius: 6,
+                          fontFamily: 'inherit', fontSize: 13, lineHeight: 1.5,
+                          whiteSpace: 'pre-wrap', color: '#111827',
+                        }}>
+                          {improvement.improved_prompt}
+                        </pre>
+                        {improvement.rationale.length > 0 && (
+                          <div style={{ marginTop: 12 }}>
+                            <div style={{
+                              fontSize: 12, fontWeight: 600, color: '#374151', marginBottom: 6,
+                            }}>
+                              What changed
+                            </div>
+                            <ul style={{
+                              margin: 0, paddingLeft: 18, fontSize: 13, lineHeight: 1.5, color: '#374151',
+                            }}>
+                              {improvement.rationale.map((b, i) => (
+                                <li key={i} style={{ marginBottom: 4 }}>{b}</li>
+                              ))}
+                            </ul>
+                          </div>
+                        )}
+                        <div style={{
+                          display: 'flex', gap: 8, marginTop: 12, justifyContent: 'flex-end',
+                        }}>
+                          <button
+                            type="button"
+                            onClick={rejectImprovement}
+                            style={{
+                              padding: '6px 12px', fontSize: 13, fontWeight: 500,
+                              border: '1px solid #d1d5db', borderRadius: 6,
+                              background: 'white', color: '#374151', cursor: 'pointer',
+                            }}
+                          >
+                            Discard
+                          </button>
+                          <button
+                            type="button"
+                            onClick={acceptImprovement}
+                            style={{
+                              padding: '6px 12px', fontSize: 13, fontWeight: 500,
+                              border: '1px solid #4f46e5', borderRadius: 6,
+                              background: '#4f46e5', color: 'white', cursor: 'pointer',
+                            }}
+                          >
+                            Use this prompt
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  )}
                 </div>
               </div>
             )}


### PR DESCRIPTION
## Summary

- Adds an **Improve** button next to the Prompt task's textarea in the workflow editor. Click it and the LLM returns a rewritten prompt plus a short rationale; **Use this prompt** replaces the textarea contents in one click, **Discard** keeps the original.
- New endpoint `POST /api/workflows/improve-prompt` (auth-gated, 10/min rate limit). It takes the current prompt text plus the task's `input_source` and asks a pydantic-ai Agent for structured `{improved_prompt, rationale[]}` output.
- The improver is given the task's input source (`step_input` / `select_document` / `workflow_documents`) so it can flag context mismatches — e.g. when the prompt says "this document" but the input is actually upstream step text from a Formatter.

## Files

- `backend/app/services/prompt_improvement_service.py` — new service. Uses `get_agent_model()` directly so we can pass `output_type=PromptImprovement` for structured output (same pattern as `extraction_engine.py`).
- `backend/app/routers/workflows.py` — new endpoint `improve_prompt_endpoint`.
- `frontend/src/api/workflows.ts` — `improvePrompt()` client + `PromptImprovement` type, 90s timeout.
- `frontend/src/components/workspace/WorkflowEditorPanel.tsx` — Improve button, loading/error/result states, inline rewrite preview panel with rationale bullets and Accept/Discard buttons.

## Out of scope (easy follow-ups)

- Wiring the same improver up to `post_process_prompt`, `DescribeImage` prompt, and extraction system prompts (service is generic; only UI hookup needed).
- Pulling a real `sample_input` from the latest `WorkflowResult` (endpoint already accepts it; just needs the frontend to fetch).
- Per-bullet accept / inline diff highlighting.

## Test plan

- [ ] Open a workflow, edit a Prompt task, click **Improve** with an empty prompt → button is disabled.
- [ ] With a vague prompt (e.g. "look at this and tell me stuff") → rewrite returned, rationale bullets shown, **Use this prompt** replaces the textarea, **Discard** clears the panel.
- [ ] Set input source to `step_input` from a non-document upstream step → rationale should call out document/step mismatches if any.
- [ ] Set input source to `workflow_documents` with multiple docs → rewrite should acknowledge multi-document input.
- [ ] Spam the button >10x/min → 429 returned.
- [ ] Logged-out user → 401 returned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)