### PR TITLE
Gate automation editing on can_manage permission

### DIFF
--- a/backend/app/routers/automations.py
+++ b/backend/app/routers/automations.py
@@ -89,7 +89,7 @@ async def _resolve_action_name(action_type: str | None, action_id: str | None) -
     return None
 
 
-async def _to_response(auto) -> AutomationResponse:
+async def _to_response(auto, *, can_manage: bool = True) -> AutomationResponse:
     action_name = await _resolve_action_name(auto.action_type, auto.action_id)
     return AutomationResponse(
         id=str(auto.id),
@@ -107,7 +107,39 @@ async def _to_response(auto) -> AutomationResponse:
         output_config=auto.output_config,
         created_at=auto.created_at.isoformat(),
         updated_at=auto.updated_at.isoformat(),
+        can_manage=can_manage,
     )
+
+
+async def _load_authorized_automation(
+    automation_id: str,
+    user: User,
+    *,
+    manage: bool = False,
+) -> tuple[Automation, access_control.TeamAccessContext]:
+    """Load an automation by id, returning (automation, team_access).
+
+    Raises 404 if the automation doesn't exist; 403 if the caller lacks the
+    requested permission. Distinguishing these statuses lets the frontend show
+    a meaningful error instead of "not found" for permission failures.
+    """
+    try:
+        auto = await Automation.get(PydanticObjectId(automation_id))
+    except Exception:
+        raise HTTPException(status_code=404, detail="Automation not found")
+    if not auto:
+        raise HTTPException(status_code=404, detail="Automation not found")
+
+    team_access = await access_control.get_team_access_context(user)
+    if manage:
+        allowed = access_control.can_manage_automation(auto, user, team_access)
+        forbidden_msg = "You don't have permission to manage this automation"
+    else:
+        allowed = access_control.can_view_automation(auto, user, team_access)
+        forbidden_msg = "You don't have permission to view this automation"
+    if not allowed:
+        raise HTTPException(status_code=403, detail=forbidden_msg)
+    return auto, team_access
 
 
 @router.post("", response_model=AutomationResponse)
@@ -130,7 +162,14 @@ async def list_automations(user: User = Depends(get_current_user)):
     automations = await svc.list_automations(
         user_id=user.user_id, team_id=team_id,
     )
-    return [await _to_response(a) for a in automations]
+    team_access = await access_control.get_team_access_context(user)
+    return [
+        await _to_response(
+            a,
+            can_manage=access_control.can_manage_automation(a, user, team_access),
+        )
+        for a in automations
+    ]
 
 
 @router.get("/active")
@@ -313,25 +352,21 @@ async def get_trigger_event_status(
 
 @router.get("/{automation_id}", response_model=AutomationResponse)
 async def get_automation(automation_id: str, user: User = Depends(get_current_user)):
-    auto = await svc.get_automation(automation_id, user=user)
-    if not auto:
-        raise HTTPException(status_code=404, detail="Automation not found")
-    return await _to_response(auto)
+    auto, team_access = await _load_authorized_automation(automation_id, user)
+    can_manage = access_control.can_manage_automation(auto, user, team_access)
+    return await _to_response(auto, can_manage=can_manage)
 
 
 @router.patch("/{automation_id}", response_model=AutomationResponse)
 async def update_automation(automation_id: str, req: UpdateAutomationRequest, user: User = Depends(get_current_user)):
-    current = await svc.get_automation(automation_id, user=user, manage=True)
-    if not current:
-        raise HTTPException(status_code=404, detail="Automation not found")
+    current, _ = await _load_authorized_automation(automation_id, user, manage=True)
 
     action_type = req.action_type if req.action_type is not None else current.action_type
     action_id = req.action_id if req.action_id is not None else current.action_id
     await _validate_action_target(action_type, action_id, user)
 
-    auto = await svc.update_automation(
-        automation_id,
-        user=user,
+    auto = await svc.apply_automation_update(
+        current,
         name=req.name,
         description=req.description,
         enabled=req.enabled,
@@ -342,16 +377,13 @@ async def update_automation(automation_id: str, req: UpdateAutomationRequest, us
         shared_with_team=req.shared_with_team,
         output_config=req.output_config,
     )
-    if not auto:
-        raise HTTPException(status_code=404, detail="Automation not found")
-    return await _to_response(auto)
+    return await _to_response(auto, can_manage=True)
 
 
 @router.delete("/{automation_id}")
 async def delete_automation(automation_id: str, user: User = Depends(get_current_user)):
-    ok = await svc.delete_automation(automation_id, user=user)
-    if not ok:
-        raise HTTPException(status_code=404, detail="Automation not found")
+    auto, _ = await _load_authorized_automation(automation_id, user, manage=True)
+    await auto.delete()
     return {"ok": True}
 
 

--- a/backend/app/schemas/automations.py
+++ b/backend/app/schemas/automations.py
@@ -74,6 +74,7 @@ class AutomationResponse(BaseModel):
     output_config: dict = {}
     created_at: str
     updated_at: str
+    can_manage: bool = True
 
 
 class TriggerEventStatusResponse(BaseModel):

--- a/backend/app/services/automation_service.py
+++ b/backend/app/services/automation_service.py
@@ -62,9 +62,8 @@ async def get_automation(
     return await Automation.get(PydanticObjectId(automation_id))
 
 
-async def update_automation(
-    automation_id: str,
-    user: User,
+async def apply_automation_update(
+    auto: Automation,
     name: str | None = None,
     description: str | None = None,
     enabled: bool | None = None,
@@ -74,10 +73,7 @@ async def update_automation(
     action_id: str | None = None,
     shared_with_team: bool | None = None,
     output_config: dict | None = None,
-) -> Automation | None:
-    auto = await get_authorized_automation(automation_id, user, manage=True)
-    if not auto:
-        return None
+) -> Automation:
     if name is not None:
         auto.name = name
     if description is not None:
@@ -99,11 +95,3 @@ async def update_automation(
     auto.updated_at = datetime.datetime.now(tz=datetime.timezone.utc)
     await auto.save()
     return auto
-
-
-async def delete_automation(automation_id: str, user: User) -> bool:
-    auto = await get_authorized_automation(automation_id, user, manage=True)
-    if not auto:
-        return False
-    await auto.delete()
-    return True

--- a/backend/tests/test_automation_service.py
+++ b/backend/tests/test_automation_service.py
@@ -15,11 +15,10 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from app.services.automation_service import (
+    apply_automation_update,
     create_automation,
-    delete_automation,
     get_automation,
     list_automations,
-    update_automation,
 )
 
 
@@ -143,32 +142,17 @@ class TestGetAutomation:
         MockA.get.assert_awaited_once()
 
 
-class TestUpdateAutomation:
-    @pytest.mark.asyncio
-    async def test_unauthorized_returns_none_without_side_effects(self):
-        user = SimpleNamespace(user_id="alice")
-        with patch(
-            "app.services.automation_service.get_authorized_automation",
-            AsyncMock(return_value=None),
-        ):
-            result = await update_automation("a-1", user, name="new")
-        assert result is None
-
+class TestApplyAutomationUpdate:
     @pytest.mark.asyncio
     async def test_selected_fields_updated_others_preserved(self):
         auto = _auto(name="Old", enabled=True, description="original")
-        user = SimpleNamespace(user_id="alice")
 
-        with patch(
-            "app.services.automation_service.get_authorized_automation",
-            AsyncMock(return_value=auto),
-        ):
-            result = await update_automation(
-                "a-1", user,
-                name="New name",
-                enabled=False,
-                trigger_config={"k": "v"},
-            )
+        result = await apply_automation_update(
+            auto,
+            name="New name",
+            enabled=False,
+            trigger_config={"k": "v"},
+        )
 
         assert result is auto
         assert auto.name == "New name"
@@ -181,45 +165,18 @@ class TestUpdateAutomation:
     @pytest.mark.asyncio
     async def test_all_optional_fields_can_be_updated(self):
         auto = _auto()
-        user = SimpleNamespace(user_id="alice")
-        with patch(
-            "app.services.automation_service.get_authorized_automation",
-            AsyncMock(return_value=auto),
-        ):
-            await update_automation(
-                "a-1", user,
-                description="new description",
-                trigger_type="m365",
-                action_type="chain",
-                action_id="wf-2",
-                shared_with_team=True,
-                output_config={"dest": "/out"},
-            )
+        await apply_automation_update(
+            auto,
+            description="new description",
+            trigger_type="m365",
+            action_type="chain",
+            action_id="wf-2",
+            shared_with_team=True,
+            output_config={"dest": "/out"},
+        )
         assert auto.description == "new description"
         assert auto.trigger_type == "m365"
         assert auto.action_type == "chain"
         assert auto.action_id == "wf-2"
         assert auto.shared_with_team is True
         assert auto.output_config == {"dest": "/out"}
-
-
-class TestDeleteAutomation:
-    @pytest.mark.asyncio
-    async def test_missing_returns_false(self):
-        user = SimpleNamespace(user_id="alice")
-        with patch(
-            "app.services.automation_service.get_authorized_automation",
-            AsyncMock(return_value=None),
-        ):
-            assert await delete_automation("a-1", user) is False
-
-    @pytest.mark.asyncio
-    async def test_deletes_and_returns_true(self):
-        auto = _auto()
-        user = SimpleNamespace(user_id="alice")
-        with patch(
-            "app.services.automation_service.get_authorized_automation",
-            AsyncMock(return_value=auto),
-        ):
-            assert await delete_automation("a-1", user) is True
-        auto.delete.assert_awaited_once()

--- a/backend/tests/test_automations_api_integration.py
+++ b/backend/tests/test_automations_api_integration.py
@@ -15,6 +15,7 @@ from bson import ObjectId
 from httpx import ASGITransport, AsyncClient
 
 from app.config import Settings
+from app.services.access_control import TeamAccessContext
 from app.utils.security import create_access_token, hash_api_token
 
 _TEST_SETTINGS = Settings(jwt_secret_key="test-secret-key", environment="development")
@@ -74,6 +75,7 @@ def _make_automation(
     auto.output_config = output_config or {}
     auto.created_at = datetime.datetime.now(datetime.timezone.utc)
     auto.updated_at = datetime.datetime.now(datetime.timezone.utc)
+    auto.delete = AsyncMock()
     return auto
 
 
@@ -949,7 +951,9 @@ class TestAutomationCRUD:
 
         with patch("app.dependencies.decode_token", return_value={"sub": "testuser", "type": "access"}), \
              patch("app.dependencies.User") as MockUser, \
-             patch("app.routers.automations.svc.list_automations", new_callable=AsyncMock, return_value=[auto]):
+             patch("app.routers.automations.svc.list_automations", new_callable=AsyncMock, return_value=[auto]), \
+             patch("app.routers.automations.access_control.get_team_access_context", new_callable=AsyncMock, return_value=TeamAccessContext()), \
+             patch("app.routers.automations.access_control.can_manage_automation", return_value=True):
             MockUser.find_one = AsyncMock(return_value=user)
 
             resp = await client.get(
@@ -962,15 +966,22 @@ class TestAutomationCRUD:
         body = resp.json()
         assert len(body) == 1
         assert body[0]["name"] == "Test Automation"
+        assert body[0]["can_manage"] is True
 
     @pytest.mark.asyncio
     async def test_get_automation_not_found(self, client):
         user = _make_user()
         cookies, headers = _auth_cookies()
 
+        from fastapi import HTTPException
+
         with patch("app.dependencies.decode_token", return_value={"sub": "testuser", "type": "access"}), \
              patch("app.dependencies.User") as MockUser, \
-             patch("app.routers.automations.svc.get_automation", new_callable=AsyncMock, return_value=None):
+             patch(
+                 "app.routers.automations._load_authorized_automation",
+                 new_callable=AsyncMock,
+                 side_effect=HTTPException(status_code=404, detail="Automation not found"),
+             ):
             MockUser.find_one = AsyncMock(return_value=user)
 
             resp = await client.get(
@@ -980,6 +991,30 @@ class TestAutomationCRUD:
             )
 
         assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_get_automation_forbidden_returns_403(self, client):
+        user = _make_user()
+        cookies, headers = _auth_cookies()
+
+        from fastapi import HTTPException
+
+        with patch("app.dependencies.decode_token", return_value={"sub": "testuser", "type": "access"}), \
+             patch("app.dependencies.User") as MockUser, \
+             patch(
+                 "app.routers.automations._load_authorized_automation",
+                 new_callable=AsyncMock,
+                 side_effect=HTTPException(status_code=403, detail="You don't have permission to view this automation"),
+             ):
+            MockUser.find_one = AsyncMock(return_value=user)
+
+            resp = await client.get(
+                "/api/automations/auto-1",
+                cookies=cookies,
+                headers=headers,
+            )
+
+        assert resp.status_code == 403
 
     @pytest.mark.asyncio
     async def test_update_automation(self, client):
@@ -992,9 +1027,9 @@ class TestAutomationCRUD:
 
         with patch("app.dependencies.decode_token", return_value={"sub": "testuser", "type": "access"}), \
              patch("app.dependencies.User") as MockUser, \
-             patch("app.routers.automations.svc.get_automation", new_callable=AsyncMock, return_value=auto), \
+             patch("app.routers.automations._load_authorized_automation", new_callable=AsyncMock, return_value=(auto, TeamAccessContext())), \
              patch("app.routers.automations._validate_action_target", new_callable=AsyncMock), \
-             patch("app.routers.automations.svc.update_automation", new_callable=AsyncMock, return_value=auto):
+             patch("app.routers.automations.svc.apply_automation_update", new_callable=AsyncMock, return_value=auto):
             MockUser.find_one = AsyncMock(return_value=user)
 
             resp = await client.patch(
@@ -1005,15 +1040,22 @@ class TestAutomationCRUD:
             )
 
         assert resp.status_code == 200
+        assert resp.json()["can_manage"] is True
 
     @pytest.mark.asyncio
     async def test_update_nonexistent_returns_404(self, client):
         user = _make_user()
         cookies, headers = _auth_cookies()
 
+        from fastapi import HTTPException
+
         with patch("app.dependencies.decode_token", return_value={"sub": "testuser", "type": "access"}), \
              patch("app.dependencies.User") as MockUser, \
-             patch("app.routers.automations.svc.get_automation", new_callable=AsyncMock, return_value=None):
+             patch(
+                 "app.routers.automations._load_authorized_automation",
+                 new_callable=AsyncMock,
+                 side_effect=HTTPException(status_code=404, detail="Automation not found"),
+             ):
             MockUser.find_one = AsyncMock(return_value=user)
 
             resp = await client.patch(
@@ -1026,13 +1068,39 @@ class TestAutomationCRUD:
         assert resp.status_code == 404
 
     @pytest.mark.asyncio
-    async def test_delete_automation(self, client):
+    async def test_update_forbidden_returns_403(self, client):
         user = _make_user()
         cookies, headers = _auth_cookies()
 
+        from fastapi import HTTPException
+
         with patch("app.dependencies.decode_token", return_value={"sub": "testuser", "type": "access"}), \
              patch("app.dependencies.User") as MockUser, \
-             patch("app.routers.automations.svc.delete_automation", new_callable=AsyncMock, return_value=True):
+             patch(
+                 "app.routers.automations._load_authorized_automation",
+                 new_callable=AsyncMock,
+                 side_effect=HTTPException(status_code=403, detail="You don't have permission to manage this automation"),
+             ):
+            MockUser.find_one = AsyncMock(return_value=user)
+
+            resp = await client.patch(
+                "/api/automations/auto-1",
+                json={"enabled": False},
+                cookies=cookies,
+                headers=headers,
+            )
+
+        assert resp.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_delete_automation(self, client):
+        user = _make_user()
+        cookies, headers = _auth_cookies()
+        auto = _make_automation()
+
+        with patch("app.dependencies.decode_token", return_value={"sub": "testuser", "type": "access"}), \
+             patch("app.dependencies.User") as MockUser, \
+             patch("app.routers.automations._load_authorized_automation", new_callable=AsyncMock, return_value=(auto, TeamAccessContext())):
             MockUser.find_one = AsyncMock(return_value=user)
 
             resp = await client.delete(
@@ -1043,15 +1111,22 @@ class TestAutomationCRUD:
 
         assert resp.status_code == 200
         assert resp.json()["ok"] is True
+        auto.delete.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_delete_nonexistent_returns_404(self, client):
         user = _make_user()
         cookies, headers = _auth_cookies()
 
+        from fastapi import HTTPException
+
         with patch("app.dependencies.decode_token", return_value={"sub": "testuser", "type": "access"}), \
              patch("app.dependencies.User") as MockUser, \
-             patch("app.routers.automations.svc.delete_automation", new_callable=AsyncMock, return_value=False):
+             patch(
+                 "app.routers.automations._load_authorized_automation",
+                 new_callable=AsyncMock,
+                 side_effect=HTTPException(status_code=404, detail="Automation not found"),
+             ):
             MockUser.find_one = AsyncMock(return_value=user)
 
             resp = await client.delete(
@@ -1061,6 +1136,30 @@ class TestAutomationCRUD:
             )
 
         assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_delete_forbidden_returns_403(self, client):
+        user = _make_user()
+        cookies, headers = _auth_cookies()
+
+        from fastapi import HTTPException
+
+        with patch("app.dependencies.decode_token", return_value={"sub": "testuser", "type": "access"}), \
+             patch("app.dependencies.User") as MockUser, \
+             patch(
+                 "app.routers.automations._load_authorized_automation",
+                 new_callable=AsyncMock,
+                 side_effect=HTTPException(status_code=403, detail="You don't have permission to manage this automation"),
+             ):
+            MockUser.find_one = AsyncMock(return_value=user)
+
+            resp = await client.delete(
+                "/api/automations/auto-1",
+                cookies=cookies,
+                headers=headers,
+            )
+
+        assert resp.status_code == 403
 
     @pytest.mark.asyncio
     async def test_unauthenticated_crud_returns_401(self, client):

--- a/frontend/src/components/workspace/AutomationEditorPanel.tsx
+++ b/frontend/src/components/workspace/AutomationEditorPanel.tsx
@@ -51,12 +51,15 @@ export function AutomationEditorPanel() {
     }
   }, [editingTitle])
 
+  const canManage = automation?.can_manage ?? true
+
   const save = useCallback(async (updates: Parameters<typeof updateAutomation>[1]) => {
     if (!openAutomationId) return
+    if (automation && !automation.can_manage) return
     const updated = await updateAutomation(openAutomationId, updates)
     setAutomation(updated)
     window.dispatchEvent(new Event('automations-updated'))
-  }, [openAutomationId])
+  }, [openAutomationId, automation])
 
   const debouncedSave = useCallback((updates: Parameters<typeof updateAutomation>[1]) => {
     if (saveTimeoutRef.current) clearTimeout(saveTimeoutRef.current)
@@ -77,30 +80,33 @@ export function AutomationEditorPanel() {
   }
 
   const handleDelete = async () => {
-    if (!openAutomationId) return
+    if (!openAutomationId || !canManage) return
     await deleteAutomation(openAutomationId)
     closeAutomation()
   }
 
   const handleToggleEnabled = async () => {
-    if (!automation) return
+    if (!automation || !canManage) return
     await save({ enabled: !automation.enabled })
   }
 
   const handleToggleShared = async () => {
-    if (!automation) return
+    if (!automation || !canManage) return
     await save({ shared_with_team: !automation.shared_with_team })
   }
 
   const handleTriggerTypeChange = async (type: TriggerType) => {
+    if (!canManage) return
     await save({ trigger_type: type, trigger_config: {} })
   }
 
   const handleActionTypeChange = async (type: ActionType) => {
+    if (!canManage) return
     await save({ action_type: type, action_id: undefined })
   }
 
   const handleActionSelect = async (id: string) => {
+    if (!canManage) return
     await save({ action_id: id || undefined })
   }
 
@@ -145,26 +151,33 @@ export function AutomationEditorPanel() {
             />
           ) : (
             <div
-              style={{ display: 'flex', alignItems: 'center', gap: 8, cursor: 'pointer', flex: 1 }}
-              onClick={() => { setTitleValue(automation.name); setEditingTitle(true) }}
+              style={{ display: 'flex', alignItems: 'center', gap: 8, cursor: canManage ? 'pointer' : 'default', flex: 1 }}
+              onClick={() => {
+                if (!canManage) return
+                setTitleValue(automation.name)
+                setEditingTitle(true)
+              }}
             >
               <span style={{ fontSize: 18, fontWeight: 600, color: '#202124', letterSpacing: '-0.01em' }}>
                 {automation.name}
               </span>
-              <Pencil style={{ width: 14, height: 14, color: '#9ca3af' }} />
+              {canManage && <Pencil style={{ width: 14, height: 14, color: '#9ca3af' }} />}
             </div>
           )}
           <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexShrink: 0 }}>
             {/* Enabled toggle */}
             <button
               onClick={handleToggleEnabled}
+              disabled={!canManage}
+              title={canManage ? undefined : 'Only the creator or a team owner/admin can change this'}
               style={{
                 display: 'flex', alignItems: 'center', gap: 6, padding: '4px 12px',
                 fontSize: 12, fontWeight: 600, fontFamily: 'inherit',
                 color: automation.enabled ? '#15803d' : '#6b7280',
                 backgroundColor: automation.enabled ? '#dcfce7' : '#f3f4f6',
                 border: '1px solid ' + (automation.enabled ? '#bbf7d0' : '#e5e7eb'),
-                borderRadius: 16, cursor: 'pointer',
+                borderRadius: 16, cursor: canManage ? 'pointer' : 'not-allowed',
+                opacity: canManage ? 1 : 0.6,
               }}
             >
               <span style={{
@@ -176,25 +189,30 @@ export function AutomationEditorPanel() {
             {/* Visible to team toggle */}
             <button
               onClick={handleToggleShared}
+              disabled={!canManage}
+              title={canManage ? undefined : 'Only the creator or a team owner/admin can change this'}
               style={{
                 display: 'flex', alignItems: 'center', gap: 6, padding: '4px 12px',
                 fontSize: 12, fontWeight: 600, fontFamily: 'inherit',
                 color: automation.shared_with_team ? 'rgb(0, 128, 128)' : '#6b7280',
                 backgroundColor: automation.shared_with_team ? 'rgba(0, 128, 128, 0.1)' : '#f3f4f6',
                 border: '1px solid ' + (automation.shared_with_team ? 'rgba(0, 128, 128, 0.3)' : '#e5e7eb'),
-                borderRadius: 16, cursor: 'pointer',
+                borderRadius: 16, cursor: canManage ? 'pointer' : 'not-allowed',
+                opacity: canManage ? 1 : 0.6,
               }}
             >
               {automation.shared_with_team ? 'Visible to team' : 'Private'}
             </button>
             {/* Delete */}
-            <button
-              onClick={handleDelete}
-              style={{ background: 'none', border: 'none', cursor: 'pointer', padding: 4, borderRadius: 4, color: '#d93025', display: 'flex' }}
-              title="Delete automation"
-            >
-              <Trash2 style={{ width: 16, height: 16 }} />
-            </button>
+            {canManage && (
+              <button
+                onClick={handleDelete}
+                style={{ background: 'none', border: 'none', cursor: 'pointer', padding: 4, borderRadius: 4, color: '#d93025', display: 'flex' }}
+                title="Delete automation"
+              >
+                <Trash2 style={{ width: 16, height: 16 }} />
+              </button>
+            )}
             {/* Close */}
             <button
               onClick={closeAutomation}
@@ -208,10 +226,21 @@ export function AutomationEditorPanel() {
 
       {/* Body */}
       <div style={{ flex: 1, overflowY: 'auto', padding: '24px', minHeight: 0 }}>
+        {!canManage && (
+          <div style={{
+            padding: '10px 14px', marginBottom: 16, borderRadius: 6,
+            backgroundColor: '#fef3c7', border: '1px solid #fde68a',
+            color: '#92400e', fontSize: 12, lineHeight: 1.45,
+          }}>
+            <strong>View only.</strong> This automation was shared with your team by another member.
+            Only the creator or a team owner/admin can change or delete it.
+          </div>
+        )}
         {/* Description */}
         <input
           type="text"
           defaultValue={automation.description || ''}
+          disabled={!canManage}
           onBlur={e => {
             const v = e.target.value.trim()
             if (v !== (automation.description || '')) debouncedSave({ description: v || undefined })

--- a/frontend/src/types/automation.ts
+++ b/frontend/src/types/automation.ts
@@ -17,4 +17,5 @@ export interface Automation {
   output_config: Record<string, unknown>
   created_at: string
   updated_at: string
+  can_manage: boolean
 }


### PR DESCRIPTION
## Summary
- Distinguish 404 vs 403 on `GET/PATCH/DELETE /automations/{id}` so the frontend can render a meaningful state instead of "not found" when a user lacks permission.
- Add a per-automation `can_manage` flag to `AutomationResponse` (computed via `access_control.can_manage_automation`) so the editor knows whether the current user can mutate the record.
- Disable name editing, enabled/shared toggles, trigger/action selects, description, and delete in `AutomationEditorPanel` when `can_manage` is false; show a "View only" banner for team-shared automations.
- Refactor the service layer: authorization is enforced at the router (one place, with helper `_load_authorized_automation`); `update_automation` becomes `apply_automation_update(auto, ...)` that mutates an already-loaded doc, and `delete_automation` is removed (router deletes inline).

## Test plan
- [x] `pytest tests/test_automation_service.py tests/test_automations_api_integration.py` — 56 passed locally
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — 0 errors (only pre-existing warnings)
- [x] `vitest run` — 135 passed
- [ ] Manual: as the automation creator, confirm all controls work
- [ ] Manual: as a non-owner team member viewing a shared automation, confirm the "View only" banner renders and all edit/delete affordances are disabled or hidden
- [ ] Manual: confirm the API returns 403 (not 404) when a non-owner tries to PATCH/DELETE someone else's automation

🤖 Generated with [Claude Code](https://claude.com/claude-code)