### PR TITLE
Email other support agents when a ticket tag is added

### DIFF
--- a/backend/app/routers/support.py
+++ b/backend/app/routers/support.py
@@ -273,6 +273,7 @@ async def update_ticket(
         priority=body.priority,
         assigned_to=body.assigned_to,
         tags=body.tags,
+        actor=user,
     )
     if not result:
         raise HTTPException(status_code=404, detail="Ticket not found")

--- a/backend/app/services/email_service.py
+++ b/backend/app/services/email_service.py
@@ -409,6 +409,37 @@ def support_new_message_email(
     return subject, html
 
 
+def support_tag_added_email(
+    support_name: str,
+    ticket_subject: str,
+    ticket_user: str,
+    added_tags: list[str],
+    actor_name: str,
+    ticket_uuid: str,
+    frontend_url: str,
+) -> tuple[str, str]:
+    """Returns (subject, html_body) when a support agent adds tag(s) to a ticket."""
+    tag_list = ", ".join(added_tags)
+    plural = "s" if len(added_tags) != 1 else ""
+    subject = f"Tag{plural} added to ticket: {ticket_subject}"
+    tag_pills = "".join(
+        f'<span style="display:inline-block;background:#f1b300;color:#000;'
+        f'font-weight:600;font-size:13px;padding:3px 10px;border-radius:12px;'
+        f'margin:0 6px 6px 0;">{t}</span>'
+        for t in added_tags
+    )
+    html = f"""<!DOCTYPE html><html><head>{_BASE_STYLE}</head><body>
+    <div class="container"><div class="card">
+      <div class="logo">Vandalizer Support</div>
+      <h1>Tag{plural} added to a ticket</h1>
+      <p>Hi {support_name}, <span class="highlight">{actor_name}</span> added tag{plural} <strong style="color:#fff">{tag_list}</strong> to ticket <strong style="color:#fff">{ticket_subject}</strong> (from {ticket_user}).</p>
+      <div style="margin:16px 0;">{tag_pills}</div>
+      <p style="margin-top:24px"><a class="btn" href="{frontend_url}/support?ticket={ticket_uuid}">View Ticket</a></p>
+      <div class="footer">Vandalizer Support System</div>
+    </div></div></body></html>"""
+    return subject, html
+
+
 # ---------------------------------------------------------------------------
 # Approval request emails
 # ---------------------------------------------------------------------------

--- a/backend/app/services/support_service.py
+++ b/backend/app/services/support_service.py
@@ -375,6 +375,7 @@ async def update_ticket(
     priority: str | None = None,
     assigned_to: str | None = None,
     tags: list[str] | None = None,
+    actor: User | None = None,
 ) -> dict | None:
     ticket = await SupportTicket.find_one(SupportTicket.uuid == ticket_uuid)
     if not ticket:
@@ -390,6 +391,7 @@ async def update_ticket(
         ticket.priority = TicketPriority(priority)
     if assigned_to is not None:
         ticket.assigned_to = assigned_to or None
+    added_tags: list[str] = []
     if tags is not None:
         # Normalize: strip whitespace, drop empties, dedupe (preserve order)
         seen: set[str] = set()
@@ -399,6 +401,8 @@ async def update_ticket(
             if t and t not in seen:
                 seen.add(t)
                 cleaned.append(t)
+        prev = set(ticket.tags or [])
+        added_tags = [t for t in cleaned if t not in prev]
         ticket.tags = cleaned
 
     ticket.updated_at = datetime.datetime.now(datetime.timezone.utc)
@@ -418,6 +422,10 @@ async def update_ticket(
         )
         # Email the ticket owner about status change
         await _email_ticket_owner_status(ticket, status)
+
+    # Email the other support agents when tags are added.
+    if added_tags:
+        await _notify_support_contacts_tag_added(ticket, added_tags, actor)
 
     return _ticket_to_dict(ticket)
 
@@ -509,6 +517,39 @@ async def _notify_support_contacts_new_message(
                     frontend_url=settings.frontend_url,
                 )
                 await send_email(email, subject, html, settings, email_type="support_new_message")
+
+
+async def _notify_support_contacts_tag_added(
+    ticket: SupportTicket,
+    added_tags: list[str],
+    actor: User | None,
+) -> None:
+    """Email the other support agents when a tag is added to a ticket."""
+    contacts = await _get_all_support_user_ids()
+    settings = Settings()
+    actor_user_id = actor.user_id if actor else None
+    actor_name = (actor.name or actor.user_id) if actor else "A support agent"
+
+    for contact in contacts:
+        user_id = contact.get("user_id")
+        email = contact.get("email")
+        name = contact.get("name", "Support")
+        # Don't email the agent who just added the tag.
+        if user_id and user_id == actor_user_id:
+            continue
+        if not email:
+            continue
+        from app.services.email_service import support_tag_added_email
+        subject, html = support_tag_added_email(
+            support_name=name,
+            ticket_subject=ticket.subject,
+            ticket_user=ticket.user_name or ticket.user_id,
+            added_tags=added_tags,
+            actor_name=actor_name,
+            ticket_uuid=ticket.uuid,
+            frontend_url=settings.frontend_url,
+        )
+        await send_email(email, subject, html, settings, email_type="support_tag_added")
 
 
 async def _email_ticket_owner_reply(


### PR DESCRIPTION
## Summary
- When a support agent adds a tag to a ticket via `PATCH /support/tickets/{uuid}`, email the other configured support contacts (the acting agent is excluded) a link to the ticket.
- New `support_tag_added_email()` template in `email_service.py` (subject: "Tag(s) added to ticket: {subject}", with tag pills + View Ticket button).
- New `_notify_support_contacts_tag_added()` helper in `support_service.py`. `update_ticket()` now snapshots the previous tag set, computes the diff after normalization, and only fires emails for newly added tags — removing or re-saving an existing tag does not notify.
- Router passes the calling user as `actor` so the service knows whom to skip.

## Test plan
- [ ] Configure two support contacts in System Config.
- [ ] As agent A, add a new tag to an open ticket → agent B receives an email with the tag(s) and a working ticket link; agent A does not.
- [ ] Re-save with the same tags → no email sent.
- [ ] Remove a tag → no email sent.
- [ ] Add multiple tags in one PATCH → one email per other agent listing all newly-added tags.
- [ ] Existing `tests/test_support_service_helpers.py` still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)