### PR TITLE
Fix library 'last used' timezone and warn about unprocessed chat docs

### DIFF
--- a/backend/app/services/chat_service.py
+++ b/backend/app/services/chat_service.py
@@ -219,21 +219,42 @@ async def chat_stream(
     # Document segments — one entry per SmartDocument so each can be trimmed
     # independently by the budget planner.
     doc_segments: list[DocumentSegment] = []
+    skipped_no_text: list[str] = []
     for doc in documents:
         if doc.raw_text:
             doc_segments.append(DocumentSegment(
                 label=f"doc:{doc.title or doc.uuid}",
                 text=f"\n\n## Document: {doc.title}\n{doc.raw_text}",
             ))
+        else:
+            skipped_no_text.append(doc.title or doc.uuid)
+
+    # Warn the caller about any selected document that the model won't see
+    # because text extraction hasn't finished (or produced no text).
+    missing_uuids = [u for u in document_uuids if u not in {d.uuid for d in documents}]
+    if skipped_no_text or missing_uuids:
+        names = list(skipped_no_text) + missing_uuids
+        joined = ", ".join(names[:5]) + ("…" if len(names) > 5 else "")
+        yield json.dumps({
+            "kind": "context_notice",
+            "content": (
+                f"{len(names)} selected document(s) had no extracted text yet "
+                f"and were not sent to the model: {joined}. "
+                "Wait for processing to finish, then re-send."
+            ),
+            "action": "documents_not_ready",
+            "tokens_dropped": 0,
+        }) + "\n"
 
     total_text_len = sum(len(s.text) for s in doc_segments)
     if document_uuids:
         logger.info(
-            "Chat doc context: requested=%d found=%d with_text=%d text_len=%d",
+            "Chat doc context: requested=%d found=%d with_text=%d text_len=%d skipped_no_text=%d",
             len(document_uuids),
             len(documents),
             sum(1 for d in documents if d.raw_text),
             total_text_len,
+            len(skipped_no_text),
         )
 
     # KB context: query ChromaDB for relevant chunks and add as a segment.

--- a/backend/app/services/library_service.py
+++ b/backend/app/services/library_service.py
@@ -596,6 +596,21 @@ async def search_libraries(
 # ---------------------------------------------------------------------------
 
 
+def _iso_utc(dt: datetime.datetime | None) -> str | None:
+    """Serialize a datetime as ISO-8601 with an explicit UTC offset.
+
+    MongoDB stores datetimes as UTC milliseconds with no timezone metadata,
+    so Beanie returns naive datetimes by default.  ``naive.isoformat()`` then
+    produces a string with no timezone suffix, which JavaScript's ``Date``
+    parser interprets as local time and shifts by the user's UTC offset.
+    """
+    if dt is None:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=datetime.timezone.utc)
+    return dt.isoformat()
+
+
 def _item_created_at(item: LibraryItem) -> str | None:
     """Return a reliable ISO creation timestamp for a library item.
 
@@ -610,7 +625,7 @@ def _item_created_at(item: LibraryItem) -> str | None:
             return BsonObjectId(str(item.id)).generation_time.isoformat()
         except Exception:
             pass
-    return item.created_at.isoformat() if item.created_at else None
+    return _iso_utc(item.created_at)
 
 
 async def _dereference_item(item: LibraryItem) -> dict | None:
@@ -652,7 +667,7 @@ async def _dereference_item(item: LibraryItem) -> dict | None:
         "verified": item.verified,
         "added_by_user_id": item.added_by_user_id,
         "created_at": _item_created_at(item),
-        "last_used_at": item.last_used_at.isoformat() if item.last_used_at else None,
+        "last_used_at": _iso_utc(item.last_used_at),
     }
 
 

--- a/frontend/src/components/library/LibraryItemRow.tsx
+++ b/frontend/src/components/library/LibraryItemRow.tsx
@@ -149,7 +149,7 @@ export function LibraryItemRow({ item, scope, onPin, onFavorite, onClone, onShar
 
       {/* Last used column */}
       <div style={{ fontSize: 12, color: '#9aa0a6', whiteSpace: 'nowrap' }}>
-        {item.last_used_at ? relativeTime(item.last_used_at) : item.created_at ? relativeTime(item.created_at) : 'Never'}
+        {item.last_used_at ? relativeTime(item.last_used_at) : 'Never'}
       </div>
 
       {/* Actions column */}


### PR DESCRIPTION
## Summary

Two unrelated polish fixes bundled together — both small.

**Library timestamps**: Beanie returns naive datetimes from MongoDB (which stores everything as UTC), so `dt.isoformat()` produced strings with no timezone suffix. JavaScript's `Date` parser then interpreted them as *local* time and shifted them by the user's UTC offset, making "Last used" times wrong by a few hours. New `_iso_utc()` helper attaches an explicit `+00:00` offset before serialization. Used for both `created_at` and `last_used_at` in the dereferenced item payload.

**Library row**: The Last Used column was falling back to `created_at` when `last_used_at` was missing. That was misleading — a never-opened item showed its creation time as if it had been used. Now shows `Never`, matching the column's meaning.

**Chat document warnings**: When a user selected documents that hadn't finished text extraction yet, the chat silently dropped them and answered with no document context. Now emits a `context_notice` event listing the affected documents and tells the user to wait and retry. Adds the skipped count to the existing chat-context log line.

## Files

- `backend/app/services/library_service.py` — `_iso_utc()` helper; applied to `_item_created_at()` and `last_used_at` in `_dereference_item()`.
- `frontend/src/components/library/LibraryItemRow.tsx` — drop the `created_at` fallback in the Last Used column.
- `backend/app/services/chat_service.py` — track `skipped_no_text` and `missing_uuids`, yield a `context_notice` event when either is non-empty.

## Test plan

- [ ] In a non-UTC timezone, open a library item and confirm Last Used shows the correct local time (was previously shifted).
- [ ] Open an item that has never been used → Last Used shows `Never` (was previously showing the creation time).
- [ ] Start a chat, select a document that's still processing (no `raw_text` yet), send a message → the UI receives a `context_notice` event naming the document and telling the user to retry. The model is not asked to answer about that document.
- [ ] Existing chat with fully-processed documents still works as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)