### PR TITLE
Add real Word (.docx) download for workflow results

### DIFF
--- a/backend/app/routers/workflows.py
+++ b/backend/app/routers/workflows.py
@@ -128,6 +128,158 @@ def _pdf_safe(value) -> str:
     return text.encode("latin-1", errors="replace").decode("latin-1")
 
 
+_INLINE_BOLD = re.compile(r"\*\*(.+?)\*\*")
+_INLINE_ITALIC = re.compile(r"(?<!\*)\*(?!\*)(.+?)(?<!\*)\*(?!\*)")
+_INLINE_CODE = re.compile(r"`(.+?)`")
+_MD_LINK = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
+
+
+def _add_runs_with_formatting(paragraph, text: str) -> None:
+    """Add runs to a docx paragraph, parsing inline **bold**, *italic*, `code`, [link](url)."""
+    # Drop markdown link syntax — keep the visible text only (URLs in LLM output
+    # are often hallucinated and useless in a Word doc).
+    text = _MD_LINK.sub(r"\1", text)
+
+    pos = 0
+    # Combined scan: find the next inline marker and emit the preceding plain run.
+    while pos < len(text):
+        next_match = None
+        next_kind = None
+        for kind, pattern in (("bold", _INLINE_BOLD), ("code", _INLINE_CODE), ("italic", _INLINE_ITALIC)):
+            m = pattern.search(text, pos)
+            if m and (next_match is None or m.start() < next_match.start()):
+                next_match = m
+                next_kind = kind
+        if next_match is None:
+            paragraph.add_run(text[pos:])
+            return
+        if next_match.start() > pos:
+            paragraph.add_run(text[pos:next_match.start()])
+        run = paragraph.add_run(next_match.group(1))
+        if next_kind == "bold":
+            run.bold = True
+        elif next_kind == "italic":
+            run.italic = True
+        elif next_kind == "code":
+            run.font.name = "Consolas"
+        pos = next_match.end()
+
+
+def _markdown_to_docx(text: str):
+    """Render a markdown-ish string into a python-docx Document.
+
+    Handles ATX headings, unordered/ordered lists, blank-line paragraphs, and
+    inline bold/italic/code. Unknown syntax falls back to a plain paragraph.
+    """
+    from docx import Document
+    from docx.shared import Inches, Pt
+
+    doc = Document()
+    for section in doc.sections:
+        section.top_margin = Inches(1)
+        section.bottom_margin = Inches(1)
+        section.left_margin = Inches(1)
+        section.right_margin = Inches(1)
+
+    style = doc.styles["Normal"]
+    style.font.name = "Arial"
+    style.font.size = Pt(11)
+
+    lines = (text or "").splitlines()
+    for raw in lines:
+        line = raw.rstrip()
+        if not line.strip():
+            doc.add_paragraph()
+            continue
+
+        heading = re.match(r"^(#{1,6})\s+(.+)$", line)
+        if heading:
+            level = min(len(heading.group(1)), 4)
+            doc.add_heading(heading.group(2).strip(), level=level)
+            continue
+
+        bullet = re.match(r"^\s*[-*+]\s+(.+)$", line)
+        if bullet:
+            p = doc.add_paragraph(style="List Bullet")
+            _add_runs_with_formatting(p, bullet.group(1).strip())
+            continue
+
+        numbered = re.match(r"^\s*\d+\.\s+(.+)$", line)
+        if numbered:
+            p = doc.add_paragraph(style="List Number")
+            _add_runs_with_formatting(p, numbered.group(1).strip())
+            continue
+
+        p = doc.add_paragraph()
+        _add_runs_with_formatting(p, line)
+
+    return doc
+
+
+def _data_to_docx_bytes(data) -> bytes:
+    """Serialize workflow output (str/dict/list) to a .docx byte payload."""
+    from docx import Document
+    from docx.shared import Inches, Pt
+
+    if isinstance(data, str):
+        try:
+            parsed = json.loads(data)
+        except (json.JSONDecodeError, ValueError):
+            parsed = None
+        if isinstance(parsed, (dict, list)):
+            data = parsed
+
+    if isinstance(data, str):
+        doc = _markdown_to_docx(data)
+    elif isinstance(data, list) and data and isinstance(data[0], dict):
+        doc = Document()
+        for section in doc.sections:
+            section.top_margin = section.bottom_margin = Inches(1)
+            section.left_margin = section.right_margin = Inches(1)
+        doc.styles["Normal"].font.name = "Arial"
+        doc.styles["Normal"].font.size = Pt(11)
+        headers = list(dict.fromkeys(k for row in data for k in row.keys()))
+        table = doc.add_table(rows=1, cols=len(headers))
+        table.style = "Light Grid Accent 1"
+        hdr_cells = table.rows[0].cells
+        for i, h in enumerate(headers):
+            hdr_cells[i].text = str(h)
+            for run in hdr_cells[i].paragraphs[0].runs:
+                run.bold = True
+        for row in data:
+            cells = table.add_row().cells
+            for i, h in enumerate(headers):
+                val = row.get(h, "")
+                cells[i].text = json.dumps(val, default=str) if isinstance(val, (dict, list)) else str(val if val is not None else "")
+    elif isinstance(data, dict):
+        doc = Document()
+        for section in doc.sections:
+            section.top_margin = section.bottom_margin = Inches(1)
+            section.left_margin = section.right_margin = Inches(1)
+        doc.styles["Normal"].font.name = "Arial"
+        doc.styles["Normal"].font.size = Pt(11)
+        table = doc.add_table(rows=1, cols=2)
+        table.style = "Light Grid Accent 1"
+        hdr = table.rows[0].cells
+        hdr[0].text = "Field"
+        hdr[1].text = "Value"
+        for cell in hdr:
+            for run in cell.paragraphs[0].runs:
+                run.bold = True
+        for k, v in data.items():
+            cells = table.add_row().cells
+            cells[0].text = str(k)
+            cells[1].text = json.dumps(v, default=str) if isinstance(v, (dict, list)) else str(v)
+    elif isinstance(data, list):
+        doc = _markdown_to_docx("\n".join(f"- {item}" for item in data))
+    else:
+        doc = _markdown_to_docx("" if data is None else str(data))
+
+    buf = io.BytesIO()
+    doc.save(buf)
+    return buf.getvalue()
+
+
 async def _authorize_documents(document_uuids: list[str], user: User) -> list[str]:
     team_access = await access_control.get_team_access_context(user)
     authorized: list[str] = []
@@ -468,6 +620,14 @@ async def download_results(
             pdf_buf,
             media_type="application/pdf",
             headers={"Content-Disposition": 'attachment; filename="results.pdf"'},
+        )
+
+    if format == "docx":
+        docx_bytes = _data_to_docx_bytes(output_data)
+        return StreamingResponse(
+            io.BytesIO(docx_bytes),
+            media_type="application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            headers={"Content-Disposition": 'attachment; filename="results.docx"'},
         )
 
     # Default: JSON

--- a/frontend/src/components/workspace/WorkflowEditorPanel.tsx
+++ b/frontend/src/components/workspace/WorkflowEditorPanel.tsx
@@ -3491,6 +3491,7 @@ function WorkflowOutputCard({ status, sessionId, running, runElapsed, showDownlo
                   { fmt: 'csv', label: 'CSV', desc: 'Spreadsheet format', parseStructured: false },
                   { fmt: 'csv', label: 'CSV (parse structured)', desc: 'Detect JSON/tables in prompt output', parseStructured: true },
                   { fmt: 'pdf', label: 'PDF', desc: 'Printable report', parseStructured: false },
+                  { fmt: 'docx', label: 'Word (.docx)', desc: 'Editable document', parseStructured: false },
                   { fmt: 'text', label: 'Plain Text', desc: 'Raw text output', parseStructured: false },
                 ] as const).map(({ fmt, label, desc, parseStructured }) => (
                   <a


### PR DESCRIPTION
## Summary

- Workflow output download dropdown previously offered JSON, CSV, PDF, and Plain Text — but no Word format. When users asked the LLM for a Word doc anyway, the model hallucinated a markdown link (`[Download Document.docx](...)`) that pointed nowhere; clicking it did nothing.
- Added a real `Word (.docx)` option to the download dropdown, backed by `python-docx` (already a project dependency). Renders headings, ordered/unordered lists, paragraph blocks, and inline `**bold**` / `*italic*` / `` `code` `` from markdown, with 11pt Arial body and 1-inch margins. Dict and `list[dict]` outputs render as a table (mirrors the PDF path).
- Hallucinated `[text](url)` links are stripped of their URL — only the visible label remains in the doc, so the result no longer ships with broken hyperlinks.

## Test plan

- [ ] Run any workflow that produces a markdown text result, click `Download → Word (.docx)`, open the file in Word and confirm headings/bullets/inline formatting render correctly with 11pt Arial and 1-inch margins.
- [ ] Run a workflow whose `final_output.output` is a `dict` or `list[dict]` — confirm the .docx contains a styled table with one column per key.
- [ ] Spot-check that an LLM output containing a fake markdown link like `[Download X.docx](http://nope)` renders the visible text only (no broken hyperlink).
- [ ] Existing JSON / CSV / PDF / Plain Text downloads still work unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)