### PR TITLE
Show validation reason in tooltip on file warning icon

### DIFF
--- a/backend/app/routers/documents.py
+++ b/backend/app/routers/documents.py
@@ -107,6 +107,7 @@ async def search_documents(
             "updated_at": doc.updated_at.isoformat() if doc.updated_at else None,
             "processing": doc.processing,
             "valid": doc.valid,
+            "validation_feedback": doc.validation_feedback,
             "task_status": doc.task_status,
             "folder": doc.folder,
             "token_count": doc.token_count,

--- a/backend/app/services/document_service.py
+++ b/backend/app/services/document_service.py
@@ -90,6 +90,7 @@ async def list_contents(
                 "extension": d.extension,
                 "processing": d.processing,
                 "valid": d.valid,
+                "validation_feedback": d.validation_feedback,
                 "task_status": d.task_status,
                 "folder": d.folder,
                 "created_at": d.created_at.isoformat() if d.created_at else "",

--- a/frontend/src/components/files/FileRow.test.tsx
+++ b/frontend/src/components/files/FileRow.test.tsx
@@ -83,4 +83,28 @@ describe('FileRow', () => {
     renderFileRow({ onToggleSelect: undefined })
     expect(screen.queryByRole('checkbox')).toBeNull()
   })
+
+  it('shows validation_feedback in tooltip when doc.valid=false', () => {
+    renderFileRow({
+      doc: makeDoc({
+        valid: false,
+        validation_feedback: 'Document appears to be empty or unreadable.',
+      }),
+    })
+    expect(
+      screen.getByTitle('Failed validation: Document appears to be empty or unreadable.'),
+    ).toBeTruthy()
+  })
+
+  it('shows generic explanation when doc.valid=false and feedback is missing', () => {
+    renderFileRow({ doc: makeDoc({ valid: false, validation_feedback: null }) })
+    expect(
+      screen.getByTitle('This document did not pass automated upload validation.'),
+    ).toBeTruthy()
+  })
+
+  it('does not show validation warning when doc.valid=true', () => {
+    renderFileRow({ doc: makeDoc({ valid: true }) })
+    expect(screen.queryByTitle(/validation/i)).toBeNull()
+  })
 })

--- a/frontend/src/components/files/FileRow.tsx
+++ b/frontend/src/components/files/FileRow.tsx
@@ -70,7 +70,22 @@ export function FileRow({ doc, onClick, onContextMenu, selected, onToggleSelect,
           {doc.processing ? (
             <Loader2 className="h-4 w-4 animate-spin shrink-0 mr-2.5" style={{ color: 'var(--highlight-color)' }} />
           ) : !doc.valid ? (
-            <AlertTriangle className="h-4 w-4 shrink-0 mr-2.5 text-red-500" />
+            <span
+              className="shrink-0 mr-2.5 inline-flex items-center"
+              role="img"
+              aria-label={
+                doc.validation_feedback
+                  ? `Failed validation: ${doc.validation_feedback}`
+                  : 'This document did not pass automated upload validation.'
+              }
+              title={
+                doc.validation_feedback
+                  ? `Failed validation: ${doc.validation_feedback}`
+                  : 'This document did not pass automated upload validation.'
+              }
+            >
+              <AlertTriangle className="h-4 w-4 text-red-500" />
+            </span>
           ) : null}
           <div style={{ minWidth: 0, flex: 1 }}>
             <span className="flex items-center gap-1.5">

--- a/frontend/src/types/document.ts
+++ b/frontend/src/types/document.ts
@@ -5,6 +5,7 @@ export interface Document {
   extension: string
   processing: boolean
   valid: boolean
+  validation_feedback?: string | null
   task_status: string | null
   folder: string | null
   created_at: string


### PR DESCRIPTION
## Summary
- A user reported a red warning triangle on a file in the file browser with no way to learn what it meant. The icon (rendered when `doc.valid === false`) had no tooltip, no aria-label, and no hover text. The actual reason — `validation_feedback` produced by the LLM upload-validation pass — was stored on the backend but the list/search endpoints never returned it.
- Backend now includes `validation_feedback` in `/documents/list` and `/documents/search` payloads.
- Frontend `Document` type gains `validation_feedback`. `FileRow` wraps the `AlertTriangle` in a `<span>` with `title` and `aria-label` so hover shows e.g. *"Failed validation: Document appears to be empty or unreadable."*, with a generic fallback when feedback is missing. Matches the existing classification-badge tooltip pattern in the same component.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run src/components/files/FileRow.test.tsx` — 9/9 pass, including 3 new cases (feedback present, feedback missing, no warning when valid)
- [ ] Manual: upload a doc that fails validation, hover the red triangle in the file list, confirm the LLM feedback appears in the tooltip
- [ ] Manual: confirm the search results page shows the same tooltip

🤖 Generated with [Claude Code](https://claude.com/claude-code)