### PR TITLE
Add Cmd/Ctrl+F find-in-document for PDF, DOCX, and spreadsheets

### DIFF
--- a/frontend/src/components/files/DocumentSearchBar.tsx
+++ b/frontend/src/components/files/DocumentSearchBar.tsx
@@ -1,0 +1,172 @@
+import { useEffect, useRef } from 'react'
+import { ChevronUp, ChevronDown, X } from 'lucide-react'
+
+interface Props {
+  query: string
+  onQueryChange: (q: string) => void
+  currentMatch: number // 1-indexed; 0 if none
+  totalMatches: number
+  onPrev: () => void
+  onNext: () => void
+  onClose: () => void
+  autoFocus?: boolean
+}
+
+export function DocumentSearchBar({
+  query, onQueryChange, currentMatch, totalMatches,
+  onPrev, onNext, onClose, autoFocus,
+}: Props) {
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    if (autoFocus) {
+      inputRef.current?.focus()
+      inputRef.current?.select()
+    }
+  }, [autoFocus])
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      e.preventDefault()
+      if (e.shiftKey) onPrev()
+      else onNext()
+    } else if (e.key === 'Escape') {
+      e.preventDefault()
+      onClose()
+    }
+  }
+
+  const trimmed = query.trim()
+  const status = trimmed === ''
+    ? ''
+    : totalMatches === 0 ? 'No results' : `${currentMatch} of ${totalMatches}`
+  const statusColor = trimmed && totalMatches === 0 ? '#ef4444' : '#6b7280'
+
+  return (
+    <div
+      role="search"
+      style={{
+        position: 'absolute',
+        top: 8,
+        right: 12,
+        zIndex: 200,
+        display: 'flex',
+        alignItems: 'center',
+        gap: 2,
+        padding: '4px 6px',
+        borderRadius: 8,
+        border: '1px solid #d1d5db',
+        backgroundColor: 'rgba(255,255,255,0.97)',
+        backdropFilter: 'blur(8px)',
+        boxShadow: '0 2px 12px rgba(0,0,0,0.15)',
+      }}
+    >
+      <input
+        ref={inputRef}
+        type="text"
+        value={query}
+        onChange={(e) => onQueryChange(e.target.value)}
+        onKeyDown={handleKeyDown}
+        placeholder="Find in document"
+        aria-label="Find in document"
+        style={{
+          width: 200,
+          height: 28,
+          padding: '0 8px',
+          fontSize: 13,
+          border: 'none',
+          outline: 'none',
+          background: 'transparent',
+          color: '#111827',
+        }}
+      />
+      <span
+        aria-live="polite"
+        style={{
+          minWidth: 70,
+          textAlign: 'center',
+          fontSize: 12,
+          color: statusColor,
+          padding: '0 4px',
+        }}
+      >
+        {status}
+      </span>
+      <button
+        type="button"
+        onClick={onPrev}
+        disabled={totalMatches === 0}
+        style={iconBtnStyle(totalMatches === 0)}
+        title="Previous (Shift+Enter)"
+        aria-label="Previous match"
+      >
+        <ChevronUp size={16} />
+      </button>
+      <button
+        type="button"
+        onClick={onNext}
+        disabled={totalMatches === 0}
+        style={iconBtnStyle(totalMatches === 0)}
+        title="Next (Enter)"
+        aria-label="Next match"
+      >
+        <ChevronDown size={16} />
+      </button>
+      <button
+        type="button"
+        onClick={onClose}
+        style={iconBtnStyle(false)}
+        title="Close (Esc)"
+        aria-label="Close find"
+      >
+        <X size={16} />
+      </button>
+    </div>
+  )
+}
+
+function iconBtnStyle(disabled: boolean): React.CSSProperties {
+  return {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: 28,
+    height: 28,
+    borderRadius: 6,
+    border: 'none',
+    background: 'transparent',
+    cursor: disabled ? 'default' : 'pointer',
+    color: disabled ? '#d1d5db' : '#374151',
+  }
+}
+
+// Window-level Cmd/Ctrl+F hook scoped to a viewer's root element. Activates
+// only when the mouse is hovering the viewer or focus is inside it, so
+// browser Find continues to work everywhere else on the page.
+export function useFindInDocumentHotkey(
+  rootRef: React.RefObject<HTMLElement | null>,
+  isOpen: boolean,
+  onOpen: () => void,
+  onClose: () => void,
+) {
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      const root = rootRef.current
+      if (!root) return
+      const inScope =
+        root.matches(':hover') || root.contains(document.activeElement)
+      if (!inScope) return
+
+      const modKey = e.metaKey || e.ctrlKey
+      if (modKey && (e.key === 'f' || e.key === 'F')) {
+        e.preventDefault()
+        onOpen()
+      } else if (e.key === 'Escape' && isOpen) {
+        e.preventDefault()
+        onClose()
+      }
+    }
+    window.addEventListener('keydown', handler)
+    return () => window.removeEventListener('keydown', handler)
+  }, [rootRef, isOpen, onOpen, onClose])
+}

--- a/frontend/src/components/files/DocumentViewer.tsx
+++ b/frontend/src/components/files/DocumentViewer.tsx
@@ -1,8 +1,9 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { ZoomIn, ZoomOut, Maximize2, ChevronLeft, ChevronRight, Loader2, X } from 'lucide-react'
+import { ZoomIn, ZoomOut, Maximize2, ChevronLeft, ChevronRight, Loader2, X, Search } from 'lucide-react'
 import { downloadFileUrl } from '../../api/files'
 import { pollStatus } from '../../api/documents'
 import { SpreadsheetViewer } from './SpreadsheetViewer'
+import { DocumentSearchBar, useFindInDocumentHotkey } from './DocumentSearchBar'
 import DOMPurify from 'dompurify'
 import { marked } from 'marked'
 import * as pdfjsLib from 'pdfjs-dist/legacy/build/pdf.mjs'
@@ -41,6 +42,75 @@ async function readTextItems(page: pdfjsLib.PDFPageProxy): Promise<unknown[]> {
   return items
 }
 
+// Walk text nodes under `root`, wrap occurrences of `query` (case-insensitive,
+// whole-text-node only — no cross-node matching) in <mark.doc-search-hl>.
+// Returns the number of matches inserted. Idempotent: prior marks from this
+// helper are unwrapped first.
+function highlightHtmlSearch(root: HTMLElement, query: string): number {
+  // Unwrap prior marks
+  const prior = root.querySelectorAll('mark.doc-search-hl')
+  prior.forEach(mark => {
+    const parent = mark.parentNode
+    if (!parent) return
+    while (mark.firstChild) parent.insertBefore(mark.firstChild, mark)
+    parent.removeChild(mark)
+  })
+  // Coalesce adjacent text nodes left behind by the unwrap
+  prior.forEach(mark => {
+    const p = mark.parentNode as Element | null
+    if (p && typeof p.normalize === 'function') p.normalize()
+  })
+
+  const trimmed = query.trim()
+  if (!trimmed) return 0
+  const needle = trimmed.toLowerCase()
+  const needleLen = needle.length
+
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, {
+    acceptNode: (node) => {
+      const parent = node.parentElement
+      if (!parent) return NodeFilter.FILTER_REJECT
+      const tag = parent.tagName
+      if (tag === 'SCRIPT' || tag === 'STYLE') return NodeFilter.FILTER_REJECT
+      return NodeFilter.FILTER_ACCEPT
+    },
+  })
+  const nodes: Text[] = []
+  let n: Node | null
+  while ((n = walker.nextNode())) nodes.push(n as Text)
+
+  let count = 0
+  for (const node of nodes) {
+    const text = node.nodeValue || ''
+    const lower = text.toLowerCase()
+    if (!lower.includes(needle)) continue
+
+    const frag = document.createDocumentFragment()
+    let cursor = 0
+    let from = 0
+    while (from < lower.length) {
+      const idx = lower.indexOf(needle, from)
+      if (idx === -1) break
+      if (idx > cursor) frag.appendChild(document.createTextNode(text.slice(cursor, idx)))
+      const mark = document.createElement('mark')
+      mark.className = 'doc-search-hl'
+      mark.dataset.searchIdx = String(count)
+      mark.style.backgroundColor = '#fde68a'
+      mark.style.color = 'inherit'
+      mark.style.padding = '0'
+      mark.style.borderRadius = '2px'
+      mark.appendChild(document.createTextNode(text.slice(idx, idx + needleLen)))
+      frag.appendChild(mark)
+      cursor = idx + needleLen
+      from = cursor
+      count++
+    }
+    if (cursor < text.length) frag.appendChild(document.createTextNode(text.slice(cursor)))
+    node.parentNode?.replaceChild(frag, node)
+  }
+  return count
+}
+
 const STATUS_MESSAGES: Record<string, { title: string; message: string }> = {
   layout: {
     title: 'Converting & Preparing Your Document...',
@@ -74,8 +144,34 @@ export function DocumentViewer({ docUuid, highlightTerms = [], onClearHighlights
   const [totalHighlights, setTotalHighlights] = useState(0)
   const [currentHighlight, setCurrentHighlight] = useState(0)
 
+  // In-document find (Cmd/Ctrl+F)
+  const rootRef = useRef<HTMLDivElement>(null)
+  const [searchOpen, setSearchOpen] = useState(false)
+  const [searchQuery, setSearchQuery] = useState('')
+  const docxContentRef = useRef<HTMLDivElement>(null)
+  const [docxMatchCount, setDocxMatchCount] = useState(0)
+  const [docxCurrentMatch, setDocxCurrentMatch] = useState(0)
+
   const zoomLevel = ZOOM_LEVELS[zoom]
   const url = downloadFileUrl(docUuid)
+
+  const openSearch = useCallback(() => setSearchOpen(true), [])
+  const closeSearch = useCallback(() => {
+    setSearchOpen(false)
+    setSearchQuery('')
+  }, [])
+
+  useFindInDocumentHotkey(rootRef, searchOpen, openSearch, closeSearch)
+
+  // When the user types into the find bar, the typed query takes priority
+  // over extraction-driven highlights. Closing the bar restores them.
+  const effectiveTerms = useMemo(() => {
+    if (searchOpen) {
+      const q = searchQuery.trim()
+      return q ? [q] : []
+    }
+    return highlightTerms
+  }, [searchOpen, searchQuery, highlightTerms])
 
   // Fetch file data with credentials and detect content type
   useEffect(() => {
@@ -184,11 +280,11 @@ export function DocumentViewer({ docUuid, highlightTerms = [], onClearHighlights
   // Re-apply highlights when terms change
   useEffect(() => {
     if (isPdf !== true || !pdfDocRef.current) return
-    applyHighlights(pdfDocRef.current, highlightTerms).catch(err => {
+    applyHighlights(pdfDocRef.current, effectiveTerms).catch(err => {
       console.error('[DocumentViewer] applyHighlights failed:', err)
     })
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [highlightTerms])
+  }, [effectiveTerms])
 
   const renderAllPages = useCallback(async (doc: pdfjsLib.PDFDocumentProxy) => {
     if (renderingRef.current) return
@@ -249,12 +345,12 @@ export function DocumentViewer({ docUuid, highlightTerms = [], onClearHighlights
     renderingRef.current = false
 
     // Apply highlights after rendering
-    if (highlightTerms.length > 0) {
-      applyHighlights(doc, highlightTerms).catch(err => {
+    if (effectiveTerms.length > 0) {
+      applyHighlights(doc, effectiveTerms).catch(err => {
         console.error('[DocumentViewer] applyHighlights failed:', err)
       })
     }
-  }, [zoomLevel, highlightTerms])
+  }, [zoomLevel, effectiveTerms])
 
   const applyHighlights = useCallback(async (doc: pdfjsLib.PDFDocumentProxy, terms: string[]) => {
     const container = containerRef.current
@@ -491,6 +587,48 @@ export function DocumentViewer({ docUuid, highlightTerms = [], onClearHighlights
     })
   }, [totalHighlights])
 
+  // ----- DOCX/HTML search wiring -----
+
+  const scrollDocxMatch = useCallback((index: number) => {
+    const root = docxContentRef.current
+    if (!root) return
+    root.querySelectorAll<HTMLElement>('mark.doc-search-hl').forEach((el) => {
+      const idx = Number(el.dataset.searchIdx)
+      el.style.backgroundColor = idx === index ? '#fbbf24' : '#fde68a'
+      el.style.outline = idx === index ? '2px solid #f59e0b' : 'none'
+    })
+    const target = root.querySelector<HTMLElement>(
+      `mark.doc-search-hl[data-search-idx="${index}"]`,
+    )
+    if (target) target.scrollIntoView({ behavior: 'smooth', block: 'center' })
+  }, [])
+
+  // Re-apply DOCX highlights when the query changes or the rendered HTML
+  // is replaced (e.g. text re-poll after processing).
+  useEffect(() => {
+    if (!isDocx) return
+    const root = docxContentRef.current
+    if (!root) return
+    const q = searchOpen ? searchQuery : ''
+    const count = highlightHtmlSearch(root, q)
+    setDocxMatchCount(count)
+    setDocxCurrentMatch(0)
+    if (count > 0) {
+      requestAnimationFrame(() => scrollDocxMatch(0))
+    }
+  }, [isDocx, searchOpen, searchQuery, docxText, scrollDocxMatch])
+
+  const goToDocxMatch = useCallback((direction: 'next' | 'prev') => {
+    if (docxMatchCount === 0) return
+    setDocxCurrentMatch(prev => {
+      const next = direction === 'next'
+        ? (prev + 1 >= docxMatchCount ? 0 : prev + 1)
+        : (prev - 1 < 0 ? docxMatchCount - 1 : prev - 1)
+      requestAnimationFrame(() => scrollDocxMatch(next))
+      return next
+    })
+  }, [docxMatchCount, scrollDocxMatch])
+
   const zoomIn = useCallback(() => {
     setZoom(prev => Math.min(prev + 1, ZOOM_LEVELS.length - 1))
   }, [])
@@ -597,7 +735,7 @@ export function DocumentViewer({ docUuid, highlightTerms = [], onClearHighlights
   // DOCX rendered markdown viewer
   if (isDocx) {
     return (
-      <div style={{ height: '100%', display: 'flex', flexDirection: 'column', position: 'relative' }}>
+      <div ref={rootRef} style={{ height: '100%', display: 'flex', flexDirection: 'column', position: 'relative' }}>
         {processingOverlay}
         <div style={{
           display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 6,
@@ -614,13 +752,28 @@ export function DocumentViewer({ docUuid, highlightTerms = [], onClearHighlights
             <ZoomIn size={16} />
           </button>
           <div style={{ width: 1, height: 20, backgroundColor: '#d1d5db', margin: '0 4px' }} />
+          <button onClick={openSearch} style={btnStyle} title="Find in document (⌘F / Ctrl+F)" aria-label="Find in document">
+            <Search size={16} />
+          </button>
           <button onClick={() => window.open(url, '_blank')} style={btnStyle} title="Download original">
             <Maximize2 size={16} />
           </button>
         </div>
         <div style={{
-          flex: 1, overflow: 'auto', backgroundColor: '#fff',
+          flex: 1, overflow: 'auto', backgroundColor: '#fff', position: 'relative',
         }}>
+          {searchOpen && (
+            <DocumentSearchBar
+              query={searchQuery}
+              onQueryChange={setSearchQuery}
+              currentMatch={docxMatchCount === 0 ? 0 : docxCurrentMatch + 1}
+              totalMatches={docxMatchCount}
+              onPrev={() => goToDocxMatch('prev')}
+              onNext={() => goToDocxMatch('next')}
+              onClose={closeSearch}
+              autoFocus
+            />
+          )}
           {docxText === null ? (
             <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100%' }}>
               <Loader2 style={{ width: 32, height: 32, color: 'var(--highlight-color)', animation: 'spin 1s linear infinite' }} />
@@ -635,6 +788,7 @@ export function DocumentViewer({ docUuid, highlightTerms = [], onClearHighlights
               color: '#333',
             }}>
               <div
+                ref={docxContentRef}
                 className="chat-markdown"
                 dangerouslySetInnerHTML={{ __html: docxHtml }}
               />
@@ -715,7 +869,7 @@ export function DocumentViewer({ docUuid, highlightTerms = [], onClearHighlights
   }
 
   return (
-    <div style={{ height: '100%', display: 'flex', flexDirection: 'column', position: 'relative' }}>
+    <div ref={rootRef} style={{ height: '100%', display: 'flex', flexDirection: 'column', position: 'relative' }}>
       {processingOverlay}
 
       {/* Toolbar */}
@@ -734,6 +888,9 @@ export function DocumentViewer({ docUuid, highlightTerms = [], onClearHighlights
           <ZoomIn size={16} />
         </button>
         <div style={{ width: 1, height: 20, backgroundColor: '#d1d5db', margin: '0 4px' }} />
+        <button onClick={openSearch} style={btnStyle} title="Find in document (⌘F / Ctrl+F)" aria-label="Find in document">
+          <Search size={16} />
+        </button>
         <button onClick={openPdfInNewTab} style={btnStyle} title="Open in new tab" aria-label="Open in new tab">
           <Maximize2 size={16} />
         </button>
@@ -744,10 +901,22 @@ export function DocumentViewer({ docUuid, highlightTerms = [], onClearHighlights
         flex: 1, overflow: 'auto', backgroundColor: '#525659',
         position: 'relative',
       }}>
+        {searchOpen && (
+          <DocumentSearchBar
+            query={searchQuery}
+            onQueryChange={setSearchQuery}
+            currentMatch={totalHighlights === 0 ? 0 : currentHighlight + 1}
+            totalMatches={totalHighlights}
+            onPrev={() => goToHighlight('prev')}
+            onNext={() => goToHighlight('next')}
+            onClose={closeSearch}
+            autoFocus
+          />
+        )}
         <div ref={containerRef} style={{ paddingBottom: 20 }} />
 
         {/* Highlight navigation bar */}
-        {totalHighlights > 0 && (
+        {!searchOpen && totalHighlights > 0 && (
           <div style={{
             position: 'sticky',
             bottom: 12,
@@ -789,7 +958,7 @@ export function DocumentViewer({ docUuid, highlightTerms = [], onClearHighlights
               textOverflow: 'ellipsis',
             }}>
               <span style={{ fontWeight: 700 }}>
-                &ldquo;{highlightTerms[0]}&rdquo;
+                &ldquo;{effectiveTerms[0]}&rdquo;
               </span>
               <span style={{ marginLeft: 6, color: '#9ca3af', fontWeight: 400 }}>
                 {currentHighlight + 1} of {totalHighlights}

--- a/frontend/src/components/files/SpreadsheetViewer.tsx
+++ b/frontend/src/components/files/SpreadsheetViewer.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useState } from 'react'
-import { ZoomIn, ZoomOut, Maximize2 } from 'lucide-react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { ZoomIn, ZoomOut, Maximize2, Search } from 'lucide-react'
 import { downloadFileUrl } from '../../api/files'
 import * as XLSX from 'xlsx'
+import { DocumentSearchBar, useFindInDocumentHotkey } from './DocumentSearchBar'
 
 interface SpreadsheetViewerProps {
   docUuid: string
@@ -20,6 +21,69 @@ export function SpreadsheetViewer({ docUuid, processing, taskStatus: _taskStatus
   const [workbook, setWorkbook] = useState<XLSX.WorkBook | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [loading, setLoading] = useState(true)
+
+  // Find-in-document state
+  const rootRef = useRef<HTMLDivElement>(null)
+  const tableScrollRef = useRef<HTMLDivElement>(null)
+  const [searchOpen, setSearchOpen] = useState(false)
+  const [searchQuery, setSearchQuery] = useState('')
+  const [currentMatchIdx, setCurrentMatchIdx] = useState(0)
+
+  const openSearch = useCallback(() => setSearchOpen(true), [])
+  const closeSearch = useCallback(() => {
+    setSearchOpen(false)
+    setSearchQuery('')
+  }, [])
+  useFindInDocumentHotkey(rootRef, searchOpen, openSearch, closeSearch)
+
+  // Compute matches across the active sheet (header row uses r = -1).
+  const matches = useMemo(() => {
+    if (!searchOpen) return [] as Array<{ r: number; c: number }>
+    const q = searchQuery.trim().toLowerCase()
+    if (!q) return [] as Array<{ r: number; c: number }>
+    const out: Array<{ r: number; c: number }> = []
+    headers.forEach((h, c) => {
+      if (h.toLowerCase().includes(q)) out.push({ r: -1, c })
+    })
+    rows.forEach((row, r) => {
+      row.forEach((cell, c) => {
+        if (cell.toLowerCase().includes(q)) out.push({ r, c })
+      })
+    })
+    return out
+  }, [searchOpen, searchQuery, headers, rows])
+
+  // Reset cursor when match set changes.
+  useEffect(() => {
+    setCurrentMatchIdx(0)
+  }, [matches])
+
+  // Map (r,c) → match index for fast cell lookup during render.
+  const matchIndexByKey = useMemo(() => {
+    const m = new Map<string, number>()
+    matches.forEach((pos, i) => m.set(`${pos.r}:${pos.c}`, i))
+    return m
+  }, [matches])
+
+  // Scroll the active match into view.
+  useEffect(() => {
+    if (matches.length === 0) return
+    const target = matches[currentMatchIdx]
+    if (!target) return
+    const container = tableScrollRef.current
+    if (!container) return
+    const sel = `[data-cell-r="${target.r}"][data-cell-c="${target.c}"]`
+    const el = container.querySelector<HTMLElement>(sel)
+    if (el) el.scrollIntoView({ behavior: 'smooth', block: 'center', inline: 'center' })
+  }, [currentMatchIdx, matches])
+
+  const goToMatch = useCallback((direction: 'next' | 'prev') => {
+    if (matches.length === 0) return
+    setCurrentMatchIdx(prev => {
+      if (direction === 'next') return prev + 1 >= matches.length ? 0 : prev + 1
+      return prev - 1 < 0 ? matches.length - 1 : prev - 1
+    })
+  }, [matches.length])
 
   const url = downloadFileUrl(docUuid)
   const zoomLevel = ZOOM_LEVELS[zoom]
@@ -103,7 +167,7 @@ export function SpreadsheetViewer({ docUuid, processing, taskStatus: _taskStatus
   }
 
   return (
-    <div style={{ height: '100%', display: 'flex', flexDirection: 'column', position: 'relative' }}>
+    <div ref={rootRef} style={{ height: '100%', display: 'flex', flexDirection: 'column', position: 'relative' }}>
       {/* Processing overlay */}
       {processing && (
         <div style={{
@@ -142,6 +206,9 @@ export function SpreadsheetViewer({ docUuid, processing, taskStatus: _taskStatus
           <ZoomIn size={16} />
         </button>
         <div style={{ width: 1, height: 20, backgroundColor: '#d1d5db', margin: '0 4px' }} />
+        <button onClick={openSearch} style={btnStyle} title="Find in document (⌘F / Ctrl+F)" aria-label="Find in document">
+          <Search size={16} />
+        </button>
         <button onClick={() => window.open(url, '_blank')} style={btnStyle} title="Open in new tab">
           <Maximize2 size={16} />
         </button>
@@ -173,7 +240,19 @@ export function SpreadsheetViewer({ docUuid, processing, taskStatus: _taskStatus
       )}
 
       {/* Table */}
-      <div style={{ flex: 1, overflow: 'auto', backgroundColor: '#fff' }}>
+      <div ref={tableScrollRef} style={{ flex: 1, overflow: 'auto', backgroundColor: '#fff', position: 'relative' }}>
+        {searchOpen && (
+          <DocumentSearchBar
+            query={searchQuery}
+            onQueryChange={setSearchQuery}
+            currentMatch={matches.length === 0 ? 0 : currentMatchIdx + 1}
+            totalMatches={matches.length}
+            onPrev={() => goToMatch('prev')}
+            onNext={() => goToMatch('next')}
+            onClose={closeSearch}
+            autoFocus
+          />
+        )}
         <div style={{
           transform: `scale(${zoomLevel})`,
           transformOrigin: 'top left',
@@ -198,17 +277,29 @@ export function SpreadsheetViewer({ docUuid, processing, taskStatus: _taskStatus
                     }}>
                       #
                     </th>
-                    {headers.map((h, i) => (
-                      <th key={i} style={{
-                        padding: '8px 12px', textAlign: 'left', fontWeight: 600,
-                        color: '#374151', backgroundColor: '#f9fafb',
-                        borderBottom: '2px solid #e5e7eb', borderRight: '1px solid #f3f4f6',
-                        position: 'sticky', top: 0, zIndex: 2,
-                        whiteSpace: 'nowrap',
-                      }}>
-                        {h}
-                      </th>
-                    ))}
+                    {headers.map((h, i) => {
+                      const matchIdx = matchIndexByKey.get(`-1:${i}`) ?? -1
+                      const isMatch = matchIdx >= 0
+                      const isCurrent = matchIdx === currentMatchIdx
+                      return (
+                        <th key={i}
+                          data-cell-r={-1}
+                          data-cell-c={i}
+                          style={{
+                            padding: '8px 12px', textAlign: 'left', fontWeight: 600,
+                            color: '#374151',
+                            backgroundColor: isCurrent ? '#fbbf24' : isMatch ? '#fde68a' : '#f9fafb',
+                            outline: isCurrent ? '2px solid #f59e0b' : 'none',
+                            outlineOffset: '-2px',
+                            borderBottom: '2px solid #e5e7eb', borderRight: '1px solid #f3f4f6',
+                            position: 'sticky', top: 0, zIndex: 2,
+                            whiteSpace: 'nowrap',
+                          }}
+                        >
+                          {h}
+                        </th>
+                      )
+                    })}
                   </tr>
                 </thead>
               )}
@@ -222,16 +313,29 @@ export function SpreadsheetViewer({ docUuid, processing, taskStatus: _taskStatus
                     }}>
                       {ri + 1}
                     </td>
-                    {headers.map((_, ci) => (
-                      <td key={ci} style={{
-                        padding: '6px 12px', color: '#374151',
-                        borderBottom: '1px solid #f3f4f6',
-                        borderRight: '1px solid #f3f4f6',
-                        whiteSpace: 'nowrap', maxWidth: 300, overflow: 'hidden', textOverflow: 'ellipsis',
-                      }}>
-                        {row[ci] ?? ''}
-                      </td>
-                    ))}
+                    {headers.map((_, ci) => {
+                      const matchIdx = matchIndexByKey.get(`${ri}:${ci}`) ?? -1
+                      const isMatch = matchIdx >= 0
+                      const isCurrent = matchIdx === currentMatchIdx
+                      const baseBg = ri % 2 === 0 ? '#fff' : '#fafafa'
+                      return (
+                        <td key={ci}
+                          data-cell-r={ri}
+                          data-cell-c={ci}
+                          style={{
+                            padding: '6px 12px', color: '#374151',
+                            backgroundColor: isCurrent ? '#fbbf24' : isMatch ? '#fde68a' : baseBg,
+                            outline: isCurrent ? '2px solid #f59e0b' : 'none',
+                            outlineOffset: '-2px',
+                            borderBottom: '1px solid #f3f4f6',
+                            borderRight: '1px solid #f3f4f6',
+                            whiteSpace: 'nowrap', maxWidth: 300, overflow: 'hidden', textOverflow: 'ellipsis',
+                          }}
+                        >
+                          {row[ci] ?? ''}
+                        </td>
+                      )
+                    })}
                   </tr>
                 ))}
               </tbody>


### PR DESCRIPTION
## Summary

- Browser CTRL+F only searched the surrounding page chrome (chat panel, toolbar) — it didn't reach into the rendered document. This adds a real find-in-document bar that activates when the viewer is hovered or focused, and falls through to native browser find everywhere else.
- New `DocumentSearchBar` component + `useFindInDocumentHotkey` hook (⌘F/Ctrl+F to open, Esc to close, Enter / Shift+Enter for next/prev, "X of Y" counter).
- Wired into all three viewers: **PDF** (reuses existing `applyHighlights` pipeline via an `effectiveTerms` memo so extraction-driven highlights resume on close), **DOCX/Markdown** (DOM walk + `<mark>` wrapping, idempotent across re-renders), and **Spreadsheet** (cell-based highlight on header + body cells with scroll-to-current).

## Test plan

- [ ] PDF: open a PDF, press ⌘F (mouse over viewer), type a phrase — highlights appear, prev/next navigates, Esc closes and any prior extraction-driven highlights resume.
- [ ] DOCX / Markdown: open a Word/markdown doc, ⌘F, type a phrase — matches highlight inline, prev/next scrolls between them.
- [ ] Spreadsheet: open an XLSX/CSV, ⌘F, type a value — matching cells get amber bg, active match gets stronger color + outline and is scrolled into view; switching sheets resets matches.
- [ ] Native browser CTRL+F still works on the chat panel, sidebar, and other non-viewer regions.
- [ ] Esc closes the search bar; clicking the X also closes it.
- [ ] Search button in each viewer's toolbar opens the same bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
