### PR TITLE
Show toast on workflow/extraction JSON import

### DIFF
--- a/frontend/src/components/workspace/ExtractionEditorPanel.tsx
+++ b/frontend/src/components/workspace/ExtractionEditorPanel.tsx
@@ -560,8 +560,9 @@ export function ExtractionEditorPanel() {
             } else {
               openExtraction(result.uuid)
             }
+            toast('Extraction imported successfully', 'success')
           } catch (err: unknown) {
-            alert(err instanceof Error ? err.message : 'Import failed')
+            toast(err instanceof Error ? err.message : 'Import failed', 'error')
           }
         }}
       />

--- a/frontend/src/components/workspace/WorkflowEditorPanel.tsx
+++ b/frontend/src/components/workspace/WorkflowEditorPanel.tsx
@@ -491,8 +491,9 @@ export function WorkflowEditorPanel() {
                 await importIntoWorkflow(workflow.id, f)
                 await queryClient.invalidateQueries({ queryKey: ['workflows'] })
                 await refresh()
+                toast('Workflow imported successfully', 'success')
               } catch (err: unknown) {
-                alert(err instanceof Error ? err.message : 'Import failed')
+                toast(err instanceof Error ? err.message : 'Import failed', 'error')
               }
             }}
           />


### PR DESCRIPTION
## Summary
- Workflow and extraction JSON imports completed silently, with no UI feedback that the action had succeeded
- Add a success toast on completion in `WorkflowEditorPanel` and `ExtractionEditorPanel`
- Replace the failure `alert()` with an error toast for consistency with the rest of these panels

## Test plan
- [ ] Open a workflow, import a JSON definition, and confirm a "Workflow imported successfully" toast appears
- [ ] Open an extraction (or import without one open), import a JSON definition, and confirm an "Extraction imported successfully" toast appears
- [ ] Import an invalid JSON file and confirm an error toast appears (instead of a browser alert)

🤖 Generated with [Claude Code](https://claude.com/claude-code)