### PR TITLE
Surface why /extractions/run-integrated returns empty results

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ React Frontend  -->  FastAPI Backend  -->  MongoDB
 
 ## Documentation
 
+- [External API Reference](docs/api.md)
 - [Authorization Matrix](AUTHORIZATION_MATRIX.md)
 - [Deployment Guide](DEPLOY.md)
 - [Operations Guide](OPERATIONS.md)

--- a/backend/app/routers/extractions.py
+++ b/backend/app/routers/extractions.py
@@ -659,13 +659,28 @@ async def run_extraction_integrated(
     for upload in files:
         if not upload.filename:
             continue
+        file_data = await upload.read()
+        # Reject zero-byte uploads. The most common cause is a curl invocation
+        # like `-F "files=@document.pdf"` run from a directory that doesn't
+        # contain the file — curl prints a warning to stderr but still POSTs an
+        # empty part, and without this guard the request would silently produce
+        # an empty extraction result.
+        if not file_data:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"Uploaded file '{upload.filename}' is empty. "
+                    "If you used curl with -F files=@<path>, check that the path "
+                    "is correct relative to your current working directory "
+                    "(consider using an absolute path)."
+                ),
+            )
         uid = _uuid.uuid4().hex.upper()
         ext = (upload.filename.rsplit(".", 1)[-1] if "." in upload.filename else "pdf").lower()
         relative_path = Path(user.user_id) / f"{uid}.{ext}"
         upload_dir = Path(settings.upload_dir) / user.user_id
         upload_dir.mkdir(parents=True, exist_ok=True)
         file_path = upload_dir / f"{uid}.{ext}"
-        file_data = await upload.read()
         file_path.write_bytes(file_data)
 
         doc = SmartDocument(
@@ -719,7 +734,32 @@ async def run_extraction_integrated(
         )
         await activity_service.activity_finish(activity.id, ActivityStatus.COMPLETED)
         await activity_service.activity_update(activity.id, documents_touched=len(all_doc_uuids))
-        return {"status": "completed", "activity_id": str(activity.id), "results": results}
+
+        # Per-document diagnostics. Empty results when uploading a file are
+        # almost always one of: still-processing (extraction worker behind),
+        # task_status="error" (text extraction failed), or task_status="complete"
+        # with raw_text_len=0 (e.g. scanned PDF with no OCR available). Surfacing
+        # this in the response lets API callers tell those cases apart without
+        # having to dig into server logs.
+        doc_diagnostics = []
+        for doc_uuid in all_doc_uuids:
+            doc = await SmartDocument.find_one(SmartDocument.uuid == doc_uuid)
+            if doc:
+                doc_diagnostics.append({
+                    "uuid": doc.uuid,
+                    "title": doc.title,
+                    "task_status": getattr(doc, "task_status", None),
+                    "processing": doc.processing,
+                    "raw_text_len": len(doc.raw_text or ""),
+                    "error_message": getattr(doc, "error_message", None),
+                })
+
+        return {
+            "status": "completed",
+            "activity_id": str(activity.id),
+            "results": results,
+            "documents": doc_diagnostics,
+        }
     except Exception as e:
         await activity_service.activity_finish(activity.id, ActivityStatus.FAILED, error=str(e))
         raise

--- a/backend/app/services/search_set_service.py
+++ b/backend/app/services/search_set_service.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import uuid as uuid_mod
 from typing import TYPE_CHECKING
 
@@ -16,6 +17,8 @@ from app.services.extraction_engine import ExtractionEngine
 
 if TYPE_CHECKING:
     from app.models.user import User
+
+logger = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
@@ -378,6 +381,10 @@ async def run_extraction_sync(
     """Run extraction synchronously via asyncio.to_thread."""
     keys = await get_extraction_keys(search_set_uuid)
     if not keys:
+        logger.warning(
+            "Extraction skipped: search_set %s has no extraction keys",
+            search_set_uuid,
+        )
         return []
 
     # Wait for any documents still being processed (e.g. file uploads where
@@ -394,6 +401,17 @@ async def run_extraction_sync(
             break
         await _asyncio.sleep(_PROCESSING_POLL_INTERVAL)
         _waited += _PROCESSING_POLL_INTERVAL
+    else:
+        still_processing = await SmartDocument.find(
+            {"uuid": {"$in": document_uuids}, "processing": True},
+        ).count()
+        if still_processing:
+            logger.warning(
+                "Extraction proceeding after %ds with %d/%d docs still processing "
+                "for search_set %s — results will likely be empty for those docs",
+                _PROCESSING_TIMEOUT, still_processing, len(document_uuids),
+                search_set_uuid,
+            )
 
     # Pre-load document texts and file paths
     import os
@@ -402,6 +420,7 @@ async def run_extraction_sync(
 
     doc_texts: list[str] = []
     doc_file_paths: list[str] = []
+    empty_text_docs: list[str] = []
     for doc_uuid in document_uuids:
         doc = await SmartDocument.find_one(SmartDocument.uuid == doc_uuid)
         if doc and doc.raw_text:
@@ -409,10 +428,21 @@ async def run_extraction_sync(
         else:
             # Placeholder to keep indices aligned with doc_file_paths
             doc_texts.append("")
+            if doc:
+                empty_text_docs.append(
+                    f"{doc_uuid}(status={getattr(doc, 'task_status', None)!r})"
+                )
         if doc and doc.path:
             doc_file_paths.append(os.path.join(upload_dir, doc.path))
         else:
             doc_file_paths.append("")
+
+    if empty_text_docs:
+        logger.warning(
+            "Extraction has %d/%d docs with empty raw_text for search_set %s: %s",
+            len(empty_text_docs), len(document_uuids), search_set_uuid,
+            ", ".join(empty_text_docs),
+        )
 
     if not any(doc_texts) and not any(doc_file_paths):
         return []

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,158 @@
+# Vandalizer External API
+
+For integrating Vandalizer extractions and automations into other tools. Authenticated with an API key (no session cookie or CSRF needed).
+
+## Authentication
+
+Generate an API key from **My Account → API Tokens** in the Vandalizer UI. Pass it in the `x-api-key` header on every request:
+
+```
+x-api-key: YOUR_API_KEY
+```
+
+The key inherits the permissions of the user that created it. Treat it like a password.
+
+## Base URL
+
+Whatever host serves the Vandalizer UI for your deployment, e.g. `https://vandalizer.example.edu`. All endpoints below are rooted at `/api`.
+
+---
+
+## `POST /api/extractions/run-integrated`
+
+Run an extraction against a search set. Accepts files, existing document UUIDs, raw text, or any combination. Runs synchronously and returns results in the response. Rate-limited to 10 requests/minute per user.
+
+### Request
+
+`multipart/form-data` with these fields:
+
+| Field             | Required | Description |
+|-------------------|----------|-------------|
+| `search_set_uuid` | yes      | UUID of the search set to run. |
+| `files`           | one of   | One or more file uploads. |
+| `document_uuids`  | one of   | Comma-separated UUIDs of documents already in Vandalizer. |
+| `text`            | one of   | Raw text to extract from. |
+| `text_title`      | no       | Optional title for the `text` payload (defaults to `"API text input"`). |
+
+At least one of `files`, `document_uuids`, or `text` must be provided.
+
+### Response
+
+```json
+{
+  "status": "completed",
+  "activity_id": "...",
+  "results": [
+    { "field_name": "extracted value", "...": "..." }
+  ],
+  "documents": [
+    {
+      "uuid": "...",
+      "title": "document.pdf",
+      "task_status": "complete",
+      "processing": false,
+      "raw_text_len": 12345,
+      "error_message": null
+    }
+  ]
+}
+```
+
+`results` is the flat list of extracted entities. `documents` is a per-document diagnostic block — see the troubleshooting section below for how to read it.
+
+### Examples
+
+#### curl — file upload
+
+```bash
+curl -X POST "https://vandalizer.example.edu/api/extractions/run-integrated" \
+  -H "x-api-key: YOUR_API_KEY" \
+  -F "search_set_uuid=YOUR_SEARCH_SET_UUID" \
+  -F "files=@/absolute/path/to/document.pdf"
+```
+
+> **Use an absolute path.** With `-F "files=@document.pdf"` (bare filename), curl resolves the path against your current working directory. If the file isn't there, curl prints a warning to stderr but still POSTs an empty body. The server will reject empty uploads with a 400, but you'll save yourself the round trip by using an absolute path.
+
+#### curl — raw text
+
+```bash
+curl -X POST "https://vandalizer.example.edu/api/extractions/run-integrated" \
+  -H "x-api-key: YOUR_API_KEY" \
+  -F "search_set_uuid=YOUR_SEARCH_SET_UUID" \
+  -F "text=Paste the document text here." \
+  -F "text_title=Invoice 1234"
+```
+
+#### curl — existing documents
+
+```bash
+curl -X POST "https://vandalizer.example.edu/api/extractions/run-integrated" \
+  -H "x-api-key: YOUR_API_KEY" \
+  -F "search_set_uuid=YOUR_SEARCH_SET_UUID" \
+  -F "document_uuids=UUID1,UUID2"
+```
+
+#### Python — file upload
+
+```python
+import requests
+
+with open("/absolute/path/to/document.pdf", "rb") as f:
+    response = requests.post(
+        "https://vandalizer.example.edu/api/extractions/run-integrated",
+        headers={"x-api-key": "YOUR_API_KEY"},
+        data={"search_set_uuid": "YOUR_SEARCH_SET_UUID"},
+        files=[("files", ("document.pdf", f, "application/pdf"))],
+    )
+print(response.json())
+```
+
+---
+
+## `GET /api/extractions/status/{activity_id}`
+
+Look up the status of a previous extraction run. Useful if the original request timed out client-side or if you want a summary later.
+
+```bash
+curl "https://vandalizer.example.edu/api/extractions/status/ACTIVITY_ID" \
+  -H "x-api-key: YOUR_API_KEY"
+```
+
+Returns `status`, `started_at`, `finished_at`, `error`, `documents_touched`, and `result_snapshot`.
+
+---
+
+## Troubleshooting
+
+### `results` is `[]`
+
+Check the `documents` array. The combination of fields tells you why:
+
+| `task_status`   | `processing` | `raw_text_len` | What happened |
+|-----------------|--------------|----------------|---------------|
+| `"complete"`    | `false`      | `> 0`          | Text extracted fine; the LLM just didn't find any of your search keys. Verify the search set fields against the document content. |
+| `"complete"`    | `false`      | `0`            | Text extraction returned empty. Common for scanned PDFs when the OCR service is unavailable. Try a digital PDF or contact your admin to verify OCR is configured. |
+| `"error"`       | `false`      | `0`            | Text extraction failed. See `error_message`. Re-upload may help for transient errors. |
+| `"extracting"`  | `true`       | `0`            | The text-extraction worker didn't finish within the 90-second timeout. Retry the request — by then the document will likely be cached. |
+| `null` / other  | varies       | varies         | Unusual state; report to your admin with the `activity_id`. |
+
+### HTTP 400 — "Uploaded file 'X' is empty"
+
+Your client sent the file part with zero bytes. The most common cause is curl resolving `-F files=@<filename>` against the wrong working directory. Use an absolute path.
+
+### HTTP 404 — "SearchSet not found"
+
+Either the UUID is wrong, or your API key's user doesn't have access to that search set (e.g. it belongs to another team). Verify in the UI.
+
+### HTTP 429 — rate limit
+
+The endpoint is rate-limited to 10 requests/minute per user. Back off and retry.
+
+---
+
+## Other endpoints
+
+- **`POST /api/automations/{id}/trigger`** — Fire a configured automation. See the Automations editor in the UI for trigger-specific input formats.
+- **`GET /api/automations/runs/{trigger_event_id}`** — Poll an automation run for completion.
+
+The Extraction editor in the UI has copy-paste-ready snippets for the search set you have open — use those when you're integrating against a specific search set.

--- a/frontend/src/components/workspace/ExtractionEditorPanel.tsx
+++ b/frontend/src/components/workspace/ExtractionEditorPanel.tsx
@@ -1727,10 +1727,14 @@ response = requests.post(
 )
 print(response.json())`
 
-  const curlFileSnippet = `curl -X POST "${endpoint}" \\
+  const curlFileSnippet = `# Use an absolute path for the file. With a bare filename, curl resolves
+# the path against your current working directory — if the file isn't there
+# curl prints a warning to stderr but still POSTs an empty body, which the
+# server will reject as a 400.
+curl -X POST "${endpoint}" \\
   -H "x-api-key: YOUR_API_KEY" \\
   -F "search_set_uuid=${searchSetUuid}" \\
-  -F "files=@document.pdf"`
+  -F "files=@/absolute/path/to/document.pdf"`
 
   const curlDocUuidSnippet = `curl -X POST "${endpoint}" \\
   -H "x-api-key: YOUR_API_KEY" \\
@@ -1771,6 +1775,16 @@ print(response.json())`
   "activity_id": "...",
   "results": [
     { "field_name": "extracted value", ... }
+  ],
+  "documents": [
+    {
+      "uuid": "...",
+      "title": "document.pdf",
+      "task_status": "complete",  // or "extracting" / "error"
+      "processing": false,
+      "raw_text_len": 12345,       // 0 means no text was extracted
+      "error_message": null
+    }
   ]
 }`
 
@@ -1881,6 +1895,15 @@ print(response.json())`
         <code>text</code> (optional, raw text to extract from) with an optional{' '}
         <code>text_title</code>. At least one of <code>files</code>, <code>document_uuids</code>, or{' '}
         <code>text</code> must be provided.
+      </div>
+
+      <div style={{ fontSize: 11, color: '#9ca3af', lineHeight: 1.6, marginTop: 8 }}>
+        <strong style={{ color: '#6b7280' }}>Empty <code>results</code>?</strong>{' '}
+        Check the <code>documents</code> array in the response. <code>raw_text_len: 0</code>{' '}
+        with <code>task_status: "complete"</code> usually means a scanned PDF where the OCR
+        service couldn't extract text. <code>task_status: "error"</code> means text extraction
+        failed — see <code>error_message</code>. <code>processing: true</code> means the
+        worker didn't finish in time; retry the request or increase the timeout.
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary

The external extraction API was reported as "returning empty results" by Nathan Layman. Tracing the code, `POST /api/extractions/run-integrated` has **at least four distinct failure modes** that all collapse to the same `{"status":"completed","results":[]}` response — making it impossible for an API caller to diagnose what went wrong without server-side log access.

The most likely cause for the specific report: Nathan ran `curl ... -F "files=@DE-FOA-...pdf"` from a directory that didn't contain the file. curl prints a stderr warning but still POSTs the form with an **empty body**, which the server happily accepts, "extracts" empty text from, and returns `[]`.

Other paths that look identical to the caller:
- Scanned PDF where the OCR endpoint isn't configured/decryptable in the Celery worker (so `raw_text` ends up empty even though `task_status="complete"`).
- Text extraction errors that route to `cleanup_document` and set `task_status="error"`.
- The 90-second processing-poll timeout firing because the `documents` queue is backed up.

### Fixes

**Server (the actual bug fix):**
- Reject zero-byte uploads with a 400 that names the curl footgun explicitly (`backend/app/routers/extractions.py`).
- Return a `documents` array on every run with `task_status`, `processing`, `raw_text_len`, and `error_message` per document — empty `results` is now diagnosable from the response alone.
- Add a `logger` to `search_set_service` and emit warnings for: search sets with no extraction keys, polling timing out with docs still processing, any docs ending up with empty `raw_text`. Operators get visibility from server logs without code changes.

**Docs (so the next person doesn't repeat this):**
- The in-app curl snippet in `ExtractionEditorPanel.tsx` now uses an absolute path with a comment explaining why; response example shows the new `documents` field; added a troubleshooting blurb for empty `results`.
- New standalone `docs/api.md` with full reference for `/extractions/run-integrated` and `/extractions/status/{id}`, including a troubleshooting table mapping the `task_status`/`processing`/`raw_text_len` combinations to root causes.
- Linked from `README.md` Documentation section.

The Python snippet was left alone — `open(...)` raises `FileNotFoundError` immediately, so it doesn't have curl's silent-empty-body problem.

## Test plan

- [ ] `make backend-static` passes (already verified locally — ruff clean on both edited files).
- [ ] Hit `/api/extractions/run-integrated` with `-F "files=@nonexistent.pdf"` from a directory missing the file — should now get HTTP 400 with the empty-file message instead of 200 + `[]`.
- [ ] Hit it with a valid PDF that has extraction keys — response should include a populated `documents` array showing `task_status: "complete"`, non-zero `raw_text_len`, alongside the usual `results`.
- [ ] Hit it with a known scanned PDF on a deployment without OCR configured — response should show `task_status: "complete"`, `raw_text_len: 0`, making the cause obvious.
- [ ] Confirm Nathan can run his original curl with an absolute path and gets non-empty results.
- [ ] Spot-check the new `docs/api.md` renders correctly on GitHub.
- [ ] Spot-check the in-app API tab on a search set page — new troubleshooting block reads cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)