### PR TITLE
Pass document text into ResearchNode and FormFillerNode on Document trigger

### DIFF
--- a/backend/app/services/workflow_engine.py
+++ b/backend/app/services/workflow_engine.py
@@ -615,7 +615,21 @@ class ResearchNode(Node):
 
     def process(self, inputs):
         question = self.data.get("question", "")
-        input_data = inputs.get("output")
+        prev_step_name = inputs.get("step_name")
+        input_source = self.data.get("input_source", "step_input")
+
+        if input_source == "select_document" and self.data.get("selected_doc_text"):
+            input_data = self.data["selected_doc_text"]
+        elif input_source == "workflow_documents" or prev_step_name == "Document":
+            doc_texts = self.data.get("doc_texts", [])
+            if len(doc_texts) > 1:
+                sections = [f"=== Document {i} ===\n{dt}" for i, dt in enumerate(doc_texts, 1)]
+                input_data = "\n\n".join(sections)
+            else:
+                input_data = doc_texts[0] if doc_texts else ""
+        else:
+            input_data = inputs.get("output")
+
         self.report_progress("Pass 1: Analyzing data")
 
         analysis_prompt = (
@@ -726,7 +740,21 @@ class FormFillerNode(Node):
 
     def process(self, inputs):
         template = self.data.get("template", "")
-        input_data = inputs.get("output")
+        prev_step_name = inputs.get("step_name")
+        input_source = self.data.get("input_source", "step_input")
+
+        if input_source == "select_document" and self.data.get("selected_doc_text"):
+            input_data = self.data["selected_doc_text"]
+        elif input_source == "workflow_documents" or prev_step_name == "Document":
+            doc_texts = self.data.get("doc_texts", [])
+            if len(doc_texts) > 1:
+                sections = [f"=== Document {i} ===\n{dt}" for i, dt in enumerate(doc_texts, 1)]
+                input_data = "\n\n".join(sections)
+            else:
+                input_data = doc_texts[0] if doc_texts else ""
+        else:
+            input_data = inputs.get("output")
+
         self.report_progress("Filling template")
 
         prompt = (

--- a/backend/tests/test_workflow_nodes.py
+++ b/backend/tests/test_workflow_nodes.py
@@ -481,6 +481,21 @@ class TestResearchNode:
         assert any("Pass 1" in str(p) for p in progress)
         assert any("Pass 2" in str(p) for p in progress)
 
+    @patch("app.services.workflow_engine.llm_chat_model")
+    def test_document_trigger_uses_doc_texts_not_uuids(self, mock_llm):
+        mock_llm.side_effect = ["findings", "report"]
+        node = ResearchNode({
+            "question": "What's the RFA about?",
+            "model": "gpt-4o",
+            "doc_texts": ["The RFA seeks proposals for AI safety research."],
+        })
+        node.process({
+            "step_name": "Document",
+            "output": ["d41d8cd98f00b204e9800998ecf8427e"],
+        })
+        for call in mock_llm.call_args_list:
+            assert call.kwargs["data"] == "The RFA seeks proposals for AI safety research."
+
 
 # ---------------------------------------------------------------------------
 # APICallNode
@@ -669,6 +684,20 @@ class TestFormFillerNode:
         node.progress_reporter = lambda d=None, p=None: progress.append(d)
         node.process({"output": {}})
         assert any("Filling" in str(p) for p in progress)
+
+    @patch("app.services.workflow_engine.llm_chat_model")
+    def test_document_trigger_uses_doc_texts_not_uuids(self, mock_llm):
+        mock_llm.return_value = "filled"
+        node = FormFillerNode({
+            "template": "Project: {{title}}",
+            "model": "gpt-4o",
+            "doc_texts": ["Project title: AI Safety Initiative."],
+        })
+        node.process({
+            "step_name": "Document",
+            "output": ["d41d8cd98f00b204e9800998ecf8427e"],
+        })
+        assert mock_llm.call_args.kwargs["data"] == "Project title: AI Safety Initiative."
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- When a workflow was triggered from a Document step, `ResearchNode` and `FormFillerNode` received the upstream `output` — a list of document UUIDs — as their `input_data` instead of the actual document text. The LLM ended up reasoning over hex strings.
- Bring both nodes in line with the existing `input_source` routing already used by the extraction-style nodes (see `workflow_engine.py:311`, `:368`, `:413`):
  - `select_document` → use `selected_doc_text`
  - `workflow_documents` (or previous step is `Document`) → use `doc_texts`, joined with `=== Document N ===` section headers when there are multiple
  - otherwise → fall back to `inputs.get("output")` (prior behavior)
- Adds focused unit tests for both nodes asserting that LLM calls receive the document text, not the UUID list.

## Test plan
- [ ] `uv run pytest tests/test_workflow_nodes.py::TestResearchNode::test_document_trigger_uses_doc_texts_not_uuids tests/test_workflow_nodes.py::TestFormFillerNode::test_document_trigger_uses_doc_texts_not_uuids` passes (verified locally).
- [ ] Build a workflow: Document → Research → run on a real document and confirm the analysis references the document content rather than UUID strings.
- [ ] Build a workflow: Document → Form Filler → run with a template referencing fields from the document and confirm fields are populated from text.
- [ ] Multi-document trigger: confirm sections are concatenated with `=== Document N ===` headers.
- [ ] Non-document upstream step (e.g. an Extraction → Research chain) still passes the prior step's output through unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
