### PR TITLE
Move Support Center to Teams dropdown, add agent ticket filing

### DIFF
--- a/backend/app/routers/support.py
+++ b/backend/app/routers/support.py
@@ -99,17 +99,24 @@ async def list_tickets(
     status: str | None = None,
     limit: int = 50,
     offset: int = 0,
+    scope: str | None = None,
     user: User = Depends(get_current_user),
 ):
-    """List tickets. Support users see all; regular users see only their own."""
+    """List tickets.
+
+    - Default: support users see all tickets, regular users see their own.
+    - ``scope=mine``: always return only the caller's own tickets, even for
+      support users. Used by the Support Center page (where agents file QA
+      tickets) so they see their personal queue, not the global one.
+    """
     is_support = await _is_support_user(user)
-    if is_support:
-        tickets = await support_service.list_all_tickets(
-            status=status, limit=limit, offset=offset
-        )
-    else:
+    if scope == "mine" or not is_support:
         tickets = await support_service.list_tickets(
             user_id=user.user_id, status=status, limit=limit, offset=offset
+        )
+    else:
+        tickets = await support_service.list_all_tickets(
+            status=status, limit=limit, offset=offset
         )
     return {"tickets": tickets}
 

--- a/frontend/src/api/support.ts
+++ b/frontend/src/api/support.ts
@@ -26,11 +26,17 @@ export async function createTicket(
   return res.json() as Promise<SupportTicket>
 }
 
-export function listTickets(status?: string, limit = 50, offset = 0) {
+export function listTickets(
+  status?: string,
+  limit = 50,
+  offset = 0,
+  scope?: 'mine',
+) {
   const params = new URLSearchParams()
   if (status) params.set('status', status)
   params.set('limit', String(limit))
   params.set('offset', String(offset))
+  if (scope) params.set('scope', scope)
   return apiFetch<{ tickets: SupportTicketSummary[] }>(
     `/api/support/tickets?${params}`,
   )

--- a/frontend/src/components/layout/TeamsDropdown.tsx
+++ b/frontend/src/components/layout/TeamsDropdown.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect } from 'react'
-import { Award, User, Users, Settings, LogOut, IdCard, Shield, ClipboardCheck, ChevronDown } from 'lucide-react'
+import { Award, User, Users, Settings, LogOut, IdCard, Shield, ClipboardCheck, ChevronDown, MessageSquare } from 'lucide-react'
 import { Link } from '@tanstack/react-router'
 import { useTeams } from '../../hooks/useTeams'
 import { useAuth } from '../../hooks/useAuth'
@@ -104,10 +104,26 @@ export function TeamsDropdown() {
             <span>Certification</span>
           </button>
 
+          {/* Support agent: Support Center */}
+          {user?.is_support_agent && (
+            <>
+              <hr className="my-1.5 border-0 h-px bg-[#cdcdcd]" />
+              <Link
+                to="/support"
+                search={{ ticket: undefined }}
+                onClick={() => setOpen(false)}
+                className="flex items-center gap-2.5 rounded-md px-3.5 py-2.5 text-sm text-[#111] hover:bg-black/[.04] transition-colors"
+              >
+                <MessageSquare className="h-4 w-4 shrink-0" style={{ width: 18 }} />
+                <span>Support Center</span>
+              </Link>
+            </>
+          )}
+
           {/* Admin: System Configuration */}
           {(user?.is_admin || user?.is_examiner) && (
             <>
-              <hr className="my-1.5 border-0 h-px bg-[#cdcdcd]" />
+              {!user?.is_support_agent && <hr className="my-1.5 border-0 h-px bg-[#cdcdcd]" />}
               <Link
                 to="/admin"
                 onClick={() => setOpen(false)}

--- a/frontend/src/pages/Admin.tsx
+++ b/frontend/src/pages/Admin.tsx
@@ -40,8 +40,6 @@ import {
   adminAddDemoUser,
 } from '../api/demo'
 import { getAdminPromptOverview, adminUpdatePrompt, type PromptOverview } from '../api/feedbackPrompt'
-import * as supportApi from '../api/support'
-import type { SupportTicket, SupportTicketSummary } from '../types/support'
 import type { DemoAdminStats, DemoApplication as DemoApp, PostExperienceResponseAdmin } from '../types/demo'
 import { POST_SURVEY_FIELDS } from '../components/survey/postSurveyFields'
 import { PRE_SURVEY_FIELDS } from './Demo'
@@ -72,7 +70,7 @@ function applyThemeToDOM(theme: ThemeConfig) {
   root.style.setProperty('--ui-radius', theme.ui_radius)
 }
 
-type Tab = 'usage' | 'users' | 'teams' | 'organizations' | 'workflows' | 'quality' | 'approvals' | 'support' | 'audit' | 'demo' | 'email' | 'certifications' | 'debugging' | 'config'
+type Tab = 'usage' | 'users' | 'teams' | 'organizations' | 'workflows' | 'quality' | 'approvals' | 'audit' | 'demo' | 'email' | 'certifications' | 'debugging' | 'config'
 
 const TABS: { key: Tab; label: string; icon: typeof BarChart3 }[] = [
   { key: 'usage', label: 'Usage', icon: BarChart3 },
@@ -82,7 +80,6 @@ const TABS: { key: Tab; label: string; icon: typeof BarChart3 }[] = [
   { key: 'workflows', label: 'Workflows', icon: Workflow },
   { key: 'quality', label: 'Quality', icon: ShieldCheck },
   { key: 'approvals', label: 'Approvals', icon: CheckCircle2 },
-  { key: 'support', label: 'Support Center', icon: MessageSquare },
   { key: 'audit', label: 'Audit Log', icon: FileText },
   { key: 'demo', label: 'Demo', icon: Zap },
   { key: 'email', label: 'Email', icon: Mail },
@@ -5128,282 +5125,6 @@ function OrganizationsTab() {
 }
 
 // ---------------------------------------------------------------------------
-// Support Center Tab
-// ---------------------------------------------------------------------------
-
-function timeAgo(dateStr: string | null): string {
-  if (!dateStr) return ''
-  const diff = Math.floor((Date.now() - new Date(dateStr).getTime()) / 1000)
-  if (diff < 60) return 'just now'
-  if (diff < 3600) return `${Math.floor(diff / 60)}m ago`
-  if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`
-  return `${Math.floor(diff / 86400)}d ago`
-}
-
-function SupportTab() {
-  const [stats, setStats] = useState<{ total: number; open: number; in_progress: number; closed: number } | null>(null)
-  const [tickets, setTickets] = useState<SupportTicketSummary[]>([])
-  const [loading, setLoading] = useState(true)
-  const [statusFilter, setStatusFilter] = useState<string>('all')
-  const [selectedTicket, setSelectedTicket] = useState<SupportTicket | null>(null)
-  const [replyText, setReplyText] = useState('')
-  const [replying, setReplying] = useState(false)
-  const { user } = useAuth()
-
-  const load = useCallback(() => {
-    setLoading(true)
-    const statusParam = statusFilter === 'all' ? undefined : statusFilter
-    Promise.all([supportApi.getTicketStats(), supportApi.listTickets(statusParam, 200)])
-      .then(([s, t]) => { setStats(s); setTickets(t.tickets) })
-      .finally(() => setLoading(false))
-  }, [statusFilter])
-
-  useEffect(() => { load() }, [load])
-
-  const openThread = async (uuid: string) => {
-    const t = await supportApi.getTicket(uuid)
-    setSelectedTicket(t)
-    await supportApi.markTicketRead(uuid)
-  }
-
-  const handleReply = async () => {
-    if (!selectedTicket || !replyText.trim()) return
-    setReplying(true)
-    try {
-      const updated = await supportApi.addMessage(selectedTicket.uuid, replyText.trim())
-      setSelectedTicket(updated)
-      setReplyText('')
-      load()
-    } finally {
-      setReplying(false)
-    }
-  }
-
-  const handleStatusChange = async (uuid: string, newStatus: string) => {
-    try {
-      const updated = await supportApi.updateTicket(uuid, { status: newStatus })
-      setSelectedTicket(updated)
-      load()
-    } catch { /* ignore */ }
-  }
-
-  const statCardStyle = (color: string) => ({
-    flex: 1, padding: '16px 20px', background: '#fff', borderRadius: 'var(--ui-radius, 12px)',
-    border: '1px solid #e5e7eb', borderLeft: `4px solid ${color}`,
-  })
-
-  if (loading && !stats) return <div style={{ padding: 40, textAlign: 'center', color: '#6b7280' }}>Loading support data...</div>
-
-  // Thread detail view
-  if (selectedTicket) {
-    const t = selectedTicket
-    const statusColors: Record<string, string> = { open: '#f59e0b', in_progress: '#3b82f6', closed: '#9ca3af' }
-    const priorityColors: Record<string, string> = { low: '#9ca3af', normal: '#3b82f6', high: '#ef4444' }
-    return (
-      <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
-        <button
-          onClick={() => { setSelectedTicket(null); load() }}
-          style={{
-            display: 'inline-flex', alignItems: 'center', gap: 6, padding: '6px 12px',
-            border: '1px solid #d1d5db', borderRadius: 'var(--ui-radius, 12px)', background: '#fff',
-            fontSize: 13, cursor: 'pointer', alignSelf: 'flex-start',
-          }}
-        >
-          <ArrowLeft size={14} /> Back to tickets
-        </button>
-
-        <div style={{ background: '#fff', border: '1px solid #e5e7eb', borderRadius: 'var(--ui-radius, 12px)', overflow: 'hidden' }}>
-          {/* Header */}
-          <div style={{ padding: '16px 20px', borderBottom: '1px solid #e5e7eb', display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
-            <div>
-              <h3 style={{ margin: 0, fontSize: 16, fontWeight: 600 }}>{t.subject}</h3>
-              <div style={{ fontSize: 13, color: '#6b7280', marginTop: 4 }}>
-                {t.user_name || t.user_id} {t.user_email ? `(${t.user_email})` : ''} &middot; {timeAgo(t.created_at)}
-              </div>
-            </div>
-            <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
-              <span style={{ fontSize: 11, padding: '2px 8px', borderRadius: 9999, background: `${priorityColors[t.priority] || '#3b82f6'}20`, color: priorityColors[t.priority] || '#3b82f6', fontWeight: 600, textTransform: 'uppercase' }}>
-                {t.priority}
-              </span>
-              <span style={{ fontSize: 11, padding: '2px 8px', borderRadius: 9999, background: `${statusColors[t.status] || '#9ca3af'}20`, color: statusColors[t.status] || '#9ca3af', fontWeight: 600, textTransform: 'uppercase' }}>
-                {t.status.replace('_', ' ')}
-              </span>
-              {t.status !== 'closed' && (
-                <select
-                  value={t.status}
-                  onChange={e => handleStatusChange(t.uuid, e.target.value)}
-                  style={{ fontSize: 12, padding: '4px 8px', borderRadius: 'var(--ui-radius, 12px)', border: '1px solid #d1d5db' }}
-                >
-                  <option value="open">Open</option>
-                  <option value="in_progress">In Progress</option>
-                  <option value="closed">Closed</option>
-                </select>
-              )}
-              {t.status === 'closed' && (
-                <button
-                  onClick={() => handleStatusChange(t.uuid, 'open')}
-                  style={{ fontSize: 12, padding: '4px 10px', borderRadius: 'var(--ui-radius, 12px)', border: '1px solid #d1d5db', background: '#fff', cursor: 'pointer' }}
-                >
-                  Reopen
-                </button>
-              )}
-            </div>
-          </div>
-
-          {/* Messages */}
-          <div style={{ padding: 20, display: 'flex', flexDirection: 'column', gap: 12, maxHeight: 500, overflowY: 'auto' }}>
-            {t.messages.map((m, i) => {
-              const isSupport = m.is_support_reply
-              return (
-                <div key={i} style={{
-                  padding: '10px 14px', borderRadius: 'var(--ui-radius, 12px)',
-                  background: isSupport ? '#eff6ff' : '#f9fafb',
-                  border: `1px solid ${isSupport ? '#bfdbfe' : '#e5e7eb'}`,
-                  maxWidth: '85%', alignSelf: isSupport ? 'flex-end' : 'flex-start',
-                }}>
-                  <div style={{ fontSize: 12, fontWeight: 600, color: isSupport ? '#1e40af' : '#374151', marginBottom: 4 }}>
-                    {m.user_name || m.user_id}
-                    {isSupport && <span style={{ marginLeft: 6, fontSize: 10, color: '#3b82f6', fontWeight: 500 }}>Support</span>}
-                    <span style={{ marginLeft: 8, fontWeight: 400, color: '#9ca3af' }}>{timeAgo(m.created_at)}</span>
-                  </div>
-                  <div style={{ fontSize: 14, color: '#374151', whiteSpace: 'pre-wrap' }}>{m.content}</div>
-                </div>
-              )
-            })}
-          </div>
-
-          {/* Reply */}
-          {t.status !== 'closed' && (
-            <div style={{ padding: '12px 20px', borderTop: '1px solid #e5e7eb', display: 'flex', gap: 8 }}>
-              <input
-                value={replyText}
-                onChange={e => setReplyText(e.target.value)}
-                onKeyDown={e => { if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); handleReply() } }}
-                placeholder="Type a reply..."
-                style={{ flex: 1, padding: '8px 12px', borderRadius: 'var(--ui-radius, 12px)', border: '1px solid #d1d5db', fontSize: 14, outline: 'none' }}
-              />
-              <button
-                onClick={handleReply}
-                disabled={replying || !replyText.trim()}
-                style={{
-                  padding: '8px 16px', borderRadius: 'var(--ui-radius, 12px)', border: 'none',
-                  background: 'var(--highlight-color, #eab308)', color: 'var(--highlight-text-color, #000)',
-                  fontSize: 13, fontWeight: 600, cursor: replyText.trim() ? 'pointer' : 'not-allowed',
-                  opacity: replying ? 0.6 : 1, display: 'flex', alignItems: 'center', gap: 6,
-                }}
-              >
-                <Send size={14} /> {replying ? 'Sending...' : 'Reply'}
-              </button>
-            </div>
-          )}
-        </div>
-      </div>
-    )
-  }
-
-  // Stats + list view
-  return (
-    <div style={{ display: 'flex', flexDirection: 'column', gap: 20 }}>
-      {/* Stats cards */}
-      {stats && (
-        <div style={{ display: 'flex', gap: 12 }}>
-          <div style={statCardStyle('#6b7280')}>
-            <div style={{ fontSize: 24, fontWeight: 700 }}>{stats.total}</div>
-            <div style={{ fontSize: 13, color: '#6b7280' }}>Total Tickets</div>
-          </div>
-          <div style={statCardStyle('#f59e0b')}>
-            <div style={{ fontSize: 24, fontWeight: 700, color: '#f59e0b' }}>{stats.open}</div>
-            <div style={{ fontSize: 13, color: '#6b7280' }}>Open</div>
-          </div>
-          <div style={statCardStyle('#3b82f6')}>
-            <div style={{ fontSize: 24, fontWeight: 700, color: '#3b82f6' }}>{stats.in_progress}</div>
-            <div style={{ fontSize: 13, color: '#6b7280' }}>In Progress</div>
-          </div>
-          <div style={statCardStyle('#22c55e')}>
-            <div style={{ fontSize: 24, fontWeight: 700, color: '#22c55e' }}>{stats.closed}</div>
-            <div style={{ fontSize: 13, color: '#6b7280' }}>Closed</div>
-          </div>
-        </div>
-      )}
-
-      {/* Ticket list */}
-      <div style={{ background: '#fff', border: '1px solid #e5e7eb', borderRadius: 'var(--ui-radius, 12px)', overflow: 'hidden' }}>
-        <div style={{ padding: '14px 20px', borderBottom: '1px solid #e5e7eb', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-          <div style={{ fontSize: 15, fontWeight: 600, display: 'flex', alignItems: 'center', gap: 10 }}>
-            <MessageSquare size={18} color="#6b7280" /> Tickets
-          </div>
-          <div style={{ display: 'flex', gap: 4 }}>
-            {['all', 'open', 'in_progress', 'closed'].map(s => (
-              <button
-                key={s}
-                onClick={() => setStatusFilter(s)}
-                style={{
-                  padding: '4px 12px', fontSize: 12, fontWeight: statusFilter === s ? 600 : 400,
-                  borderRadius: 9999, border: '1px solid #e5e7eb', cursor: 'pointer',
-                  background: statusFilter === s ? '#111827' : '#fff',
-                  color: statusFilter === s ? '#fff' : '#6b7280',
-                }}
-              >
-                {s === 'in_progress' ? 'In Progress' : s.charAt(0).toUpperCase() + s.slice(1)}
-              </button>
-            ))}
-          </div>
-        </div>
-
-        {loading ? (
-          <div style={{ padding: 40, textAlign: 'center', color: '#9ca3af' }}>Loading...</div>
-        ) : tickets.length === 0 ? (
-          <div style={{ padding: 40, textAlign: 'center', color: '#9ca3af' }}>No tickets found.</div>
-        ) : (
-          <div>
-            {tickets.map(t => {
-              const statusColors: Record<string, string> = { open: '#f59e0b', in_progress: '#3b82f6', closed: '#9ca3af' }
-              const priorityColors: Record<string, string> = { low: '#9ca3af', normal: '#3b82f6', high: '#ef4444' }
-              const needsAttention = t.status !== 'closed' && t.last_message_user_id && !t.last_message_is_support_reply && user && !t.read_by?.includes(user.user_id)
-              return (
-                <div
-                  key={t.uuid}
-                  onClick={() => openThread(t.uuid)}
-                  style={{
-                    padding: '12px 20px', borderBottom: '1px solid #f3f4f6', cursor: 'pointer',
-                    display: 'flex', justifyContent: 'space-between', alignItems: 'center',
-                    background: needsAttention ? '#fffbeb' : '#fff',
-                    transition: 'background 0.1s',
-                  }}
-                  onMouseEnter={e => { if (!needsAttention) (e.currentTarget as HTMLDivElement).style.background = '#f9fafb' }}
-                  onMouseLeave={e => { if (!needsAttention) (e.currentTarget as HTMLDivElement).style.background = '#fff' }}
-                >
-                  <div style={{ flex: 1, minWidth: 0 }}>
-                    <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-                      {needsAttention && <span style={{ width: 8, height: 8, borderRadius: '50%', background: '#3b82f6', flexShrink: 0 }} />}
-                      <span style={{ fontSize: 14, fontWeight: 500, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{t.subject}</span>
-                      <span style={{ fontSize: 11, padding: '1px 6px', borderRadius: 9999, background: `${statusColors[t.status]}20`, color: statusColors[t.status], fontWeight: 600 }}>
-                        {t.status.replace('_', ' ')}
-                      </span>
-                      <span style={{ fontSize: 11, padding: '1px 6px', borderRadius: 9999, background: `${priorityColors[t.priority]}20`, color: priorityColors[t.priority], fontWeight: 600 }}>
-                        {t.priority}
-                      </span>
-                    </div>
-                    <div style={{ fontSize: 12, color: '#9ca3af', marginTop: 4, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                      {t.user_name || t.user_id} &middot; {t.message_count} message{t.message_count !== 1 ? 's' : ''}
-                      {t.last_message_preview ? ` \u2014 ${t.last_message_preview}` : ''}
-                    </div>
-                  </div>
-                  <div style={{ fontSize: 12, color: '#9ca3af', flexShrink: 0, marginLeft: 16 }}>
-                    {timeAgo(t.updated_at || t.created_at)}
-                  </div>
-                </div>
-              )
-            })}
-          </div>
-        )}
-      </div>
-    </div>
-  )
-}
-
-
-// ---------------------------------------------------------------------------
 // Approvals Tab
 // ---------------------------------------------------------------------------
 
@@ -5841,7 +5562,7 @@ export default function Admin() {
   const hasAccess = isGlobalAdmin || isStaff || isExaminer || isTeamAdmin
 
   // Staff see everything except config; examiners see analytics tabs only
-  const hiddenForNonAdmin = ['config', 'quality', 'demo', 'debugging', 'organizations', 'approvals', 'support', 'audit', 'certifications']
+  const hiddenForNonAdmin = ['config', 'quality', 'demo', 'debugging', 'organizations', 'approvals', 'audit', 'certifications']
   let visibleTabs = isGlobalAdmin
     ? TABS
     : isStaff
@@ -5921,7 +5642,6 @@ export default function Admin() {
           {activeTab === 'workflows' && <WorkflowsTab />}
           {activeTab === 'quality' && <QualityTab />}
           {activeTab === 'approvals' && (isGlobalAdmin || isStaff) && <ApprovalsTab />}
-          {activeTab === 'support' && (isGlobalAdmin || isStaff) && <SupportTab />}
           {activeTab === 'audit' && (isGlobalAdmin || isStaff) && <AuditTab />}
           {activeTab === 'demo' && (isGlobalAdmin || isStaff) && <DemoTab />}
           {activeTab === 'email' && (isGlobalAdmin || isStaff) && <EmailAnalyticsTab />}

--- a/frontend/src/pages/SupportCenter.tsx
+++ b/frontend/src/pages/SupportCenter.tsx
@@ -1,0 +1,697 @@
+import { useEffect, useState, useCallback, useRef } from 'react'
+import { Navigate, useNavigate, useSearch } from '@tanstack/react-router'
+import {
+  ArrowLeft, MessageSquare, Send, Plus, Paperclip, X, Loader2,
+  CheckCircle2, Clock, Circle,
+} from 'lucide-react'
+import { PageLayout } from '../components/layout/PageLayout'
+import { useAuth } from '../hooks/useAuth'
+import { useToast } from '../contexts/ToastContext'
+import { openSupportPanel } from '../utils/supportPanel'
+import * as supportApi from '../api/support'
+import type {
+  SupportTicket, SupportTicketSummary, SupportAttachment,
+} from '../types/support'
+
+type View = 'list' | 'new' | 'chat'
+
+const MAX_BYTES = 10 * 1024 * 1024
+
+function timeAgo(dateStr: string | null): string {
+  if (!dateStr) return ''
+  const diff = Math.floor((Date.now() - new Date(dateStr).getTime()) / 1000)
+  if (diff < 60) return 'just now'
+  if (diff < 3600) return `${Math.floor(diff / 60)}m ago`
+  if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`
+  return `${Math.floor(diff / 86400)}d ago`
+}
+
+const STATUS_BG: Record<string, string> = {
+  open: '#fef3c7',
+  in_progress: '#dbeafe',
+  closed: '#f3f4f6',
+}
+const STATUS_FG: Record<string, string> = {
+  open: '#b45309',
+  in_progress: '#1d4ed8',
+  closed: '#6b7280',
+}
+
+export default function SupportCenter() {
+  const { user } = useAuth()
+  const navigate = useNavigate()
+  const search = useSearch({ from: '/support' }) as { ticket?: string }
+  const { toast } = useToast()
+
+  const [view, setView] = useState<View>('list')
+  const [tickets, setTickets] = useState<SupportTicketSummary[]>([])
+  const [loading, setLoading] = useState(true)
+  const [activeTicketUuid, setActiveTicketUuid] = useState<string | null>(null)
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    try {
+      const data = await supportApi.listTickets(undefined, 100, 0, 'mine')
+      setTickets(data.tickets)
+    } catch {
+      toast('Failed to load tickets', 'error')
+    } finally {
+      setLoading(false)
+    }
+  }, [toast])
+
+  useEffect(() => { load() }, [load])
+
+  // Deep link: /support?ticket=X. If the ticket is mine, open it in chat view.
+  // If it isn't (i.e., a notification points at a queue item), hand off to the
+  // answering panel and clear the URL param so the page doesn't keep retrying.
+  useEffect(() => {
+    if (!search.ticket || !user) return
+    const uuid = search.ticket
+    supportApi.getTicket(uuid).then((t) => {
+      if (t.user_id === user.user_id) {
+        setActiveTicketUuid(uuid)
+        setView('chat')
+      } else {
+        openSupportPanel(uuid)
+        navigate({ to: '/support', search: { ticket: undefined } })
+      }
+    }).catch(() => { /* not found / not authorized — ignore */ })
+  }, [search.ticket, user, navigate])
+
+  if (!user?.is_support_agent) {
+    return <Navigate to="/" search={{ mode: undefined, tab: undefined, workflow: undefined, extraction: undefined, automation: undefined, kb: undefined }} />
+  }
+
+  const openTicket = (uuid: string) => {
+    setActiveTicketUuid(uuid)
+    setView('chat')
+  }
+
+  const backToList = () => {
+    setActiveTicketUuid(null)
+    setView('list')
+    load()
+  }
+
+  return (
+    <PageLayout>
+      {view === 'list' && (
+        <ListView
+          tickets={tickets}
+          loading={loading}
+          onNew={() => setView('new')}
+          onSelect={openTicket}
+        />
+      )}
+      {view === 'new' && (
+        <NewTicketView
+          onBack={() => setView('list')}
+          onCreated={(t) => {
+            setActiveTicketUuid(t.uuid)
+            setView('chat')
+            load()
+          }}
+        />
+      )}
+      {view === 'chat' && activeTicketUuid && (
+        <ChatView
+          ticketUuid={activeTicketUuid}
+          onBack={backToList}
+        />
+      )}
+    </PageLayout>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// List view — my tickets + prominent New Ticket CTA
+// ---------------------------------------------------------------------------
+
+function ListView({
+  tickets, loading, onNew, onSelect,
+}: {
+  tickets: SupportTicketSummary[]
+  loading: boolean
+  onNew: () => void
+  onSelect: (uuid: string) => void
+}) {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 20 }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+          <MessageSquare size={20} color="#6b7280" />
+          <div>
+            <h1 style={{ margin: 0, fontSize: 20, fontWeight: 700 }}>Support Center</h1>
+            <p style={{ margin: '2px 0 0', fontSize: 13, color: '#6b7280' }}>
+              File your own tickets and run QA against the support workflow. The answering queue lives in the floating Support panel.
+            </p>
+          </div>
+        </div>
+        <button
+          onClick={onNew}
+          style={{
+            display: 'inline-flex', alignItems: 'center', gap: 6,
+            padding: '8px 14px', borderRadius: 'var(--ui-radius, 12px)', border: 'none',
+            background: '#2563eb', color: '#fff', fontSize: 14, fontWeight: 600, cursor: 'pointer',
+          }}
+        >
+          <Plus size={16} /> New Ticket
+        </button>
+      </div>
+
+      <div style={{ background: '#fff', border: '1px solid #e5e7eb', borderRadius: 'var(--ui-radius, 12px)', overflow: 'hidden' }}>
+        <div style={{ padding: '14px 20px', borderBottom: '1px solid #e5e7eb', fontSize: 14, fontWeight: 600 }}>
+          My Tickets
+        </div>
+        {loading ? (
+          <div style={{ padding: 40, textAlign: 'center', color: '#9ca3af' }}>
+            <Loader2 size={20} style={{ display: 'inline-block', animation: 'spin 1s linear infinite', verticalAlign: 'middle' }} />
+            <span style={{ marginLeft: 8 }}>Loading...</span>
+          </div>
+        ) : tickets.length === 0 ? (
+          <div style={{ padding: 40, textAlign: 'center', color: '#9ca3af' }}>
+            <MessageSquare size={28} color="#d1d5db" style={{ display: 'block', margin: '0 auto 8px' }} />
+            <div style={{ fontSize: 14, marginBottom: 12 }}>You haven&rsquo;t filed any tickets.</div>
+            <button
+              onClick={onNew}
+              style={{
+                display: 'inline-flex', alignItems: 'center', gap: 6,
+                padding: '8px 14px', borderRadius: 'var(--ui-radius, 12px)', border: 'none',
+                background: '#2563eb', color: '#fff', fontSize: 13, fontWeight: 600, cursor: 'pointer',
+              }}
+            >
+              <Plus size={14} /> File your first ticket
+            </button>
+          </div>
+        ) : (
+          <div>
+            {tickets.map((t) => (
+              <button
+                key={t.uuid}
+                onClick={() => onSelect(t.uuid)}
+                style={{
+                  display: 'flex', justifyContent: 'space-between', alignItems: 'center',
+                  width: '100%', padding: '12px 20px', borderBottom: '1px solid #f3f4f6',
+                  background: '#fff', border: 'none', borderTop: 'none', borderLeft: 'none', borderRight: 'none',
+                  cursor: 'pointer', textAlign: 'left', fontFamily: 'inherit',
+                }}
+                onMouseEnter={(e) => { (e.currentTarget as HTMLButtonElement).style.background = '#f9fafb' }}
+                onMouseLeave={(e) => { (e.currentTarget as HTMLButtonElement).style.background = '#fff' }}
+              >
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                    <span style={{ fontSize: 14, fontWeight: 500, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                      {t.subject}
+                    </span>
+                    <span style={{
+                      fontSize: 11, padding: '1px 6px', borderRadius: 9999,
+                      background: STATUS_BG[t.status], color: STATUS_FG[t.status], fontWeight: 600,
+                    }}>
+                      {t.status.replace('_', ' ')}
+                    </span>
+                  </div>
+                  <div style={{ fontSize: 12, color: '#9ca3af', marginTop: 4, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                    {t.message_count} message{t.message_count !== 1 ? 's' : ''}
+                    {t.last_message_preview ? ` — ${t.last_message_preview}` : ''}
+                  </div>
+                </div>
+                <div style={{ fontSize: 12, color: '#9ca3af', flexShrink: 0, marginLeft: 16 }}>
+                  {timeAgo(t.updated_at || t.created_at)}
+                </div>
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// New ticket form
+// ---------------------------------------------------------------------------
+
+function NewTicketView({
+  onBack, onCreated,
+}: {
+  onBack: () => void
+  onCreated: (ticket: SupportTicket) => void
+}) {
+  const { toast } = useToast()
+  const [subject, setSubject] = useState('')
+  const [message, setMessage] = useState('')
+  const [priority, setPriority] = useState('normal')
+  const [files, setFiles] = useState<File[]>([])
+  const [submitting, setSubmitting] = useState(false)
+  const fileInputRef = useRef<HTMLInputElement>(null)
+
+  const onPickFiles = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const picked = Array.from(e.target.files ?? [])
+    if (fileInputRef.current) fileInputRef.current.value = ''
+    const accepted: File[] = []
+    for (const f of picked) {
+      if (f.size > MAX_BYTES) { toast(`${f.name} is over 10MB`, 'error'); continue }
+      accepted.push(f)
+    }
+    if (accepted.length) setFiles((prev) => [...prev, ...accepted])
+  }
+
+  const handleSubmit = async () => {
+    if (!subject.trim() || !message.trim()) return
+    setSubmitting(true)
+    try {
+      const ticket = await supportApi.createTicket(subject.trim(), message.trim(), priority, files)
+      toast('Ticket created', 'success')
+      onCreated(ticket)
+    } catch (err) {
+      toast(err instanceof Error ? err.message : 'Failed to create ticket', 'error')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  const labelStyle = { display: 'block', fontSize: 12, fontWeight: 600, color: '#374151', marginBottom: 6 }
+  const inputStyle = {
+    width: '100%', padding: '8px 12px', fontSize: 14, fontFamily: 'inherit',
+    border: '1px solid #d1d5db', borderRadius: 'var(--ui-radius, 12px)', outline: 'none',
+    boxSizing: 'border-box' as const,
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 16, maxWidth: 720 }}>
+      <button
+        onClick={onBack}
+        style={{
+          display: 'inline-flex', alignItems: 'center', gap: 6, padding: '6px 12px',
+          border: '1px solid #d1d5db', borderRadius: 'var(--ui-radius, 12px)', background: '#fff',
+          fontSize: 13, cursor: 'pointer', alignSelf: 'flex-start',
+        }}
+      >
+        <ArrowLeft size={14} /> Back to my tickets
+      </button>
+
+      <div style={{ background: '#fff', border: '1px solid #e5e7eb', borderRadius: 'var(--ui-radius, 12px)', padding: 24 }}>
+        <h2 style={{ margin: '0 0 4px', fontSize: 18, fontWeight: 700 }}>File a Ticket</h2>
+        <p style={{ margin: '0 0 20px', fontSize: 13, color: '#6b7280' }}>
+          Tickets you create here go into the same queue your team answers from.
+        </p>
+
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
+          <div>
+            <label style={labelStyle}>Subject</label>
+            <input
+              value={subject}
+              onChange={(e) => setSubject(e.target.value)}
+              placeholder="Brief summary of your issue"
+              style={inputStyle}
+              autoFocus
+            />
+          </div>
+          <div>
+            <label style={labelStyle}>Priority</label>
+            <select
+              value={priority}
+              onChange={(e) => setPriority(e.target.value)}
+              style={inputStyle}
+            >
+              <option value="low">Low</option>
+              <option value="normal">Normal</option>
+              <option value="high">High</option>
+            </select>
+          </div>
+          <div>
+            <label style={labelStyle}>Description</label>
+            <textarea
+              value={message}
+              onChange={(e) => setMessage(e.target.value)}
+              rows={6}
+              placeholder="What's going on? Include reproduction steps when possible."
+              style={{ ...inputStyle, resize: 'vertical', fontFamily: 'inherit' }}
+            />
+          </div>
+          <div>
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+              <label style={labelStyle}>Attachments</label>
+              <button
+                type="button"
+                onClick={() => fileInputRef.current?.click()}
+                style={{
+                  display: 'inline-flex', alignItems: 'center', gap: 4, padding: '4px 10px',
+                  border: '1px solid #d1d5db', borderRadius: 'var(--ui-radius, 12px)', background: '#fff',
+                  fontSize: 12, cursor: 'pointer',
+                }}
+              >
+                <Paperclip size={12} /> Attach
+              </button>
+              <input
+                ref={fileInputRef}
+                type="file"
+                multiple
+                onChange={onPickFiles}
+                style={{ display: 'none' }}
+              />
+            </div>
+            {files.length > 0 && (
+              <ul style={{ margin: '8px 0 0', padding: 0, listStyle: 'none', display: 'flex', flexDirection: 'column', gap: 4 }}>
+                {files.map((f, i) => (
+                  <li
+                    key={`${f.name}-${i}`}
+                    style={{
+                      display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 8,
+                      padding: '6px 10px', background: '#f9fafb', border: '1px solid #e5e7eb',
+                      borderRadius: 'var(--ui-radius, 12px)', fontSize: 12,
+                    }}
+                  >
+                    <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }} title={f.name}>{f.name}</span>
+                    <button
+                      type="button"
+                      onClick={() => setFiles((prev) => prev.filter((_, idx) => idx !== i))}
+                      style={{ background: 'none', border: 'none', cursor: 'pointer', color: '#9ca3af', padding: 2 }}
+                      title="Remove"
+                    >
+                      <X size={12} />
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        </div>
+
+        <div style={{ marginTop: 20, display: 'flex', gap: 8 }}>
+          <button
+            onClick={handleSubmit}
+            disabled={!subject.trim() || !message.trim() || submitting}
+            style={{
+              display: 'inline-flex', alignItems: 'center', gap: 6,
+              padding: '8px 16px', borderRadius: 'var(--ui-radius, 12px)', border: 'none',
+              background: '#2563eb', color: '#fff', fontSize: 14, fontWeight: 600,
+              cursor: (!subject.trim() || !message.trim() || submitting) ? 'not-allowed' : 'pointer',
+              opacity: (!subject.trim() || !message.trim() || submitting) ? 0.6 : 1,
+            }}
+          >
+            {submitting && <Loader2 size={14} style={{ animation: 'spin 1s linear infinite' }} />}
+            Submit Ticket
+          </button>
+          <button
+            onClick={onBack}
+            style={{
+              padding: '8px 16px', borderRadius: 'var(--ui-radius, 12px)',
+              border: '1px solid #d1d5db', background: '#fff',
+              fontSize: 14, fontWeight: 500, cursor: 'pointer',
+            }}
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Chat view — customer mode (no status controls, no agent badges)
+// ---------------------------------------------------------------------------
+
+function ChatView({
+  ticketUuid, onBack,
+}: {
+  ticketUuid: string
+  onBack: () => void
+}) {
+  const { user } = useAuth()
+  const { toast } = useToast()
+  const [ticket, setTicket] = useState<SupportTicket | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [reply, setReply] = useState('')
+  const [sending, setSending] = useState(false)
+  const [previewAttachment, setPreviewAttachment] = useState<SupportAttachment | null>(null)
+  const messagesEndRef = useRef<HTMLDivElement>(null)
+  const fileInputRef = useRef<HTMLInputElement>(null)
+
+  const loadTicket = useCallback(async () => {
+    try {
+      const data = await supportApi.getTicket(ticketUuid)
+      setTicket(data)
+    } catch {
+      toast('Failed to load ticket', 'error')
+    } finally {
+      setLoading(false)
+    }
+  }, [ticketUuid, toast])
+
+  useEffect(() => {
+    loadTicket()
+    supportApi.markTicketRead(ticketUuid).catch(() => {})
+    const interval = setInterval(loadTicket, 15000)
+    return () => clearInterval(interval)
+  }, [loadTicket, ticketUuid])
+
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' })
+  }, [ticket?.messages.length])
+
+  const handleSend = async () => {
+    if (!reply.trim() || sending) return
+    setSending(true)
+    try {
+      const updated = await supportApi.addMessage(ticketUuid, reply.trim())
+      setTicket(updated)
+      setReply('')
+    } catch {
+      toast('Failed to send message', 'error')
+    } finally {
+      setSending(false)
+    }
+  }
+
+  const handleFileUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (!file) return
+    if (fileInputRef.current) fileInputRef.current.value = ''
+    if (file.size > MAX_BYTES) {
+      toast(`File must be under 10MB`, 'error')
+      return
+    }
+    try {
+      const updated = await supportApi.addAttachment(ticketUuid, file)
+      setTicket(updated)
+      toast('File attached', 'success')
+    } catch (err) {
+      toast(err instanceof Error ? err.message : 'Upload failed', 'error')
+    }
+  }
+
+  if (loading) {
+    return (
+      <div style={{ padding: 40, textAlign: 'center', color: '#9ca3af' }}>
+        <Loader2 size={20} style={{ animation: 'spin 1s linear infinite' }} /> Loading ticket...
+      </div>
+    )
+  }
+
+  if (!ticket) {
+    return (
+      <div style={{ padding: 40, textAlign: 'center', color: '#9ca3af' }}>
+        Ticket not found.
+        <div style={{ marginTop: 12 }}>
+          <button onClick={onBack} style={{ background: 'none', border: 'none', color: '#2563eb', cursor: 'pointer' }}>
+            Back
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  const StatusIcon = ticket.status === 'closed' ? CheckCircle2 : ticket.status === 'in_progress' ? Clock : Circle
+  const statusColor = ticket.status === 'closed' ? '#9ca3af' : ticket.status === 'in_progress' ? '#3b82f6' : '#f59e0b'
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 16, maxWidth: 900 }}>
+      <button
+        onClick={onBack}
+        style={{
+          display: 'inline-flex', alignItems: 'center', gap: 6, padding: '6px 12px',
+          border: '1px solid #d1d5db', borderRadius: 'var(--ui-radius, 12px)', background: '#fff',
+          fontSize: 13, cursor: 'pointer', alignSelf: 'flex-start',
+        }}
+      >
+        <ArrowLeft size={14} /> Back to my tickets
+      </button>
+
+      <div style={{ background: '#fff', border: '1px solid #e5e7eb', borderRadius: 'var(--ui-radius, 12px)', overflow: 'hidden', position: 'relative' }}>
+        <div style={{ padding: '16px 20px', borderBottom: '1px solid #e5e7eb', display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: 12 }}>
+          <div style={{ minWidth: 0 }}>
+            <h3 style={{ margin: 0, fontSize: 16, fontWeight: 600, overflow: 'hidden', textOverflow: 'ellipsis' }}>{ticket.subject}</h3>
+            <div style={{ fontSize: 13, color: '#6b7280', marginTop: 4, display: 'flex', alignItems: 'center', gap: 6 }}>
+              <StatusIcon size={12} color={statusColor} />
+              <span style={{ textTransform: 'capitalize' }}>{ticket.status.replace('_', ' ')}</span>
+              <span>&middot; opened {timeAgo(ticket.created_at)}</span>
+            </div>
+          </div>
+        </div>
+
+        <div style={{ padding: 20, display: 'flex', flexDirection: 'column', gap: 12, maxHeight: 520, overflowY: 'auto' }}>
+          {ticket.messages.map((m) => {
+            const isMine = m.user_id === user?.user_id
+            const msgAttachments = ticket.attachments.filter((a) => a.message_uuid === m.uuid)
+            return (
+              <div key={m.uuid} style={{ display: 'flex', flexDirection: 'column', alignItems: isMine ? 'flex-end' : 'flex-start' }}>
+                <div style={{
+                  maxWidth: '85%', padding: '10px 14px', borderRadius: 'var(--ui-radius, 12px)',
+                  background: isMine ? '#2563eb' : '#f3f4f6',
+                  color: isMine ? '#fff' : '#111827',
+                }}>
+                  {!isMine && (
+                    <div style={{ fontSize: 11, fontWeight: 600, color: '#6b7280', marginBottom: 4 }}>
+                      {m.user_name || 'Support'}
+                    </div>
+                  )}
+                  <div style={{ fontSize: 14, whiteSpace: 'pre-wrap' }}>{m.content}</div>
+                  <div style={{ fontSize: 10, marginTop: 4, color: isMine ? 'rgba(255,255,255,0.75)' : '#9ca3af' }}>
+                    {timeAgo(m.created_at)}
+                  </div>
+                </div>
+                {msgAttachments.length > 0 && (
+                  <div style={{ marginTop: 6, display: 'flex', flexDirection: 'column', gap: 6, alignItems: isMine ? 'flex-end' : 'flex-start' }}>
+                    {msgAttachments.map((a) => (
+                      <AttachmentChip key={a.uuid} attachment={a} ticketUuid={ticketUuid} onPreview={setPreviewAttachment} />
+                    ))}
+                  </div>
+                )}
+              </div>
+            )
+          })}
+          {ticket.attachments.filter((a) => !a.message_uuid).length > 0 && (
+            <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6, paddingTop: 8, borderTop: '1px solid #f3f4f6' }}>
+              {ticket.attachments.filter((a) => !a.message_uuid).map((a) => (
+                <AttachmentChip key={a.uuid} attachment={a} ticketUuid={ticketUuid} onPreview={setPreviewAttachment} />
+              ))}
+            </div>
+          )}
+          <div ref={messagesEndRef} />
+        </div>
+
+        {ticket.status !== 'closed' && (
+          <div style={{ padding: '12px 20px', borderTop: '1px solid #e5e7eb', display: 'flex', gap: 8, alignItems: 'center' }}>
+            <button
+              onClick={() => fileInputRef.current?.click()}
+              title="Attach file"
+              style={{ background: 'none', border: 'none', cursor: 'pointer', color: '#6b7280', padding: 4 }}
+            >
+              <Paperclip size={16} />
+            </button>
+            <input ref={fileInputRef} type="file" onChange={handleFileUpload} style={{ display: 'none' }} />
+            <input
+              value={reply}
+              onChange={(e) => setReply(e.target.value)}
+              onKeyDown={(e) => { if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); handleSend() } }}
+              placeholder="Type a reply..."
+              style={{
+                flex: 1, padding: '8px 12px', fontSize: 14,
+                border: '1px solid #d1d5db', borderRadius: 'var(--ui-radius, 12px)', outline: 'none',
+              }}
+            />
+            <button
+              onClick={handleSend}
+              disabled={sending || !reply.trim()}
+              style={{
+                display: 'inline-flex', alignItems: 'center', gap: 4,
+                padding: '8px 14px', borderRadius: 'var(--ui-radius, 12px)', border: 'none',
+                background: '#2563eb', color: '#fff', fontSize: 13, fontWeight: 600,
+                cursor: reply.trim() && !sending ? 'pointer' : 'not-allowed',
+                opacity: sending ? 0.6 : 1,
+              }}
+            >
+              <Send size={14} /> {sending ? 'Sending...' : 'Reply'}
+            </button>
+          </div>
+        )}
+        {ticket.status === 'closed' && (
+          <div style={{ padding: '12px 20px', borderTop: '1px solid #e5e7eb', fontSize: 13, color: '#6b7280', textAlign: 'center' }}>
+            This ticket is closed. An agent can reopen it from the Support panel.
+          </div>
+        )}
+
+        {previewAttachment && (
+          <div
+            onClick={() => setPreviewAttachment(null)}
+            style={{
+              position: 'fixed', inset: 0, zIndex: 100,
+              background: 'rgba(0,0,0,0.7)', display: 'flex', alignItems: 'center', justifyContent: 'center',
+            }}
+          >
+            <div onClick={(e) => e.stopPropagation()} style={{ position: 'relative', maxWidth: '95%', maxHeight: '90%' }}>
+              <button
+                onClick={() => setPreviewAttachment(null)}
+                style={{
+                  position: 'absolute', top: -8, right: -8, padding: 6,
+                  borderRadius: '50%', border: 'none', background: '#fff', cursor: 'pointer',
+                  boxShadow: '0 4px 12px rgba(0,0,0,0.2)',
+                }}
+              >
+                <X size={14} />
+              </button>
+              <img
+                src={`/api/support/tickets/${ticketUuid}/attachments/${previewAttachment.uuid}`}
+                alt={previewAttachment.filename}
+                style={{ maxWidth: '100%', maxHeight: '80vh', borderRadius: 8 }}
+              />
+              <div style={{ marginTop: 8, textAlign: 'center', color: 'rgba(255,255,255,0.8)', fontSize: 12 }}>
+                {previewAttachment.filename}
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function AttachmentChip({
+  attachment: a, ticketUuid, onPreview,
+}: {
+  attachment: SupportAttachment
+  ticketUuid: string
+  onPreview: (a: SupportAttachment) => void
+}) {
+  const [imgBroken, setImgBroken] = useState(false)
+  const isImage = a.file_type?.startsWith('image/') && !imgBroken
+  const downloadUrl = `/api/support/tickets/${ticketUuid}/attachments/${a.uuid}`
+
+  if (isImage) {
+    return (
+      <button
+        onClick={() => onPreview(a)}
+        title={a.filename}
+        style={{
+          padding: 0, border: '1px solid #e5e7eb', borderRadius: 'var(--ui-radius, 12px)',
+          overflow: 'hidden', cursor: 'pointer', background: 'none',
+        }}
+      >
+        <img
+          src={downloadUrl}
+          alt={a.filename}
+          onError={() => setImgBroken(true)}
+          style={{ display: 'block', maxWidth: 220, maxHeight: 160, objectFit: 'cover' }}
+        />
+      </button>
+    )
+  }
+
+  return (
+    <a
+      href={downloadUrl}
+      download={a.filename}
+      style={{
+        display: 'inline-flex', alignItems: 'center', gap: 6,
+        padding: '6px 10px', border: '1px solid #e5e7eb', borderRadius: 'var(--ui-radius, 12px)',
+        background: '#fff', color: '#2563eb', fontSize: 12, textDecoration: 'none',
+      }}
+    >
+      <Paperclip size={12} />
+      {a.filename}
+    </a>
+  )
+}

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -19,6 +19,7 @@ const Admin = lazy(() => import('./pages/Admin'))
 const Account = lazy(() => import('./pages/Account'))
 const Automation = lazy(() => import('./pages/Automation'))
 const Verification = lazy(() => import('./pages/Verification'))
+const SupportCenter = lazy(() => import('./pages/SupportCenter'))
 const Docs = lazy(() => import('./pages/Docs'))
 const Demo = lazy(() => import('./pages/Demo'))
 const DemoFeedback = lazy(() => import('./pages/DemoFeedback'))
@@ -217,6 +218,19 @@ const verificationRoute = createRoute({
   ),
 })
 
+const supportRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/support',
+  validateSearch: (search: Record<string, unknown>) => ({
+    ticket: (search.ticket as string) || undefined,
+  }),
+  component: () => (
+    <ProtectedRoute>
+      <SupportCenter />
+    </ProtectedRoute>
+  ),
+})
+
 const docsRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/docs',
@@ -308,6 +322,7 @@ const routeTree = rootRoute.addChildren([
   officeRoute,
   browserAutomationRoute,
   verificationRoute,
+  supportRoute,
   docsRoute,
   certificationRoute,
   demoRoute,


### PR DESCRIPTION
## Summary

- Splits the support UX into two single-purpose surfaces: the header floating panel stays as the agent answer-mode queue (unchanged), and a new `/support` page in the Teams dropdown becomes the customer-mode surface where support agents file their own tickets and QA the support flow.
- Removes the Support tab from the Admin panel; the new dropdown entry is gated by `user.is_support_agent`, which the backend already derives from `SystemConfig.support_contacts` in `/auth/me`. Adding someone as a support contact now flips both the menu and the API gates for them.
- Backend: `GET /support/tickets?scope=mine` returns the caller's own tickets even for support users, so the page can show a personal queue without changing what the floating panel sees.
- The existing `/support?ticket=X` deep link from notification emails now lands somewhere useful: own tickets open in the page chat view; foreign tickets hand off to the answering panel and clear the URL.

## UX layout

| Surface | Audience | Job |
|---|---|---|
| Header **Support** floating panel | non-agents | File tickets, track own threads (unchanged) |
| Header **Support** floating panel | support agents | Answer the global queue (unchanged) |
| Teams dropdown → **Support Center** (`/support`) | support agents only | File their own tickets / QA the support flow |

## Test plan

- [ ] As an admin, open the Teams dropdown — "Support Center" entry appears.
- [ ] As a non-admin user added to **Admin → Config → Support Contacts**, refresh and confirm the dropdown entry appears for them too.
- [ ] As a non-admin user not in support contacts, confirm the entry is hidden and `/support` redirects to `/`.
- [ ] As a support agent, click **Support Center** → file a new ticket with attachment → confirm it lands in the answering panel for other agents.
- [ ] Confirm the new ticket appears in *My Tickets* on `/support` and the agent's own messages render as customer-side (no "Support" badge).
- [ ] Confirm the floating panel is unchanged: agents still see the global queue, no New Ticket button, status controls still present.
- [ ] Open a notification email link `/support?ticket=<own>` → page opens that ticket. Open `/support?ticket=<other>` → answering panel opens with that ticket and URL clears.
- [ ] Verify Admin sidebar no longer lists Support Center.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
