### PR TITLE
Admin Certifications panel: user progress + debug unlock

### DIFF
--- a/backend/app/models/certification.py
+++ b/backend/app/models/certification.py
@@ -16,6 +16,7 @@ class CertificationProgress(Document):
     certified_at: Optional[datetime.datetime] = None
     streak_days: int = 0
     last_activity_date: Optional[str] = None  # YYYY-MM-DD for streak tracking
+    unlocked: bool = False  # Admin debug flag — bypasses module prerequisite gating
     created_at: datetime.datetime = Field(default_factory=lambda: datetime.datetime.now(tz=datetime.timezone.utc))
     updated_at: datetime.datetime = Field(default_factory=lambda: datetime.datetime.now(tz=datetime.timezone.utc))
 

--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -2180,3 +2180,141 @@ async def email_analytics(
         recent_failures=recent_failures,
         providers=sorted(providers),
     )
+
+
+# ---------------------------------------------------------------------------
+# Certifications — admin view of user progress through Vandal Workflow Architect
+# ---------------------------------------------------------------------------
+
+
+class CertificationProgressItem(BaseModel):
+    user_id: str
+    name: Optional[str] = None
+    email: Optional[str] = None
+    level: str
+    total_xp: int
+    modules_completed: int
+    modules_total: int
+    certified: bool
+    certified_at: Optional[datetime.datetime] = None
+    streak_days: int
+    last_activity_date: Optional[str] = None
+    unlocked: bool = False
+    updated_at: Optional[datetime.datetime] = None
+
+
+class CertificationProgressDetail(CertificationProgressItem):
+    modules: dict
+
+
+@router.get("/certifications", response_model=list[CertificationProgressItem])
+async def list_certification_progress(user: User = Depends(get_current_user)):
+    """List all users who have started the certification program with progress summary."""
+    await _require_admin(user)
+
+    from app.models.certification import CertificationProgress
+    from app.services import certification_service as cert_svc
+
+    progresses = await CertificationProgress.find().to_list()
+    if not progresses:
+        return []
+
+    user_ids = [p.user_id for p in progresses]
+    users = await User.find({"user_id": {"$in": user_ids}}).to_list()
+    user_map = {u.user_id: u for u in users}
+
+    total_modules = len(cert_svc.MODULE_ORDER)
+    items: list[CertificationProgressItem] = []
+    for p in progresses:
+        u = user_map.get(p.user_id)
+        completed = sum(1 for m in p.modules.values() if isinstance(m, dict) and m.get("completed"))
+        items.append(
+            CertificationProgressItem(
+                user_id=p.user_id,
+                name=u.name if u else None,
+                email=u.email if u else None,
+                level=p.level,
+                total_xp=p.total_xp,
+                modules_completed=completed,
+                modules_total=total_modules,
+                certified=p.certified,
+                certified_at=p.certified_at,
+                streak_days=p.streak_days,
+                last_activity_date=p.last_activity_date,
+                unlocked=p.unlocked,
+                updated_at=p.updated_at,
+            )
+        )
+
+    items.sort(key=lambda i: (i.modules_completed, i.total_xp), reverse=True)
+    return items
+
+
+@router.get("/certifications/{user_id}", response_model=CertificationProgressDetail)
+async def get_certification_progress_detail(
+    user_id: str,
+    user: User = Depends(get_current_user),
+):
+    """Get a single user's full certification progress including per-module state."""
+    await _require_admin(user)
+
+    from app.models.certification import CertificationProgress
+    from app.services import certification_service as cert_svc
+
+    p = await CertificationProgress.find_one(CertificationProgress.user_id == user_id)
+    if not p:
+        raise HTTPException(status_code=404, detail="No certification progress for this user")
+
+    target = await User.find_one(User.user_id == user_id)
+    completed = sum(1 for m in p.modules.values() if isinstance(m, dict) and m.get("completed"))
+
+    return CertificationProgressDetail(
+        user_id=p.user_id,
+        name=target.name if target else None,
+        email=target.email if target else None,
+        level=p.level,
+        total_xp=p.total_xp,
+        modules_completed=completed,
+        modules_total=len(cert_svc.MODULE_ORDER),
+        certified=p.certified,
+        certified_at=p.certified_at,
+        streak_days=p.streak_days,
+        last_activity_date=p.last_activity_date,
+        unlocked=p.unlocked,
+        updated_at=p.updated_at,
+        modules=p.modules,
+    )
+
+
+class CertificationUnlockRequest(BaseModel):
+    unlocked: bool
+
+
+@router.put("/certifications/{user_id}/unlock")
+async def set_certification_unlock(
+    user_id: str,
+    payload: CertificationUnlockRequest,
+    user: User = Depends(get_current_user),
+):
+    """Debug toggle — when unlocked, the user can pick any module without prerequisites."""
+    await _require_admin(user)
+
+    from app.models.certification import CertificationProgress
+
+    prog = await CertificationProgress.find_one(CertificationProgress.user_id == user_id)
+    if not prog:
+        prog = CertificationProgress(user_id=user_id)
+        await prog.insert()
+
+    prog.unlocked = payload.unlocked
+    prog.updated_at = datetime.datetime.now(tz=datetime.timezone.utc)
+    await prog.save()
+
+    await _audit(
+        user,
+        "certification.unlock" if payload.unlocked else "certification.lock",
+        f"{'Unlocked' if payload.unlocked else 'Locked'} certification for user {user_id}",
+        {"user_id": user_id, "unlocked": payload.unlocked},
+    )
+
+    return {"user_id": user_id, "unlocked": prog.unlocked}

--- a/backend/app/services/certification_service.py
+++ b/backend/app/services/certification_service.py
@@ -115,6 +115,7 @@ async def get_progress_dict(user_id: str) -> dict:
         "certified_at": prog.certified_at.isoformat() if prog.certified_at else None,
         "streak_days": prog.streak_days,
         "last_activity_date": prog.last_activity_date,
+        "unlocked": prog.unlocked,
     }
 
 

--- a/frontend/src/api/admin.ts
+++ b/frontend/src/api/admin.ts
@@ -494,3 +494,46 @@ export interface EmailAnalyticsResponse {
 export function getEmailAnalytics(days: number = 30) {
   return apiFetch<EmailAnalyticsResponse>(`/api/admin/email-analytics?days=${days}`)
 }
+
+// Certifications
+
+export interface CertificationProgressItem {
+  user_id: string
+  name: string | null
+  email: string | null
+  level: string
+  total_xp: number
+  modules_completed: number
+  modules_total: number
+  certified: boolean
+  certified_at: string | null
+  streak_days: number
+  last_activity_date: string | null
+  unlocked: boolean
+  updated_at: string | null
+}
+
+export interface CertificationProgressDetail extends CertificationProgressItem {
+  modules: Record<string, {
+    completed?: boolean
+    stars?: number
+    completed_at?: string | null
+    attempts?: number
+    xp_earned?: number
+  }>
+}
+
+export function getCertificationProgressList() {
+  return apiFetch<CertificationProgressItem[]>('/api/admin/certifications')
+}
+
+export function getCertificationProgressDetail(userId: string) {
+  return apiFetch<CertificationProgressDetail>(`/api/admin/certifications/${userId}`)
+}
+
+export function setCertificationUnlock(userId: string, unlocked: boolean) {
+  return apiFetch<{ user_id: string; unlocked: boolean }>(
+    `/api/admin/certifications/${userId}/unlock`,
+    { method: 'PUT', body: JSON.stringify({ unlocked }) },
+  )
+}

--- a/frontend/src/pages/Admin.tsx
+++ b/frontend/src/pages/Admin.tsx
@@ -6,7 +6,7 @@ import {
   CheckCircle2, XCircle, Clock, Download, TrendingUp, TrendingDown,
   ChevronDown, ChevronUp, ArrowUpDown, Play, Minus, AlertCircle,
   ArrowLeft, FileText, FolderTree, X, Eye, Check, CheckCircle,
-  Mail, Send, Link, UserPlus, Star, Award, Lock, Unlock,
+  Mail, Send, Link, UserPlus, Star, Award, Unlock,
 } from 'lucide-react'
 import {
   AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer,

--- a/frontend/src/pages/Admin.tsx
+++ b/frontend/src/pages/Admin.tsx
@@ -6,7 +6,7 @@ import {
   CheckCircle2, XCircle, Clock, Download, TrendingUp, TrendingDown,
   ChevronDown, ChevronUp, ArrowUpDown, Play, Minus, AlertCircle,
   ArrowLeft, FileText, FolderTree, X, Eye, Check, CheckCircle,
-  Mail, Send, Link, UserPlus, Star,
+  Mail, Send, Link, UserPlus, Star, Award, Lock, Unlock,
 } from 'lucide-react'
 import {
   AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer,
@@ -29,6 +29,7 @@ import {
   adminListAllTeams, adminCreateTeam, adminAddUserToTeam, adminRemoveUserFromTeam, getIsolatedUsers,
   updateUserRoles,
   getEmailAnalytics,
+  getCertificationProgressList, setCertificationUnlock,
 } from '../api/admin'
 import { getTeamMembers } from '../api/teams'
 import * as orgApi from '../api/organizations'
@@ -53,6 +54,7 @@ import type {
   QualityAlert, QualityItem, QualityItemDetail,
   AdminTeamItem, IsolatedUserItem,
   EmailAnalyticsResponse,
+  CertificationProgressItem,
 } from '../api/admin'
 import { relativeTime } from '../utils/time'
 import { ModelCharacterBars } from '../components/ModelEffortPicker'
@@ -70,7 +72,7 @@ function applyThemeToDOM(theme: ThemeConfig) {
   root.style.setProperty('--ui-radius', theme.ui_radius)
 }
 
-type Tab = 'usage' | 'users' | 'teams' | 'organizations' | 'workflows' | 'quality' | 'approvals' | 'support' | 'audit' | 'demo' | 'email' | 'debugging' | 'config'
+type Tab = 'usage' | 'users' | 'teams' | 'organizations' | 'workflows' | 'quality' | 'approvals' | 'support' | 'audit' | 'demo' | 'email' | 'certifications' | 'debugging' | 'config'
 
 const TABS: { key: Tab; label: string; icon: typeof BarChart3 }[] = [
   { key: 'usage', label: 'Usage', icon: BarChart3 },
@@ -84,6 +86,7 @@ const TABS: { key: Tab; label: string; icon: typeof BarChart3 }[] = [
   { key: 'audit', label: 'Audit Log', icon: FileText },
   { key: 'demo', label: 'Demo', icon: Zap },
   { key: 'email', label: 'Email', icon: Mail },
+  { key: 'certifications', label: 'Certifications', icon: Award },
   { key: 'debugging', label: 'Debugging', icon: Bug },
   { key: 'config', label: 'Config', icon: Settings },
 ]
@@ -5634,6 +5637,193 @@ function AuditTab() {
   )
 }
 
+// ──────────────────────────────────────────
+// Certifications Tab — track user progress through Vandal Workflow Architect
+// ──────────────────────────────────────────
+
+function CertificationsTab() {
+  const [items, setItems] = useState<CertificationProgressItem[]>([])
+  const [loading, setLoading] = useState(true)
+  const [search, setSearch] = useState('')
+  const [busyUser, setBusyUser] = useState<string | null>(null)
+
+  const refresh = useCallback(async () => {
+    setLoading(true)
+    try {
+      const data = await getCertificationProgressList()
+      setItems(data)
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => { refresh() }, [refresh])
+
+  const filtered = useMemo(() => {
+    if (!search.trim()) return items
+    const q = search.toLowerCase()
+    return items.filter(p =>
+      (p.name || '').toLowerCase().includes(q) ||
+      (p.email || '').toLowerCase().includes(q) ||
+      (p.user_id || '').toLowerCase().includes(q)
+    )
+  }, [items, search])
+
+  const toggleUnlock = async (item: CertificationProgressItem) => {
+    setBusyUser(item.user_id)
+    try {
+      await setCertificationUnlock(item.user_id, !item.unlocked)
+      setItems(prev => prev.map(p =>
+        p.user_id === item.user_id ? { ...p, unlocked: !item.unlocked } : p
+      ))
+    } finally {
+      setBusyUser(null)
+    }
+  }
+
+  const handleExport = () => {
+    downloadCSV('certifications.csv',
+      ['User', 'Email', 'Level', 'Total XP', 'Modules Completed', 'Modules Total', 'Certified', 'Certified At', 'Streak', 'Last Activity', 'Unlocked'],
+      filtered.map(p => [
+        p.name || p.user_id, p.email,
+        p.level, p.total_xp,
+        p.modules_completed, p.modules_total,
+        p.certified ? 'yes' : 'no',
+        p.certified_at,
+        p.streak_days,
+        p.last_activity_date,
+        p.unlocked ? 'yes' : 'no',
+      ])
+    )
+  }
+
+  if (loading) return <div style={{ padding: 40, textAlign: 'center', color: '#6b7280' }}>Loading certification progress...</div>
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+      <div>
+        <h2 style={{ fontSize: 20, fontWeight: 700, margin: 0 }}>Certifications</h2>
+        <p style={{ fontSize: 13, color: '#6b7280', marginTop: 4 }}>
+          Users who have started the Vandal Workflow Architect certification and where they are in the program.
+        </p>
+      </div>
+
+      <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+        <SearchInput value={search} onChange={setSearch} placeholder="Search users..." />
+        <div style={{ flex: 1 }} />
+        <button
+          onClick={refresh}
+          style={{ display: 'flex', alignItems: 'center', gap: 6, padding: '6px 12px', border: '1px solid #d1d5db', borderRadius: 6, background: '#fff', fontSize: 13, cursor: 'pointer', fontFamily: 'inherit' }}
+        >
+          <RefreshCw size={14} /> Refresh
+        </button>
+        <ExportButton onClick={handleExport} />
+      </div>
+
+      <div style={{ background: '#fff', border: '1px solid #e5e7eb', borderRadius: 'var(--ui-radius, 12px)', overflow: 'hidden' }}>
+        <div style={{ padding: '16px 20px', borderBottom: '1px solid #e5e7eb', fontSize: 15, fontWeight: 600 }}>
+          Certification Progress ({filtered.length})
+        </div>
+        {filtered.length === 0 ? (
+          <div style={{ padding: 40, textAlign: 'center', color: '#6b7280' }}>No users have started the certification yet.</div>
+        ) : (
+          <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+            <thead>
+              <tr style={{ background: '#f9fafb', borderBottom: '1px solid #e5e7eb' }}>
+                <th style={{ padding: '10px 16px', textAlign: 'left', fontSize: 11, fontWeight: 600, color: '#6b7280', textTransform: 'uppercase' }}>User</th>
+                <th style={{ padding: '10px 16px', textAlign: 'left', fontSize: 11, fontWeight: 600, color: '#6b7280', textTransform: 'uppercase' }}>Level</th>
+                <th style={{ padding: '10px 16px', textAlign: 'right', fontSize: 11, fontWeight: 600, color: '#6b7280', textTransform: 'uppercase' }}>XP</th>
+                <th style={{ padding: '10px 16px', textAlign: 'left', fontSize: 11, fontWeight: 600, color: '#6b7280', textTransform: 'uppercase' }}>Modules</th>
+                <th style={{ padding: '10px 16px', textAlign: 'center', fontSize: 11, fontWeight: 600, color: '#6b7280', textTransform: 'uppercase' }}>Certified</th>
+                <th style={{ padding: '10px 16px', textAlign: 'right', fontSize: 11, fontWeight: 600, color: '#6b7280', textTransform: 'uppercase' }}>Last Active</th>
+                <th style={{ padding: '10px 16px', textAlign: 'right', fontSize: 11, fontWeight: 600, color: '#6b7280', textTransform: 'uppercase' }}>Debug Unlock</th>
+              </tr>
+            </thead>
+            <tbody>
+              {filtered.map(p => {
+                const pct = p.modules_total > 0 ? (p.modules_completed / p.modules_total) * 100 : 0
+                return (
+                  <tr key={p.user_id} style={{ borderBottom: '1px solid #f3f4f6' }}>
+                    <td style={{ padding: '12px 16px' }}>
+                      <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+                        <UserAvatar name={p.name || p.email} />
+                        <div>
+                          <div style={{ fontSize: 14, fontWeight: 500 }}>{p.name || 'Unknown'}</div>
+                          <div style={{ fontSize: 12, color: '#6b7280' }}>{p.email || p.user_id}</div>
+                        </div>
+                      </div>
+                    </td>
+                    <td style={{ padding: '12px 16px' }}>
+                      <span style={{
+                        display: 'inline-block', padding: '2px 10px', borderRadius: 9999,
+                        fontSize: 11, fontWeight: 700, backgroundColor: '#eef2ff', color: '#4338ca',
+                        textTransform: 'uppercase', letterSpacing: 0.5,
+                      }}>
+                        {p.level}
+                      </span>
+                    </td>
+                    <td style={{ padding: '12px 16px', textAlign: 'right', fontSize: 14, fontFamily: 'ui-monospace, monospace' }}>{formatNumber(p.total_xp)}</td>
+                    <td style={{ padding: '12px 16px', minWidth: 200 }}>
+                      <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+                        <div style={{ flex: 1, height: 6, backgroundColor: '#f3f4f6', borderRadius: 3, overflow: 'hidden' }}>
+                          <div style={{ width: `${pct}%`, height: '100%', backgroundColor: 'var(--highlight-color, #eab308)', borderRadius: 3 }} />
+                        </div>
+                        <span style={{ fontSize: 12, color: '#6b7280', fontFamily: 'ui-monospace, monospace', minWidth: 48, textAlign: 'right' }}>
+                          {p.modules_completed}/{p.modules_total}
+                        </span>
+                      </div>
+                    </td>
+                    <td style={{ padding: '12px 16px', textAlign: 'center' }}>
+                      {p.certified ? (
+                        <span title={p.certified_at ? `Certified ${formatDate(p.certified_at)}` : 'Certified'} style={{ display: 'inline-flex', alignItems: 'center', gap: 4, color: '#16a34a', fontSize: 13, fontWeight: 600 }}>
+                          <Award size={14} /> Yes
+                        </span>
+                      ) : (
+                        <span style={{ color: '#9ca3af', fontSize: 13 }}>—</span>
+                      )}
+                    </td>
+                    <td style={{ padding: '12px 16px', textAlign: 'right', fontSize: 13, color: '#6b7280' }}>
+                      {p.last_activity_date || formatDate(p.updated_at)}
+                    </td>
+                    <td style={{ padding: '12px 16px', textAlign: 'right' }}>
+                      <button
+                        onClick={() => toggleUnlock(p)}
+                        disabled={busyUser === p.user_id}
+                        title={p.unlocked
+                          ? 'Re-lock prerequisites for this user'
+                          : 'Unlock all units so this user can select any module without prerequisites'}
+                        style={{
+                          display: 'inline-flex', alignItems: 'center', gap: 6,
+                          padding: '5px 10px', border: '1px solid',
+                          borderColor: p.unlocked ? '#16a34a' : '#d1d5db',
+                          borderRadius: 6, fontSize: 12, fontWeight: 500,
+                          background: p.unlocked ? '#dcfce7' : '#fff',
+                          color: p.unlocked ? '#166534' : '#374151',
+                          cursor: busyUser === p.user_id ? 'wait' : 'pointer',
+                          opacity: busyUser === p.user_id ? 0.6 : 1,
+                          fontFamily: 'inherit',
+                        }}
+                      >
+                        {p.unlocked ? <><Unlock size={12} /> Unlocked</> : <><Lock size={12} /> Unlock</>}
+                      </button>
+                    </td>
+                  </tr>
+                )
+              })}
+            </tbody>
+          </table>
+        )}
+      </div>
+
+      <div style={{ fontSize: 12, color: '#6b7280', padding: '8px 4px' }}>
+        <strong>Note:</strong> The unlock toggle is a debugging aid. It lets a user select any unit
+        in the certification program without completing the prerequisites — it does not mark
+        modules as completed or grant XP.
+      </div>
+    </div>
+  )
+}
+
 export default function Admin() {
   const { user } = useAuth()
   const { currentTeam } = useTeams()
@@ -5651,7 +5841,7 @@ export default function Admin() {
   const hasAccess = isGlobalAdmin || isStaff || isExaminer || isTeamAdmin
 
   // Staff see everything except config; examiners see analytics tabs only
-  const hiddenForNonAdmin = ['config', 'quality', 'demo', 'debugging', 'organizations', 'approvals', 'support', 'audit']
+  const hiddenForNonAdmin = ['config', 'quality', 'demo', 'debugging', 'organizations', 'approvals', 'support', 'audit', 'certifications']
   let visibleTabs = isGlobalAdmin
     ? TABS
     : isStaff
@@ -5735,6 +5925,7 @@ export default function Admin() {
           {activeTab === 'audit' && (isGlobalAdmin || isStaff) && <AuditTab />}
           {activeTab === 'demo' && (isGlobalAdmin || isStaff) && <DemoTab />}
           {activeTab === 'email' && (isGlobalAdmin || isStaff) && <EmailAnalyticsTab />}
+          {activeTab === 'certifications' && (isGlobalAdmin || isStaff) && <CertificationsTab />}
           {activeTab === 'debugging' && (isGlobalAdmin || isStaff) && <DebuggingTab />}
           {activeTab === 'config' && isGlobalAdmin && <ConfigTab />}
         </div>

--- a/frontend/src/pages/Certification.tsx
+++ b/frontend/src/pages/Certification.tsx
@@ -970,6 +970,7 @@ export default function Certification() {
     const module = MODULES.find(m => m.id === moduleId)
     if (!module) return true
     if (module.number === 0) return false // Module 0 always unlocked
+    if (progress?.unlocked) return false // Admin debug unlock — bypass prerequisites
     const prevModule = MODULES.find(m => m.number === module.number - 1)
     if (!prevModule) return false
     return !progress?.modules[prevModule.id]?.completed

--- a/frontend/src/types/certification.ts
+++ b/frontend/src/types/certification.ts
@@ -27,6 +27,7 @@ export interface CertificationProgress {
   certified_at: string | null
   streak_days: number
   last_activity_date: string | null
+  unlocked?: boolean
 }
 
 export interface ValidationCheck {


### PR DESCRIPTION
## Summary
- New **Certifications** tab in the Admin panel (admin/staff only) that lists every user enrolled in the Vandal Workflow Architect certification with their level, total XP, module-completion progress bar, certified status, and last activity.
- Per-user **debug Unlock** toggle that lets the user pick any module in the program without prerequisites being met. It does **not** mark modules complete or grant XP — it only bypasses the lock gate in the cert UI.
- Backend: added `unlocked` flag on `CertificationProgress`, three new admin endpoints (`GET /api/admin/certifications`, `GET /api/admin/certifications/{user_id}`, `PUT /api/admin/certifications/{user_id}/unlock`), and audit logging on the unlock action.
- Frontend: `isModuleLocked` in `pages/Certification.tsx` honors `progress.unlocked` to bypass prerequisite gating for unlocked users.

## Test plan
- [ ] Open Admin → Certifications as an admin and verify enrolled users render with correct level/XP/module counts.
- [ ] Verify the tab is hidden for team admins / examiners and visible for staff.
- [ ] Toggle Unlock for a test user, sign in as that user, and confirm any unit can be selected without completing prior modules.
- [ ] Confirm completing a module under unlocked still requires passing the validators (no XP from the toggle alone).
- [ ] Toggle Unlock back off and confirm the prerequisite gating returns.
- [ ] Confirm an `AdminAuditLog` entry is written for both unlock and re-lock actions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)