### PR TITLE
Open support ticket in chat panel on every notification click

### DIFF
--- a/frontend/src/components/support/SupportChatPanel.tsx
+++ b/frontend/src/components/support/SupportChatPanel.tsx
@@ -722,10 +722,8 @@ export function SupportChatPanel({
     return () => clearInterval(interval)
   }, [open, loadTickets])
 
-  // Sync with the ticket the parent asked to open. A notification click
-  // dispatches `open-support-panel` with a ticket uuid; without this effect
-  // we'd only honor it on first mount and subsequent clicks would just
-  // reveal the panel on whatever view it was last on.
+  // Sync with the ticket the parent asked to open. Used by the feedback
+  // prompt and Support button flows that drive `initialTicket` via state.
   useEffect(() => {
     if (!open) return
     if (initialTicket) {
@@ -736,6 +734,24 @@ export function SupportChatPanel({
       setView('list')
     }
   }, [open, initialTicket])
+
+  // Also listen for `open-support-panel` events directly. The parent only
+  // sees a state change when the event's ticket uuid differs from what it
+  // was last asked to open — so re-clicking the same notification after the
+  // user has navigated back to the list would otherwise be a no-op. Reading
+  // the event ourselves lets every click jump back to the ticket.
+  useEffect(() => {
+    const handler = (e: Event) => {
+      const detail = (e as CustomEvent).detail
+      const ticketUuid = detail?.ticketUuid
+      if (ticketUuid) {
+        setActiveTicket(ticketUuid)
+        setView('chat')
+      }
+    }
+    window.addEventListener('open-support-panel', handler)
+    return () => window.removeEventListener('open-support-panel', handler)
+  }, [])
 
   // Close on Escape
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Clicking a ticket alert in the notification bell now reliably opens that ticket inside the chat panel — previously, re-clicking a notification after the user had navigated back to the list view was a no-op.
- Root cause: the panel synced the requested ticket through an `[open, initialTicket]` effect on parent state. After the panel was open with `supportTicket='A'` and the user pressed Back, parent state was unchanged, so re-clicking the same notification didn't trigger the effect.
- Fix: `SupportChatPanel` now listens for `open-support-panel` events directly, so each dispatch unconditionally sets `view='chat'` and `activeTicket=ticketUuid`, regardless of parent state. The existing `initialTicket` prop sync stays in place for the feedback-prompt and Support-button flows.

## Test plan
- [ ] Click bell → click a ticket alert → panel opens to that ticket in chat view
- [ ] Inside the panel, click Back → list view → click bell → click the same alert → panel jumps back to the ticket
- [ ] Click bell → click alert for ticket A → click bell → click alert for ticket B → panel switches from A to B
- [ ] Open panel via Support button (no ticket) → list view shows; nothing regresses
- [ ] Feedback-prompt flow still opens the prompt ticket directly

Generated with [Claude Code](https://claude.com/claude-code)
