### PR TITLE
Open PDF inline in new tab instead of triggering a download

### DIFF
--- a/frontend/src/components/files/DocumentViewer.tsx
+++ b/frontend/src/components/files/DocumentViewer.tsx
@@ -503,6 +503,17 @@ export function DocumentViewer({ docUuid, highlightTerms = [], onClearHighlights
     setZoom(2)
   }, [])
 
+  // The /api/files/download endpoint always sets Content-Disposition: attachment,
+  // so opening it in a new tab triggers a download. For inline viewing we open
+  // a blob URL instead — no disposition header means the browser renders it.
+  const openPdfInNewTab = useCallback(() => {
+    if (!pdfDataRef.current) return
+    const blob = new Blob([pdfDataRef.current.slice(0)], { type: 'application/pdf' })
+    const inlineUrl = URL.createObjectURL(blob)
+    window.open(inlineUrl, '_blank')
+    setTimeout(() => URL.revokeObjectURL(inlineUrl), 60_000)
+  }, [])
+
   const btnStyle: React.CSSProperties = {
     display: 'flex', alignItems: 'center', justifyContent: 'center',
     width: 32, height: 32, borderRadius: 6, border: '1px solid #d1d5db',
@@ -666,7 +677,12 @@ export function DocumentViewer({ docUuid, highlightTerms = [], onClearHighlights
             <ZoomIn size={16} />
           </button>
           <div style={{ width: 1, height: 20, backgroundColor: '#d1d5db', margin: '0 4px' }} />
-          <button onClick={() => window.open(url, '_blank')} style={btnStyle} title="Open in new tab">
+          <button
+            onClick={() => { if (blobUrl) window.open(blobUrl, '_blank') }}
+            style={btnStyle}
+            title="Open in new tab"
+            disabled={!blobUrl}
+          >
             <Maximize2 size={16} />
           </button>
         </div>
@@ -718,7 +734,7 @@ export function DocumentViewer({ docUuid, highlightTerms = [], onClearHighlights
           <ZoomIn size={16} />
         </button>
         <div style={{ width: 1, height: 20, backgroundColor: '#d1d5db', margin: '0 4px' }} />
-        <button onClick={() => window.open(url, '_blank')} style={btnStyle} title="Open in new tab">
+        <button onClick={openPdfInNewTab} style={btnStyle} title="Open in new tab" aria-label="Open in new tab">
           <Maximize2 size={16} />
         </button>
       </div>


### PR DESCRIPTION
## Summary
- The document viewer's "open in new tab" button (Maximize2 icon) was hitting `/api/files/download`, which always returns `Content-Disposition: attachment` (`backend/app/routers/files.py:88`) — so the new tab triggered a download instead of rendering the PDF.
- For PDFs, we already hold the file bytes in `pdfDataRef`. Wrap them in a `Blob` and open that blob URL — no disposition header, so the browser renders inline. Revoke after 60s.
- For the non-PDF iframe fallback, reuse the existing `blobUrl` (already created for the iframe) instead of the download endpoint.
- DOCX path left alone — that button is "Download original" and the download is intentional there.

## Test plan
- [ ] Open a PDF document, click the full-screen / open-in-new-tab button → PDF should render inline in a new tab (no download).
- [ ] Open a non-PDF, non-DOCX, non-spreadsheet file (e.g., an image), click open-in-new-tab → file should preview in a new tab.
- [ ] Open a DOCX, click "Download original" → still downloads (unchanged behavior).
- [ ] Verify no console errors and that the temporary blob URL eventually gets revoked.

Generated with [Claude Code](https://claude.com/claude-code)
