### PR TITLE
Surface workflow JSON import on the Workflows page

### DIFF
--- a/frontend/src/hooks/useWorkflows.ts
+++ b/frontend/src/hooks/useWorkflows.ts
@@ -29,6 +29,11 @@ export function useWorkflows() {
     onSuccess: () => qc.invalidateQueries({ queryKey }),
   })
 
+  const importMutation = useMutation({
+    mutationFn: (file: File) => api.importWorkflow(file),
+    onSuccess: () => qc.invalidateQueries({ queryKey }),
+  })
+
   const create = async (name: string) => {
     return createMutation.mutateAsync({ name })
   }
@@ -41,5 +46,9 @@ export function useWorkflows() {
     return duplicateMutation.mutateAsync(id)
   }
 
-  return { workflows, loading, refresh, create, remove, duplicate }
+  const importFromFile = async (file: File) => {
+    return importMutation.mutateAsync(file)
+  }
+
+  return { workflows, loading, refresh, create, remove, duplicate, importFromFile }
 }

--- a/frontend/src/pages/Workflows.tsx
+++ b/frontend/src/pages/Workflows.tsx
@@ -1,19 +1,23 @@
-import { useMemo, useState } from 'react'
+import { useMemo, useRef, useState } from 'react'
 import { useNavigate } from '@tanstack/react-router'
 import { Plus, Copy, Trash2, Search, ArrowUpDown } from 'lucide-react'
 import { PageLayout } from '../components/layout/PageLayout'
 import { useWorkflows } from '../hooks/useWorkflows'
+import { useToast } from '../contexts/ToastContext'
 
 type SortKey = 'name' | 'runs' | 'steps'
 
 export default function Workflows() {
   const navigate = useNavigate()
-  const { workflows, loading, create, remove, duplicate } = useWorkflows()
+  const { workflows, loading, create, remove, duplicate, importFromFile } = useWorkflows()
+  const { toast } = useToast()
   const [newName, setNewName] = useState('')
   const [creating, setCreating] = useState(false)
+  const [importing, setImporting] = useState(false)
   const [search, setSearch] = useState('')
   const [sortBy, setSortBy] = useState<SortKey>('name')
   const [sortAsc, setSortAsc] = useState(true)
+  const fileInputRef = useRef<HTMLInputElement>(null)
 
   const filtered = useMemo(() => {
     let list = workflows
@@ -45,6 +49,19 @@ export default function Workflows() {
     }
   }
 
+  const handleImportFile = async (file: File) => {
+    setImporting(true)
+    try {
+      const wf = await importFromFile(file)
+      toast(`Imported "${wf.name}"`, 'success')
+      navigate({ to: '/workflows/$id', params: { id: wf.id } })
+    } catch (err) {
+      toast(err instanceof Error ? err.message : 'Import failed', 'error')
+    } finally {
+      setImporting(false)
+    }
+  }
+
   const toggleSort = (key: SortKey) => {
     if (sortBy === key) setSortAsc(!sortAsc)
     else { setSortBy(key); setSortAsc(true) }
@@ -59,23 +76,45 @@ export default function Workflows() {
         </div>
 
         {/* Create new */}
-        <div className="flex gap-2 mb-4">
-          <input
-            type="text"
-            value={newName}
-            onChange={e => setNewName(e.target.value)}
-            onKeyDown={e => e.key === 'Enter' && handleCreate()}
-            placeholder="New workflow name..."
-            className="flex-1 px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-highlight"
-          />
-          <button
-            onClick={handleCreate}
-            disabled={creating || !newName.trim()}
-            className="flex items-center gap-1 px-4 py-2 bg-highlight text-highlight-text rounded-lg text-sm font-bold hover:brightness-90 disabled:opacity-50"
-          >
-            <Plus size={16} />
-            Create
-          </button>
+        <div className="mb-4">
+          <div className="flex gap-2">
+            <input
+              type="text"
+              value={newName}
+              onChange={e => setNewName(e.target.value)}
+              onKeyDown={e => e.key === 'Enter' && handleCreate()}
+              placeholder="New workflow name..."
+              className="flex-1 px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-highlight"
+            />
+            <button
+              onClick={handleCreate}
+              disabled={creating || !newName.trim()}
+              className="flex items-center gap-1 px-4 py-2 bg-highlight text-highlight-text rounded-lg text-sm font-bold hover:brightness-90 disabled:opacity-50"
+            >
+              <Plus size={16} />
+              Create
+            </button>
+          </div>
+          <div className="mt-1.5 text-xs text-gray-400">
+            <button
+              onClick={() => fileInputRef.current?.click()}
+              disabled={importing}
+              className="hover:text-gray-600 hover:underline disabled:opacity-50"
+            >
+              {importing ? 'Importing...' : 'or import from JSON'}
+            </button>
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept=".json,application/json"
+              className="hidden"
+              onChange={e => {
+                const f = e.target.files?.[0]
+                if (f) handleImportFile(f)
+                e.target.value = ''
+              }}
+            />
+          </div>
         </div>
 
         {/* Search & Sort */}


### PR DESCRIPTION
## Summary
- User feedback: "Add an option to upload a JSON when creating a workflow." The full import pipeline already existed end-to-end (`POST /api/workflows/import`, service-layer ID/ownership rewriting, `importWorkflow` in the frontend API client) but had **zero UI callers** — exports from a teammate had no way back in.
- Adds a small gray "or import from JSON" link directly below the Create row on the Workflows page. Clicking opens a hidden file picker; on selection, calls the existing import endpoint, toasts the result, and navigates to the new workflow.
- Treated as a power-user affordance, not a primary CTA — equal billing with Create would be visual noise for the 95% of users who never receive a JSON export.

## Test plan
- [ ] Click "or import from JSON", pick a `.vandalizer.json` file → success toast, lands in the new workflow editor with the imported steps.
- [ ] Try importing an invalid/corrupt JSON file → error toast with the backend's detail message; no navigation.
- [ ] Confirm the link is visually subordinate to the "Create" button (small, gray, underlines on hover).
- [ ] Verify ownership: imported workflow is scoped to the current user's `team_id` (handled by existing service code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
