### PR TITLE
Show "Select a document to run" hint above muted Run button

### DIFF
--- a/frontend/src/components/workspace/WorkflowEditorPanel.tsx
+++ b/frontend/src/components/workspace/WorkflowEditorPanel.tsx
@@ -786,6 +786,12 @@ export function WorkflowEditorPanel() {
             </label>
           )
         )}
+        {!isTextInput && selectedDocUuids.length === 0 && (
+          <div style={{ fontSize: 12, color: '#6b7280', marginBottom: 10, display: 'flex', alignItems: 'center', gap: 4 }}>
+            <FileText style={{ width: 12, height: 12 }} />
+            Select a document to run this workflow
+          </div>
+        )}
         <button
           onClick={handleRun}
           disabled={runner.running || (isTextInput ? !textInput.trim() : selectedDocUuids.length === 0)}


### PR DESCRIPTION
## Summary
- Document-selection-triggered workflows muted the Run button until a document was selected, with no on-screen explanation. Users tried clicking and got no feedback.
- Adds a one-line helper ("Select a document to run this workflow") above the Run button, shown only when the workflow expects a document and none is selected.
- Uses the existing 12px / `#6b7280` helper-text style and `FileText` icon already in use elsewhere in the toolbar — no new dependencies.

## Test plan
- [ ] Open a document-selection workflow with no documents selected → hint visible above the muted Run button.
- [ ] Select one or more documents → hint disappears, Run button activates.
- [ ] Switch to a text-input workflow → hint never appears regardless of selection state.
- [ ] With >1 docs selected, the existing "Run per document" checkbox still renders correctly (mutually exclusive with the hint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)