### PR TITLE
Add real full-screen mode to certification panel

### DIFF
--- a/frontend/src/components/certification/CertificationPanel.tsx
+++ b/frontend/src/components/certification/CertificationPanel.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef, useMemo, useCallback } from 'react'
 import { createPortal } from 'react-dom'
 import { useQueryClient } from '@tanstack/react-query'
 import {
+  AppWindow,
   Award,
   ChevronLeft,
   Cog,
@@ -136,7 +137,8 @@ function ValidationResults({ result, onDismiss }: { result: ValidationResult; on
 // ---------------------------------------------------------------------------
 
 const MODE_ICONS: { mode: PanelMode; icon: typeof Maximize2; label: string }[] = [
-  { mode: 'floating', icon: Maximize2, label: 'Float' },
+  { mode: 'floating', icon: AppWindow, label: 'Float' },
+  { mode: 'fullscreen', icon: Maximize2, label: 'Full screen' },
   { mode: 'docked-left', icon: PanelLeft, label: 'Dock left' },
   { mode: 'docked-right', icon: PanelRight, label: 'Dock right' },
   { mode: 'docked-bottom', icon: PanelBottom, label: 'Dock bottom' },
@@ -317,6 +319,7 @@ export function CertificationPanel() {
   const containerClass = cn(
     'fixed z-[9000] bg-white flex flex-col',
     mode === 'floating' && 'shadow-2xl border border-gray-200 cert-panel-enter',
+    mode === 'fullscreen' && 'top-0 left-0 right-0 bottom-0 cert-panel-enter',
     mode === 'docked-left' && 'top-[69px] left-0 bottom-0 border-r border-gray-200 cert-panel-dock-left',
     mode === 'docked-right' && 'top-[69px] right-0 bottom-0 border-l border-gray-200 cert-panel-dock-right',
     mode === 'docked-bottom' && 'left-0 right-0 bottom-0 border-t border-gray-200 cert-panel-dock-bottom',

--- a/frontend/src/contexts/CertificationPanelContext.tsx
+++ b/frontend/src/contexts/CertificationPanelContext.tsx
@@ -2,7 +2,7 @@ import { createContext, useCallback, useContext, useState, type ReactNode } from
 import { useCertification } from '../hooks/useCertification'
 import type { CertificationProgress, ValidationResult, CompletionResult, CertExercise } from '../types/certification'
 
-export type PanelMode = 'floating' | 'docked-left' | 'docked-right' | 'docked-bottom'
+export type PanelMode = 'floating' | 'fullscreen' | 'docked-left' | 'docked-right' | 'docked-bottom'
 
 interface CertificationPanelContextValue {
   // Panel UI state
@@ -30,7 +30,7 @@ const STORAGE_KEY = 'cert-panel-mode'
 function getStoredMode(): PanelMode {
   try {
     const stored = localStorage.getItem(STORAGE_KEY)
-    if (stored && ['floating', 'docked-left', 'docked-right', 'docked-bottom'].includes(stored)) {
+    if (stored && ['floating', 'fullscreen', 'docked-left', 'docked-right', 'docked-bottom'].includes(stored)) {
       return stored as PanelMode
     }
   } catch {}


### PR DESCRIPTION
## Summary
- The `Maximize2` icon in the cert panel header read as "fullscreen" but actually toggled a 540×80vh centered floating dialog — clicking it while already in floating mode was a silent no-op.
- Split into two distinct modes: `AppWindow` icon for **Float** (windowed dialog), and `Maximize2` for a new **Full screen** mode that actually fills the viewport.

## Test plan
- [ ] Open the certification panel; verify five mode buttons are visible (Float, Full screen, Dock left, Dock right, Dock bottom)
- [ ] Click the `Maximize2` (Full screen) icon — panel expands to fill the entire viewport
- [ ] Switch back to Float — panel returns to centered 540×80vh dialog
- [ ] Reload page; verify mode persists via `localStorage` (`cert-panel-mode`)
- [ ] Verify dragging is disabled in fullscreen and dock modes; only floating allows drag

🤖 Generated with [Claude Code](https://claude.com/claude-code)