### PR TITLE
Support ticket tags + default open filter

### DIFF
--- a/backend/app/models/support.py
+++ b/backend/app/models/support.py
@@ -74,6 +74,10 @@ class SupportTicket(Document):
     # Read tracking — user_ids who have viewed the ticket since the last message
     read_by: list[str] = []
 
+    # Tags applied by support agents — internal-only; never returned to the
+    # ticket owner or other non-support users.
+    tags: list[str] = []
+
     # Timestamps
     created_at: datetime.datetime = Field(
         default_factory=lambda: datetime.datetime.now(datetime.timezone.utc)
@@ -90,6 +94,7 @@ class SupportTicket(Document):
             "user_id",
             "status",
             "assigned_to",
+            "tags",
             [("status", 1), ("created_at", -1)],
             [("user_id", 1), ("created_at", -1)],
         ]

--- a/backend/app/routers/support.py
+++ b/backend/app/routers/support.py
@@ -28,6 +28,13 @@ class UpdateTicketRequest(BaseModel):
     status: str | None = None
     priority: str | None = None
     assigned_to: str | None = None
+    tags: list[str] | None = None
+
+
+def _strip_tags(payload: dict) -> dict:
+    """Remove the internal-only tags field — non-support callers must not see it."""
+    payload.pop("tags", None)
+    return payload
 
 
 # ---------------------------------------------------------------------------
@@ -75,8 +82,10 @@ async def create_ticket(
         team_id=team_id,
     )
 
+    is_support = await _is_support_user(user)
+
     if not file_payloads:
-        return ticket
+        return ticket if is_support else _strip_tags(ticket)
 
     initial_message_uuid = ticket["messages"][0]["uuid"] if ticket.get("messages") else None
     for filename, content_type, data in file_payloads:
@@ -91,12 +100,13 @@ async def create_ticket(
         if result is not None:
             ticket = result
 
-    return ticket
+    return ticket if is_support else _strip_tags(ticket)
 
 
 @router.get("/tickets")
 async def list_tickets(
     status: str | None = None,
+    tag: str | None = None,
     limit: int = 50,
     offset: int = 0,
     scope: str | None = None,
@@ -108,16 +118,21 @@ async def list_tickets(
     - ``scope=mine``: always return only the caller's own tickets, even for
       support users. Used by the Support Center page (where agents file QA
       tickets) so they see their personal queue, not the global one.
+    - ``tag``: filter to tickets carrying this tag. Tags are support-internal,
+      so this filter is ignored for non-support callers.
     """
     is_support = await _is_support_user(user)
+    effective_tag = tag if is_support else None
     if scope == "mine" or not is_support:
         tickets = await support_service.list_tickets(
-            user_id=user.user_id, status=status, limit=limit, offset=offset
+            user_id=user.user_id, status=status, tag=effective_tag, limit=limit, offset=offset
         )
     else:
         tickets = await support_service.list_all_tickets(
-            status=status, limit=limit, offset=offset
+            status=status, tag=effective_tag, limit=limit, offset=offset
         )
+    if not is_support:
+        tickets = [_strip_tags(t) for t in tickets]
     return {"tickets": tickets}
 
 
@@ -135,6 +150,8 @@ async def get_ticket(
     if ticket["user_id"] != user.user_id and not is_support:
         raise HTTPException(status_code=403, detail="Not authorized")
 
+    if not is_support:
+        _strip_tags(ticket)
     return ticket
 
 
@@ -173,7 +190,7 @@ async def add_message(
     )
     if not result:
         raise HTTPException(status_code=404, detail="Ticket not found")
-    return result
+    return result if is_support else _strip_tags(result)
 
 
 @router.post("/tickets/{ticket_uuid}/attachments")
@@ -203,7 +220,7 @@ async def add_attachment(
     )
     if not result:
         raise HTTPException(status_code=404, detail="Ticket not found")
-    return result
+    return result if is_support else _strip_tags(result)
 
 
 @router.get("/tickets/{ticket_uuid}/attachments/{attachment_uuid}")
@@ -255,6 +272,7 @@ async def update_ticket(
         status=body.status,
         priority=body.priority,
         assigned_to=body.assigned_to,
+        tags=body.tags,
     )
     if not result:
         raise HTTPException(status_code=404, detail="Ticket not found")
@@ -268,6 +286,15 @@ async def get_ticket_stats(user: User = Depends(get_current_user)):
     if not is_support:
         raise HTTPException(status_code=403, detail="Not authorized")
     return await support_service.get_ticket_stats()
+
+
+@router.get("/tags")
+async def list_tags(user: User = Depends(get_current_user)):
+    """Return distinct tags currently in use across tickets. Support users only."""
+    is_support = await _is_support_user(user)
+    if not is_support:
+        raise HTTPException(status_code=403, detail="Not authorized")
+    return {"tags": await support_service.list_all_tags()}
 
 
 @router.get("/contacts")

--- a/backend/app/services/support_service.py
+++ b/backend/app/services/support_service.py
@@ -97,6 +97,7 @@ def _ticket_to_dict(t: SupportTicket) -> dict:
         "updated_at": _iso_utc(t.updated_at),
         "closed_at": _iso_utc(t.closed_at),
         "category": t.category,
+        "tags": list(getattr(t, "tags", []) or []),
     }
 
 
@@ -124,6 +125,7 @@ def _ticket_summary(t: SupportTicket) -> dict:
         ),
         "read_by": t.read_by,
         "category": t.category,
+        "tags": list(getattr(t, "tags", []) or []),
         "created_at": _iso_utc(t.created_at),
         "updated_at": _iso_utc(t.updated_at),
         "closed_at": _iso_utc(t.closed_at),
@@ -178,6 +180,7 @@ async def list_tickets(
     user_id: str | None = None,
     status: str | None = None,
     assigned_to: str | None = None,
+    tag: str | None = None,
     limit: int = 50,
     offset: int = 0,
 ) -> list[dict]:
@@ -188,6 +191,8 @@ async def list_tickets(
         query["status"] = status
     if assigned_to:
         query["assigned_to"] = assigned_to
+    if tag:
+        query["tags"] = tag
 
     tickets = (
         await SupportTicket.find(query)
@@ -201,12 +206,15 @@ async def list_tickets(
 
 async def list_all_tickets(
     status: str | None = None,
+    tag: str | None = None,
     limit: int = 50,
     offset: int = 0,
 ) -> list[dict]:
     query: dict = {}
     if status:
         query["status"] = status
+    if tag:
+        query["tags"] = tag
     tickets = (
         await SupportTicket.find(query)
         .sort("-updated_at")
@@ -215,6 +223,12 @@ async def list_all_tickets(
         .to_list()
     )
     return [_ticket_summary(t) for t in tickets]
+
+
+async def list_all_tags() -> list[str]:
+    """Return every distinct tag in use across tickets, sorted."""
+    raw = await SupportTicket.get_motor_collection().distinct("tags")
+    return sorted({str(t) for t in raw if t})
 
 
 async def get_ticket(ticket_uuid: str) -> dict | None:
@@ -360,6 +374,7 @@ async def update_ticket(
     status: str | None = None,
     priority: str | None = None,
     assigned_to: str | None = None,
+    tags: list[str] | None = None,
 ) -> dict | None:
     ticket = await SupportTicket.find_one(SupportTicket.uuid == ticket_uuid)
     if not ticket:
@@ -375,6 +390,16 @@ async def update_ticket(
         ticket.priority = TicketPriority(priority)
     if assigned_to is not None:
         ticket.assigned_to = assigned_to or None
+    if tags is not None:
+        # Normalize: strip whitespace, drop empties, dedupe (preserve order)
+        seen: set[str] = set()
+        cleaned: list[str] = []
+        for raw in tags:
+            t = raw.strip()
+            if t and t not in seen:
+                seen.add(t)
+                cleaned.append(t)
+        ticket.tags = cleaned
 
     ticket.updated_at = datetime.datetime.now(datetime.timezone.utc)
     await ticket.save()

--- a/backend/tests/test_support_service_helpers.py
+++ b/backend/tests/test_support_service_helpers.py
@@ -74,6 +74,7 @@ def _ticket(messages=None, attachments=None) -> SimpleNamespace:
         attachments=attachments or [],
         read_by=["alice"],
         category="bug",
+        tags=[],
         created_at=datetime.datetime(2026, 3, 5, 9, 0, 0),
         updated_at=datetime.datetime(2026, 3, 5, 11, 0, 0),
         closed_at=None,

--- a/frontend/src/api/support.ts
+++ b/frontend/src/api/support.ts
@@ -31,12 +31,14 @@ export function listTickets(
   limit = 50,
   offset = 0,
   scope?: 'mine',
+  tag?: string,
 ) {
   const params = new URLSearchParams()
   if (status) params.set('status', status)
   params.set('limit', String(limit))
   params.set('offset', String(offset))
   if (scope) params.set('scope', scope)
+  if (tag) params.set('tag', tag)
   return apiFetch<{ tickets: SupportTicketSummary[] }>(
     `/api/support/tickets?${params}`,
   )
@@ -75,7 +77,7 @@ export async function addAttachment(
 
 export function updateTicket(
   ticketUuid: string,
-  updates: { status?: string; priority?: string; assigned_to?: string },
+  updates: { status?: string; priority?: string; assigned_to?: string; tags?: string[] },
 ) {
   return apiFetch<SupportTicket>(`/api/support/tickets/${ticketUuid}`, {
     method: 'PATCH',
@@ -95,4 +97,8 @@ export function getTicketStats() {
 
 export function getSupportContacts() {
   return apiFetch<{ contacts: SupportContact[] }>('/api/support/contacts')
+}
+
+export function listAllTags() {
+  return apiFetch<{ tags: string[] }>('/api/support/tags')
 }

--- a/frontend/src/pages/SupportCenter.tsx
+++ b/frontend/src/pages/SupportCenter.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState, useCallback, useRef } from 'react'
 import { Navigate, useNavigate, useSearch } from '@tanstack/react-router'
 import {
-  ArrowLeft, MessageSquare, Send, Plus, Paperclip, X, Loader2, Link2,
+  ArrowLeft, MessageSquare, Send, Plus, Paperclip, X, Loader2, Link2, Tag,
 } from 'lucide-react'
 import { PageLayout } from '../components/layout/PageLayout'
 import { useAuth } from '../hooks/useAuth'
@@ -47,7 +47,10 @@ export default function SupportCenter() {
   const [view, setView] = useState<View>('list')
   const [tickets, setTickets] = useState<SupportTicketSummary[]>([])
   const [stats, setStats] = useState<Stats | null>(null)
-  const [statusFilter, setStatusFilter] = useState<StatusFilter>('all')
+  // Default to "open" — agents care about the active queue, not the archive.
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>('open')
+  const [tagFilter, setTagFilter] = useState<string>('')
+  const [allTags, setAllTags] = useState<string[]>([])
   const [loading, setLoading] = useState(true)
   const [activeTicketUuid, setActiveTicketUuid] = useState<string | null>(null)
 
@@ -55,18 +58,21 @@ export default function SupportCenter() {
     setLoading(true)
     try {
       const statusParam = statusFilter === 'all' ? undefined : statusFilter
-      const [s, t] = await Promise.all([
+      const tagParam = tagFilter || undefined
+      const [s, t, tagList] = await Promise.all([
         supportApi.getTicketStats(),
-        supportApi.listTickets(statusParam, 200),
+        supportApi.listTickets(statusParam, 200, 0, undefined, tagParam),
+        supportApi.listAllTags(),
       ])
       setStats(s)
       setTickets(t.tickets)
+      setAllTags(tagList.tags)
     } catch {
       toast('Failed to load tickets', 'error')
     } finally {
       setLoading(false)
     }
-  }, [toast, statusFilter])
+  }, [toast, statusFilter, tagFilter])
 
   useEffect(() => { load() }, [load])
 
@@ -108,6 +114,9 @@ export default function SupportCenter() {
           loading={loading}
           statusFilter={statusFilter}
           onStatusFilterChange={setStatusFilter}
+          tagFilter={tagFilter}
+          onTagFilterChange={setTagFilter}
+          allTags={allTags}
           currentUserId={user.user_id}
           onNew={() => setView('new')}
           onSelect={openTicket}
@@ -138,13 +147,18 @@ export default function SupportCenter() {
 // ---------------------------------------------------------------------------
 
 function ListView({
-  tickets, stats, loading, statusFilter, onStatusFilterChange, currentUserId, onNew, onSelect,
+  tickets, stats, loading, statusFilter, onStatusFilterChange,
+  tagFilter, onTagFilterChange, allTags,
+  currentUserId, onNew, onSelect,
 }: {
   tickets: SupportTicketSummary[]
   stats: Stats | null
   loading: boolean
   statusFilter: StatusFilter
   onStatusFilterChange: (s: StatusFilter) => void
+  tagFilter: string
+  onTagFilterChange: (t: string) => void
+  allTags: string[]
   currentUserId: string
   onNew: () => void
   onSelect: (uuid: string) => void
@@ -203,24 +217,43 @@ function ListView({
 
       {/* Ticket list */}
       <div style={{ background: '#fff', border: '1px solid #e5e7eb', borderRadius: 'var(--ui-radius, 12px)', overflow: 'hidden' }}>
-        <div style={{ padding: '14px 20px', borderBottom: '1px solid #e5e7eb', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        <div style={{ padding: '14px 20px', borderBottom: '1px solid #e5e7eb', display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 12, flexWrap: 'wrap' }}>
           <div style={{ fontSize: 15, fontWeight: 600 }}>Tickets</div>
-          <div style={{ display: 'flex', gap: 4 }}>
-            {(['all', 'open', 'in_progress', 'closed'] as StatusFilter[]).map(s => (
-              <button
-                key={s}
-                onClick={() => onStatusFilterChange(s)}
+          <div style={{ display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap' }}>
+            <div style={{ display: 'flex', gap: 4 }}>
+              {(['all', 'open', 'in_progress', 'closed'] as StatusFilter[]).map(s => (
+                <button
+                  key={s}
+                  onClick={() => onStatusFilterChange(s)}
+                  style={{
+                    padding: '4px 12px', fontSize: 12, fontWeight: statusFilter === s ? 600 : 400,
+                    borderRadius: 9999, border: '1px solid #e5e7eb', cursor: 'pointer',
+                    background: statusFilter === s ? '#111827' : '#fff',
+                    color: statusFilter === s ? '#fff' : '#6b7280',
+                    fontFamily: 'inherit',
+                  }}
+                >
+                  {s === 'in_progress' ? 'In Progress' : s.charAt(0).toUpperCase() + s.slice(1)}
+                </button>
+              ))}
+            </div>
+            <div style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+              <Tag size={12} color="#6b7280" />
+              <select
+                value={tagFilter}
+                onChange={(e) => onTagFilterChange(e.target.value)}
                 style={{
-                  padding: '4px 12px', fontSize: 12, fontWeight: statusFilter === s ? 600 : 400,
-                  borderRadius: 9999, border: '1px solid #e5e7eb', cursor: 'pointer',
-                  background: statusFilter === s ? '#111827' : '#fff',
-                  color: statusFilter === s ? '#fff' : '#6b7280',
-                  fontFamily: 'inherit',
+                  padding: '4px 8px', fontSize: 12, border: '1px solid #e5e7eb',
+                  borderRadius: 9999, background: '#fff', color: tagFilter ? '#111827' : '#6b7280',
+                  cursor: 'pointer', fontFamily: 'inherit',
                 }}
               >
-                {s === 'in_progress' ? 'In Progress' : s.charAt(0).toUpperCase() + s.slice(1)}
-              </button>
-            ))}
+                <option value="">All tags</option>
+                {allTags.map((t) => (
+                  <option key={t} value={t}>{t}</option>
+                ))}
+              </select>
+            </div>
           </div>
         </div>
 
@@ -275,6 +308,17 @@ function ListView({
                       }}>
                         {t.priority}
                       </span>
+                      {(t.tags ?? []).map((tag) => (
+                        <span
+                          key={tag}
+                          style={{
+                            fontSize: 11, padding: '1px 6px', borderRadius: 9999,
+                            background: '#eef2ff', color: '#4338ca', fontWeight: 500,
+                          }}
+                        >
+                          {tag}
+                        </span>
+                      ))}
                     </div>
                     <div style={{ fontSize: 12, color: '#9ca3af', marginTop: 4, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
                       {t.user_name || t.user_id} &middot; {t.message_count} message{t.message_count !== 1 ? 's' : ''}
@@ -663,6 +707,19 @@ function ChatView({
           </div>
         </div>
 
+        {/* Tag editor — internal-only; ticket owner never sees these */}
+        <TagEditor
+          tags={ticket.tags ?? []}
+          onChange={async (next) => {
+            try {
+              const updated = await supportApi.updateTicket(ticketUuid, { tags: next })
+              setTicket(updated)
+            } catch {
+              toast('Failed to update tags', 'error')
+            }
+          }}
+        />
+
         {/* Messages — agent on right (blue, "Support" label), customer on left */}
         <div style={{ padding: 20, display: 'flex', flexDirection: 'column', gap: 12, maxHeight: 520, overflowY: 'auto' }}>
           {ticket.messages.map((m) => {
@@ -824,5 +881,101 @@ function AttachmentChip({
       <Paperclip size={12} />
       {a.filename}
     </a>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Tag editor — agent-only chips with add/remove
+// ---------------------------------------------------------------------------
+
+function TagEditor({
+  tags, onChange,
+}: {
+  tags: string[]
+  onChange: (next: string[]) => void
+}) {
+  const [draft, setDraft] = useState('')
+  const [adding, setAdding] = useState(false)
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  const commit = () => {
+    const t = draft.trim()
+    if (!t) { setDraft(''); setAdding(false); return }
+    if (tags.includes(t)) { setDraft(''); setAdding(false); return }
+    onChange([...tags, t])
+    setDraft('')
+    setAdding(false)
+  }
+
+  const remove = (t: string) => {
+    onChange(tags.filter((x) => x !== t))
+  }
+
+  return (
+    <div style={{
+      padding: '8px 20px', borderBottom: '1px solid #e5e7eb', background: '#fafafa',
+      display: 'flex', alignItems: 'center', gap: 6, flexWrap: 'wrap',
+    }}>
+      <Tag size={12} color="#6b7280" />
+      <span style={{ fontSize: 11, color: '#6b7280', fontWeight: 600, marginRight: 4 }}>
+        Tags
+      </span>
+      {tags.length === 0 && !adding && (
+        <span style={{ fontSize: 12, color: '#9ca3af' }}>None</span>
+      )}
+      {tags.map((t) => (
+        <span
+          key={t}
+          style={{
+            display: 'inline-flex', alignItems: 'center', gap: 4,
+            fontSize: 12, padding: '2px 4px 2px 8px', borderRadius: 9999,
+            background: '#eef2ff', color: '#4338ca', fontWeight: 500,
+          }}
+        >
+          {t}
+          <button
+            onClick={() => remove(t)}
+            title={`Remove ${t}`}
+            style={{
+              display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+              width: 16, height: 16, padding: 0, border: 'none', background: 'none',
+              color: '#4338ca', cursor: 'pointer', borderRadius: 9999,
+            }}
+          >
+            <X size={10} />
+          </button>
+        </span>
+      ))}
+      {adding ? (
+        <input
+          ref={inputRef}
+          value={draft}
+          autoFocus
+          onChange={(e) => setDraft(e.target.value)}
+          onBlur={commit}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') { e.preventDefault(); commit() }
+            if (e.key === 'Escape') { setDraft(''); setAdding(false) }
+          }}
+          placeholder="tag…"
+          style={{
+            fontSize: 12, padding: '2px 8px', border: '1px solid #d1d5db',
+            borderRadius: 9999, outline: 'none', minWidth: 80, fontFamily: 'inherit',
+          }}
+        />
+      ) : (
+        <button
+          onClick={() => setAdding(true)}
+          style={{
+            display: 'inline-flex', alignItems: 'center', gap: 3,
+            fontSize: 12, padding: '2px 8px', borderRadius: 9999,
+            border: '1px dashed #d1d5db', background: 'transparent', color: '#6b7280',
+            cursor: 'pointer', fontFamily: 'inherit',
+          }}
+        >
+          <Plus size={10} /> Add tag
+        </button>
+      )}
+    </div>
   )
 }

--- a/frontend/src/types/support.ts
+++ b/frontend/src/types/support.ts
@@ -27,6 +27,8 @@ export interface SupportTicket {
   team_id: string | null
   assigned_to: string | null
   category: string | null
+  // Only present for support agents — backend strips this for ticket owners.
+  tags?: string[]
   messages: SupportMessage[]
   attachments: SupportAttachment[]
   message_count: number
@@ -44,6 +46,8 @@ export interface SupportTicketSummary {
   user_name: string | null
   assigned_to: string | null
   category: string | null
+  // Only present for support agents — backend strips this for ticket owners.
+  tags?: string[]
   message_count: number
   last_message_preview: string | null
   last_message_at: string | null


### PR DESCRIPTION
## Summary
- Support agents can now tag tickets and filter the queue by tag from the Support Center.
- Tags are agent-internal: the backend strips them from any response served to non-support callers, so ticket owners never see them and the `tag` query filter is ignored for non-agents.
- Default the Support Center list to **Open** instead of **All** so agents land on the active queue.

## Changes
**Backend**
- `SupportTicket.tags: list[str]` (+ Mongo index).
- `list_tickets` / `list_all_tickets` accept a `tag` filter; `update_ticket` accepts `tags` (whitespace-stripped, deduped, order preserved).
- New `GET /api/support/tags` (support-only) for the filter dropdown.
- Router applies `_strip_tags()` to every ticket response served to a non-support caller (`GET /tickets`, `GET /tickets/{uuid}`, `POST /tickets`, `POST /tickets/{uuid}/messages`, `POST /tickets/{uuid}/attachments`).

**Frontend**
- `tags?: string[]` on `SupportTicket` / `SupportTicketSummary` (optional because the backend strips it for non-agents).
- `listTickets(..., tag?)`, `updateTicket({ tags })`, and `listAllTags()` in the API client.
- `SupportCenter`:
  - Default status filter is now `open`.
  - Tag dropdown next to the status pills, populated from `/api/support/tags`.
  - Indigo tag chips on each ticket row.
  - `TagEditor` strip in the ticket header — add via Enter/blur, Esc to cancel, X to remove.

The customer-facing `SupportChatPanel` is untouched; it can't display tags because the backend never sends them to non-agents.

## Test plan
- [ ] As a support agent, open the Support Center and confirm the list defaults to Open tickets.
- [ ] Open a ticket, add a couple of tags, refresh — tags persist.
- [ ] Select a tag in the filter dropdown — the list narrows to tickets with that tag.
- [ ] As a non-agent user, open one of your own tickets — confirm no `tags` field is returned and no tag UI is shown.
- [ ] Hit `GET /api/support/tags` as a non-agent — expect 403.
- [ ] Verify removing all tags from a ticket clears them and the tag filter dropdown updates after refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
