### PR TITLE
Add 'What is this?' explainer overlays for Automations and KBs

### DIFF
--- a/frontend/src/components/workspace/AutomationEditorPanel.tsx
+++ b/frontend/src/components/workspace/AutomationEditorPanel.tsx
@@ -1,11 +1,12 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { X, Pencil, Trash2, FolderOpen, Globe, Copy, Check, ChevronRight } from 'lucide-react'
+import { X, Pencil, Trash2, FolderOpen, Globe, Copy, Check, ChevronRight, HelpCircle } from 'lucide-react'
 import { useWorkspace } from '../../contexts/WorkspaceContext'
 import { getAutomation, updateAutomation, deleteAutomation } from '../../api/automations'
 import { apiFetch } from '../../api/client'
 import { useWorkflows } from '../../hooks/useWorkflows'
 import { useSearchSets } from '../../hooks/useExtractions'
 import { ItemPickerModal } from './ItemPickerModal'
+import { AutomationsExplainer } from './AutomationsExplainer'
 import type { Automation, TriggerType, ActionType } from '../../types/automation'
 
 const TRIGGER_OPTIONS: { value: TriggerType; label: string; icon: typeof FolderOpen; description: string }[] = [
@@ -26,6 +27,7 @@ export function AutomationEditorPanel() {
   const [automation, setAutomation] = useState<Automation | null>(null)
   const [loading, setLoading] = useState(true)
   const [showActionPicker, setShowActionPicker] = useState(false)
+  const [showExplainer, setShowExplainer] = useState(false)
   const [editingTitle, setEditingTitle] = useState(false)
   const [titleValue, setTitleValue] = useState('')
   const titleInputRef = useRef<HTMLInputElement>(null)
@@ -129,7 +131,7 @@ export function AutomationEditorPanel() {
   }
 
   return (
-    <div className="flex h-full flex-col" style={{ backgroundColor: '#fff' }}>
+    <div className="flex h-full flex-col" style={{ backgroundColor: '#fff', position: 'relative' }}>
       {/* Header */}
       <div style={{ padding: '16px 24px', borderBottom: '1px solid #e5e7eb', flexShrink: 0 }}>
         <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
@@ -395,7 +397,38 @@ export function AutomationEditorPanel() {
         <SectionLabel>Post-Action Output</SectionLabel>
         <OutputStorageCard automation={automation} onSave={debouncedSave} />
         <OutputNotificationCard automation={automation} onSave={debouncedSave} />
+
+        {/* "What are automations?" pill */}
+        <div style={{ display: 'flex', justifyContent: 'center', marginTop: 24, marginBottom: 4 }}>
+          <button
+            onClick={() => setShowExplainer(true)}
+            style={{
+              display: 'inline-flex', alignItems: 'center', gap: 6,
+              padding: '6px 14px', fontSize: 12, fontWeight: 500, fontFamily: 'inherit',
+              color: '#6b7280',
+              backgroundColor: '#f9fafb',
+              border: '1px solid #e5e7eb',
+              borderRadius: 999, cursor: 'pointer',
+              transition: 'all 0.15s',
+            }}
+            onMouseEnter={e => {
+              e.currentTarget.style.backgroundColor = '#f3f4f6'
+              e.currentTarget.style.color = '#374151'
+              e.currentTarget.style.borderColor = '#d1d5db'
+            }}
+            onMouseLeave={e => {
+              e.currentTarget.style.backgroundColor = '#f9fafb'
+              e.currentTarget.style.color = '#6b7280'
+              e.currentTarget.style.borderColor = '#e5e7eb'
+            }}
+          >
+            <HelpCircle size={13} />
+            What are automations?
+          </button>
+        </div>
       </div>
+
+      {showExplainer && <AutomationsExplainer onClose={() => setShowExplainer(false)} />}
     </div>
   )
 }

--- a/frontend/src/components/workspace/AutomationsExplainer.tsx
+++ b/frontend/src/components/workspace/AutomationsExplainer.tsx
@@ -1,0 +1,283 @@
+import { useEffect } from 'react'
+import { X, FolderSearch, Zap, FileCheck, Sparkles, type LucideIcon } from 'lucide-react'
+import { AutomationsTutorial } from './AutomationsTutorial'
+
+export function AutomationsExplainer({ onClose }: { onClose: () => void }) {
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    window.addEventListener('keydown', handler)
+    return () => window.removeEventListener('keydown', handler)
+  }, [onClose])
+
+  return (
+    <>
+      <style>{`
+        @keyframes explainerFadeIn {
+          from { opacity: 0; }
+          to { opacity: 1; }
+        }
+        @keyframes explainerScaleIn {
+          from { opacity: 0; transform: translateY(16px) scale(0.985); }
+          to { opacity: 1; transform: translateY(0) scale(1); }
+        }
+        @keyframes explainerSectionIn {
+          from { opacity: 0; transform: translateY(14px); }
+          to { opacity: 1; transform: translateY(0); }
+        }
+        @keyframes explainerGlow {
+          0%, 100% { opacity: 0.45; }
+          50% { opacity: 0.85; }
+        }
+        .explainer-root { animation: explainerFadeIn 220ms ease-out; }
+        .explainer-content { animation: explainerScaleIn 420ms cubic-bezier(0.2, 0.8, 0.2, 1); }
+        .explainer-section { opacity: 0; animation: explainerSectionIn 520ms cubic-bezier(0.2, 0.8, 0.2, 1) forwards; }
+        .explainer-glow { animation: explainerGlow 4s ease-in-out infinite; }
+      `}</style>
+
+      <div
+        className="explainer-root"
+        style={{
+          position: 'absolute', inset: 0, zIndex: 50,
+          background: 'radial-gradient(ellipse at top, #232a3d 0%, #141826 55%, #0d111c 100%)',
+          overflowY: 'auto',
+        }}
+      >
+        {/* Ambient glow */}
+        <div
+          className="explainer-glow"
+          style={{
+            position: 'absolute', top: -120, left: '50%', transform: 'translateX(-50%)',
+            width: 520, height: 520, borderRadius: '50%',
+            background: 'radial-gradient(circle, rgba(234, 179, 8, 0.15) 0%, transparent 65%)',
+            pointerEvents: 'none',
+          }}
+        />
+
+        {/* Close button */}
+        <button
+          onClick={onClose}
+          style={{
+            position: 'absolute', top: 14, right: 14, zIndex: 10,
+            display: 'flex', alignItems: 'center', justifyContent: 'center',
+            width: 32, height: 32, borderRadius: 8,
+            background: 'rgba(255,255,255,0.06)',
+            border: '1px solid rgba(255,255,255,0.1)',
+            color: '#c0c7d6', cursor: 'pointer',
+          }}
+          aria-label="Close"
+        >
+          <X size={16} />
+        </button>
+
+        <div className="explainer-content" style={{ padding: '48px 32px 56px', maxWidth: 720, margin: '0 auto', position: 'relative' }}>
+          {/* Hero */}
+          <div className="explainer-section" style={{ animationDelay: '60ms', textAlign: 'center', marginBottom: 28 }}>
+            <div style={{
+              display: 'inline-flex', alignItems: 'center', gap: 6, padding: '5px 14px',
+              borderRadius: 999,
+              background: 'rgba(234, 179, 8, 0.12)',
+              border: '1px solid rgba(234, 179, 8, 0.3)',
+              fontSize: 11, fontWeight: 700, color: '#fbbf24',
+              textTransform: 'uppercase', letterSpacing: '0.1em',
+              marginBottom: 18,
+            }}>
+              <Sparkles size={12} /> Automations
+            </div>
+            <h1 style={{
+              fontSize: 34, fontWeight: 700, color: '#fff', letterSpacing: '-0.025em',
+              lineHeight: 1.1, margin: '0 0 14px',
+            }}>
+              Work that runs<br />while you don't have to.
+            </h1>
+            <p style={{
+              fontSize: 15, color: '#9aa3b8', maxWidth: 500, margin: '0 auto', lineHeight: 1.6,
+            }}>
+              Automations watch for new files, run the right workflow on them, and put the
+              results wherever you need. Set one up once — then forget it exists.
+            </p>
+          </div>
+
+          {/* Animation */}
+          <div className="explainer-section" style={{ animationDelay: '180ms', marginBottom: 44 }}>
+            <AutomationsTutorial />
+          </div>
+
+          {/* What they do */}
+          <Section title="What they do for you" delay="280ms">
+            <Card
+              icon={FolderSearch}
+              title="Watch"
+              body="Monitor a folder, an inbox, or an API endpoint for new documents."
+            />
+            <Card
+              icon={Zap}
+              title="Trigger"
+              body="The moment a file arrives, run an extraction, workflow, or task on it."
+            />
+            <Card
+              icon={FileCheck}
+              title="Deliver"
+              body="Save the results to a folder, email your team, or push them to downstream systems."
+            />
+          </Section>
+
+          {/* Research admin examples */}
+          <Section
+            title="Built for research administration"
+            subtitle="Patterns we see across grants, contracts, and compliance offices."
+            delay="380ms"
+          >
+            <UseCase
+              accent="#f59e0b"
+              trigger="New NIH award letter lands in /Awards/2026"
+              action="Extract sponsor terms, period dates, and budget — route a summary to compliance and the PI."
+            />
+            <UseCase
+              accent="#3b82f6"
+              trigger="Contract uploaded to /Legal/Subawards"
+              action="Pull obligation amounts, key dates, and termination clauses. Email the findings to the pre-award analyst."
+            />
+            <UseCase
+              accent="#8b5cf6"
+              trigger="IRB protocol submitted via API"
+              action="Validate required sections, flag missing approvals, and create a coordinator checklist."
+            />
+            <UseCase
+              accent="#10b981"
+              trigger="Cost-share commitment letter received"
+              action="Extract committed amounts and matching periods, append a row to the cost-share log."
+            />
+          </Section>
+
+          {/* How to use */}
+          <Section title="How you'd set one up" delay="480ms">
+            <Step num="1" title="Pick a trigger" body="Watch a folder, expose an API endpoint, or connect an M365 inbox." />
+            <Step num="2" title="Pick what to run" body="Choose a workflow, an extraction template, or a single task." />
+            <Step num="3" title="Choose where results go" body="Save to a folder, email a recipient list, or both." />
+            <Step num="4" title="Enable it" body="That's the whole job. Files arrive, work happens, results land where you need them." />
+          </Section>
+
+          {/* CTA */}
+          <div className="explainer-section" style={{ animationDelay: '580ms', textAlign: 'center', marginTop: 36 }}>
+            <button
+              onClick={onClose}
+              style={{
+                padding: '11px 26px', fontSize: 14, fontWeight: 600,
+                color: '#1a1f2e',
+                background: 'linear-gradient(135deg, #fbbf24 0%, #eab308 100%)',
+                border: 'none', borderRadius: 10, cursor: 'pointer', fontFamily: 'inherit',
+                boxShadow: '0 6px 20px -6px rgba(234, 179, 8, 0.5)',
+              }}
+            >
+              Got it — back to the automation
+            </button>
+          </div>
+        </div>
+      </div>
+    </>
+  )
+}
+
+function Section({
+  title, subtitle, delay, children,
+}: {
+  title: string; subtitle?: string; delay: string; children: React.ReactNode
+}) {
+  return (
+    <div className="explainer-section" style={{ animationDelay: delay, marginBottom: 36 }}>
+      <h2 style={{
+        fontSize: 20, fontWeight: 700, color: '#fff', margin: '0 0 4px',
+        letterSpacing: '-0.01em',
+      }}>
+        {title}
+      </h2>
+      {subtitle && (
+        <p style={{ fontSize: 13, color: '#7a8499', margin: '0 0 14px' }}>{subtitle}</p>
+      )}
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 10, marginTop: subtitle ? 0 : 14 }}>
+        {children}
+      </div>
+    </div>
+  )
+}
+
+function Card({ icon: Icon, title, body }: { icon: LucideIcon; title: string; body: string }) {
+  return (
+    <div style={{
+      display: 'flex', gap: 14, alignItems: 'flex-start',
+      padding: 16, borderRadius: 12,
+      background: 'rgba(255,255,255,0.03)',
+      border: '1px solid rgba(255,255,255,0.07)',
+    }}>
+      <div style={{
+        width: 36, height: 36, borderRadius: 10,
+        background: 'rgba(234, 179, 8, 0.12)',
+        border: '1px solid rgba(234, 179, 8, 0.28)',
+        display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0,
+      }}>
+        <Icon size={18} style={{ color: '#fbbf24' }} />
+      </div>
+      <div>
+        <div style={{ fontSize: 14, fontWeight: 600, color: '#e5e7eb', marginBottom: 4 }}>
+          {title}
+        </div>
+        <div style={{ fontSize: 13, color: '#9aa3b8', lineHeight: 1.55 }}>{body}</div>
+      </div>
+    </div>
+  )
+}
+
+function UseCase({ trigger, action, accent }: { trigger: string; action: string; accent: string }) {
+  return (
+    <div style={{
+      padding: 16, borderRadius: 12,
+      background: 'rgba(255,255,255,0.03)',
+      border: '1px solid rgba(255,255,255,0.07)',
+      borderLeft: `3px solid ${accent}`,
+    }}>
+      <div style={{
+        display: 'inline-block', padding: '2px 8px', borderRadius: 6,
+        background: `${accent}22`, color: accent,
+        fontSize: 10, fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.08em',
+        marginBottom: 8,
+      }}>
+        When
+      </div>
+      <div style={{ fontSize: 13.5, fontWeight: 600, color: '#e5e7eb', marginBottom: 8, lineHeight: 1.45 }}>
+        {trigger}
+      </div>
+      <div style={{ fontSize: 13, color: '#9aa3b8', lineHeight: 1.55 }}>
+        <span style={{ color: accent, fontWeight: 600 }}>→ </span>{action}
+      </div>
+    </div>
+  )
+}
+
+function Step({ num, title, body }: { num: string; title: string; body: string }) {
+  return (
+    <div style={{
+      display: 'flex', gap: 14, alignItems: 'flex-start',
+      padding: 14, borderRadius: 12,
+      background: 'rgba(255,255,255,0.03)',
+      border: '1px solid rgba(255,255,255,0.07)',
+    }}>
+      <div style={{
+        width: 28, height: 28, borderRadius: '50%',
+        background: 'linear-gradient(135deg, #fbbf24 0%, #eab308 100%)',
+        display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0,
+        fontSize: 13, fontWeight: 700, color: '#1a1f2e',
+        boxShadow: '0 2px 10px -2px rgba(234, 179, 8, 0.4)',
+      }}>
+        {num}
+      </div>
+      <div>
+        <div style={{ fontSize: 14, fontWeight: 600, color: '#e5e7eb', marginBottom: 2 }}>
+          {title}
+        </div>
+        <div style={{ fontSize: 13, color: '#9aa3b8', lineHeight: 1.55 }}>{body}</div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/workspace/KnowledgeExplainer.tsx
+++ b/frontend/src/components/workspace/KnowledgeExplainer.tsx
@@ -1,0 +1,283 @@
+import { useEffect } from 'react'
+import { X, Layers, Search, BookOpen, Sparkles, type LucideIcon } from 'lucide-react'
+import { KnowledgeTutorial } from './KnowledgeTutorial'
+
+export function KnowledgeExplainer({ onClose }: { onClose: () => void }) {
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    window.addEventListener('keydown', handler)
+    return () => window.removeEventListener('keydown', handler)
+  }, [onClose])
+
+  return (
+    <>
+      <style>{`
+        @keyframes kbExplainerFadeIn {
+          from { opacity: 0; }
+          to { opacity: 1; }
+        }
+        @keyframes kbExplainerScaleIn {
+          from { opacity: 0; transform: translateY(16px) scale(0.985); }
+          to { opacity: 1; transform: translateY(0) scale(1); }
+        }
+        @keyframes kbExplainerSectionIn {
+          from { opacity: 0; transform: translateY(14px); }
+          to { opacity: 1; transform: translateY(0); }
+        }
+        @keyframes kbExplainerGlow {
+          0%, 100% { opacity: 0.45; }
+          50% { opacity: 0.85; }
+        }
+        .kb-explainer-root { animation: kbExplainerFadeIn 220ms ease-out; }
+        .kb-explainer-content { animation: kbExplainerScaleIn 420ms cubic-bezier(0.2, 0.8, 0.2, 1); }
+        .kb-explainer-section { opacity: 0; animation: kbExplainerSectionIn 520ms cubic-bezier(0.2, 0.8, 0.2, 1) forwards; }
+        .kb-explainer-glow { animation: kbExplainerGlow 4s ease-in-out infinite; }
+      `}</style>
+
+      <div
+        className="kb-explainer-root"
+        style={{
+          position: 'absolute', inset: 0, zIndex: 50,
+          background: 'radial-gradient(ellipse at top, #1f2740 0%, #131628 55%, #0c1020 100%)',
+          overflowY: 'auto',
+        }}
+      >
+        {/* Ambient glow */}
+        <div
+          className="kb-explainer-glow"
+          style={{
+            position: 'absolute', top: -120, left: '50%', transform: 'translateX(-50%)',
+            width: 520, height: 520, borderRadius: '50%',
+            background: 'radial-gradient(circle, rgba(96, 165, 250, 0.18) 0%, transparent 65%)',
+            pointerEvents: 'none',
+          }}
+        />
+
+        {/* Close button */}
+        <button
+          onClick={onClose}
+          style={{
+            position: 'absolute', top: 14, right: 14, zIndex: 10,
+            display: 'flex', alignItems: 'center', justifyContent: 'center',
+            width: 32, height: 32, borderRadius: 8,
+            background: 'rgba(255,255,255,0.06)',
+            border: '1px solid rgba(255,255,255,0.1)',
+            color: '#c0c7d6', cursor: 'pointer',
+          }}
+          aria-label="Close"
+        >
+          <X size={16} />
+        </button>
+
+        <div className="kb-explainer-content" style={{ padding: '48px 32px 56px', maxWidth: 720, margin: '0 auto', position: 'relative' }}>
+          {/* Hero */}
+          <div className="kb-explainer-section" style={{ animationDelay: '60ms', textAlign: 'center', marginBottom: 28 }}>
+            <div style={{
+              display: 'inline-flex', alignItems: 'center', gap: 6, padding: '5px 14px',
+              borderRadius: 999,
+              background: 'rgba(96, 165, 250, 0.12)',
+              border: '1px solid rgba(96, 165, 250, 0.3)',
+              fontSize: 11, fontWeight: 700, color: '#93c5fd',
+              textTransform: 'uppercase', letterSpacing: '0.1em',
+              marginBottom: 18,
+            }}>
+              <Sparkles size={12} /> Knowledge Bases
+            </div>
+            <h1 style={{
+              fontSize: 34, fontWeight: 700, color: '#fff', letterSpacing: '-0.025em',
+              lineHeight: 1.1, margin: '0 0 14px',
+            }}>
+              Ask anything.<br />Get answers from your sources.
+            </h1>
+            <p style={{
+              fontSize: 15, color: '#9aa3b8', maxWidth: 500, margin: '0 auto', lineHeight: 1.6,
+            }}>
+              A knowledge base turns a folder of documents, a stack of policies, or a website
+              into something you can talk to — with citations back to the exact source.
+            </p>
+          </div>
+
+          {/* Animation */}
+          <div className="kb-explainer-section" style={{ animationDelay: '180ms', marginBottom: 44 }}>
+            <KnowledgeTutorial />
+          </div>
+
+          {/* What they do */}
+          <Section title="What they do for you" delay="280ms">
+            <Card
+              icon={Layers}
+              title="Index"
+              body="Pull text out of your documents, websites, and uploads, and split it into searchable chunks."
+            />
+            <Card
+              icon={Search}
+              title="Search"
+              body="Find the passages most relevant to any question — even when the wording doesn't match."
+            />
+            <Card
+              icon={BookOpen}
+              title="Cite"
+              body="Every answer points back to the exact document and page it came from. No black boxes."
+            />
+          </Section>
+
+          {/* Research admin examples */}
+          <Section
+            title="Built for research administration"
+            subtitle="Patterns we see across grants, contracts, and compliance offices."
+            delay="380ms"
+          >
+            <UseCase
+              accent="#60a5fa"
+              question="Is salary cap waivable on a K award?"
+              answer="Federal regulations KB returns the answer with a citation to 2 CFR §200.305 and the relevant NIH NOT-OD notice."
+            />
+            <UseCase
+              accent="#a78bfa"
+              question="What's the F&A rate cap for the Gates Foundation?"
+              answer="Sponsor policies KB pulls the matching clause from 200+ indexed funder pages — with the source URL."
+            />
+            <UseCase
+              accent="#34d399"
+              question="What's our process for closing out a fixed-price subaward?"
+              answer="Internal SOPs KB answers from your office's playbook so new staff stop opening tickets for the same questions."
+            />
+            <UseCase
+              accent="#f472b6"
+              question="What did we tell DCAA about Q3 indirect costs?"
+              answer="Audit response KB surfaces the exact correspondence and exhibits — searchable months after the fact."
+            />
+          </Section>
+
+          {/* How to use */}
+          <Section title="How you'd build one" delay="480ms">
+            <Step num="1" title="Create a knowledge base" body="Name it after the question you want answered (e.g. 'NIH grant policies')." />
+            <Step num="2" title="Add sources" body="Pick documents from your library, paste URLs, or point it at a website to crawl." />
+            <Step num="3" title="Wait for it to build" body="Sources are chunked and indexed in the background. Status updates live." />
+            <Step num="4" title="Open chat and ask" body="Ask in plain English. You'll get answers with citations to the source documents." />
+          </Section>
+
+          {/* CTA */}
+          <div className="kb-explainer-section" style={{ animationDelay: '580ms', textAlign: 'center', marginTop: 36 }}>
+            <button
+              onClick={onClose}
+              style={{
+                padding: '11px 26px', fontSize: 14, fontWeight: 600,
+                color: '#0c1020',
+                background: 'linear-gradient(135deg, #93c5fd 0%, #60a5fa 100%)',
+                border: 'none', borderRadius: 10, cursor: 'pointer', fontFamily: 'inherit',
+                boxShadow: '0 6px 20px -6px rgba(96, 165, 250, 0.5)',
+              }}
+            >
+              Got it — back to the knowledge base
+            </button>
+          </div>
+        </div>
+      </div>
+    </>
+  )
+}
+
+function Section({
+  title, subtitle, delay, children,
+}: {
+  title: string; subtitle?: string; delay: string; children: React.ReactNode
+}) {
+  return (
+    <div className="kb-explainer-section" style={{ animationDelay: delay, marginBottom: 36 }}>
+      <h2 style={{
+        fontSize: 20, fontWeight: 700, color: '#fff', margin: '0 0 4px',
+        letterSpacing: '-0.01em',
+      }}>
+        {title}
+      </h2>
+      {subtitle && (
+        <p style={{ fontSize: 13, color: '#7a8499', margin: '0 0 14px' }}>{subtitle}</p>
+      )}
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 10, marginTop: subtitle ? 0 : 14 }}>
+        {children}
+      </div>
+    </div>
+  )
+}
+
+function Card({ icon: Icon, title, body }: { icon: LucideIcon; title: string; body: string }) {
+  return (
+    <div style={{
+      display: 'flex', gap: 14, alignItems: 'flex-start',
+      padding: 16, borderRadius: 12,
+      background: 'rgba(255,255,255,0.03)',
+      border: '1px solid rgba(255,255,255,0.07)',
+    }}>
+      <div style={{
+        width: 36, height: 36, borderRadius: 10,
+        background: 'rgba(96, 165, 250, 0.12)',
+        border: '1px solid rgba(96, 165, 250, 0.28)',
+        display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0,
+      }}>
+        <Icon size={18} style={{ color: '#93c5fd' }} />
+      </div>
+      <div>
+        <div style={{ fontSize: 14, fontWeight: 600, color: '#e5e7eb', marginBottom: 4 }}>
+          {title}
+        </div>
+        <div style={{ fontSize: 13, color: '#9aa3b8', lineHeight: 1.55 }}>{body}</div>
+      </div>
+    </div>
+  )
+}
+
+function UseCase({ question, answer, accent }: { question: string; answer: string; accent: string }) {
+  return (
+    <div style={{
+      padding: 16, borderRadius: 12,
+      background: 'rgba(255,255,255,0.03)',
+      border: '1px solid rgba(255,255,255,0.07)',
+      borderLeft: `3px solid ${accent}`,
+    }}>
+      <div style={{
+        display: 'inline-block', padding: '2px 8px', borderRadius: 6,
+        background: `${accent}22`, color: accent,
+        fontSize: 10, fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.08em',
+        marginBottom: 8,
+      }}>
+        Ask
+      </div>
+      <div style={{ fontSize: 13.5, fontWeight: 600, color: '#e5e7eb', marginBottom: 8, lineHeight: 1.45, fontStyle: 'italic' }}>
+        "{question}"
+      </div>
+      <div style={{ fontSize: 13, color: '#9aa3b8', lineHeight: 1.55 }}>
+        <span style={{ color: accent, fontWeight: 600 }}>→ </span>{answer}
+      </div>
+    </div>
+  )
+}
+
+function Step({ num, title, body }: { num: string; title: string; body: string }) {
+  return (
+    <div style={{
+      display: 'flex', gap: 14, alignItems: 'flex-start',
+      padding: 14, borderRadius: 12,
+      background: 'rgba(255,255,255,0.03)',
+      border: '1px solid rgba(255,255,255,0.07)',
+    }}>
+      <div style={{
+        width: 28, height: 28, borderRadius: '50%',
+        background: 'linear-gradient(135deg, #93c5fd 0%, #60a5fa 100%)',
+        display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0,
+        fontSize: 13, fontWeight: 700, color: '#0c1020',
+        boxShadow: '0 2px 10px -2px rgba(96, 165, 250, 0.4)',
+      }}>
+        {num}
+      </div>
+      <div>
+        <div style={{ fontSize: 14, fontWeight: 600, color: '#e5e7eb', marginBottom: 2 }}>
+          {title}
+        </div>
+        <div style={{ fontSize: 13, color: '#9aa3b8', lineHeight: 1.55 }}>{body}</div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/workspace/KnowledgePanel.tsx
+++ b/frontend/src/components/workspace/KnowledgePanel.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
-import { Plus, Loader2, ArrowLeft, X, FileText, Globe, MessageSquare, AlertCircle, CheckCircle2, Users, ShieldCheck, Send, Tag, Check, Download, Upload } from 'lucide-react'
+import { Plus, Loader2, ArrowLeft, X, FileText, Globe, MessageSquare, AlertCircle, CheckCircle2, Users, ShieldCheck, Send, Tag, Check, Download, Upload, HelpCircle } from 'lucide-react'
 import { useKnowledgeBases, useScopedKnowledgeBases } from '../../hooks/useKnowledgeBases'
 import { useWorkspace } from '../../contexts/WorkspaceContext'
 import { useAuth } from '../../hooks/useAuth'
@@ -15,6 +15,7 @@ import { DocumentPickerModal } from '../knowledge/DocumentPickerModal'
 import { KBSearchBar } from '../knowledge/KBSearchBar'
 import { KBListView } from '../knowledge/KBListView'
 import { KnowledgeTutorial } from './KnowledgeTutorial'
+import { KnowledgeExplainer } from './KnowledgeExplainer'
 import { useToast } from '../../contexts/ToastContext'
 
 type TabKey = 'mine' | 'team' | 'explore'
@@ -67,6 +68,7 @@ export function KnowledgePanel() {
   const [detailLoading, setDetailLoading] = useState(false)
   const [showUrlModal, setShowUrlModal] = useState(false)
   const [showDocPicker, setShowDocPicker] = useState(false)
+  const [showExplainer, setShowExplainer] = useState(false)
   const [addingDocs, setAddingDocs] = useState(false)
   const [addingUrls, setAddingUrls] = useState(false)
   const [editingTitle, setEditingTitle] = useState(false)
@@ -324,7 +326,7 @@ export function KnowledgePanel() {
   if (selectedKB) {
     const badge = STATUS_BADGE[selectedKB.status] || STATUS_BADGE.empty
     return (
-      <div style={{ height: '100%', display: 'flex', flexDirection: 'column', background: '#1e1e1e' }}>
+      <div style={{ height: '100%', display: 'flex', flexDirection: 'column', background: '#1e1e1e', position: 'relative' }}>
         {/* Header */}
         <div
           style={{
@@ -660,8 +662,39 @@ export function KnowledgePanel() {
                 })}
               </div>
             )}
+
+            {/* "What are knowledge bases?" pill */}
+            <div style={{ display: 'flex', justifyContent: 'center', marginTop: 24, marginBottom: 4 }}>
+              <button
+                onClick={() => setShowExplainer(true)}
+                style={{
+                  display: 'inline-flex', alignItems: 'center', gap: 6,
+                  padding: '6px 14px', fontSize: 12, fontWeight: 500, fontFamily: 'inherit',
+                  color: '#9ca3af',
+                  backgroundColor: '#262626',
+                  border: '1px solid #3a3a3a',
+                  borderRadius: 999, cursor: 'pointer',
+                  transition: 'all 0.15s',
+                }}
+                onMouseEnter={e => {
+                  e.currentTarget.style.backgroundColor = '#2f2f2f'
+                  e.currentTarget.style.color = '#e5e7eb'
+                  e.currentTarget.style.borderColor = '#4a4a4a'
+                }}
+                onMouseLeave={e => {
+                  e.currentTarget.style.backgroundColor = '#262626'
+                  e.currentTarget.style.color = '#9ca3af'
+                  e.currentTarget.style.borderColor = '#3a3a3a'
+                }}
+              >
+                <HelpCircle size={13} />
+                What are knowledge bases?
+              </button>
+            </div>
           </div>
         )}
+
+        {showExplainer && <KnowledgeExplainer onClose={() => setShowExplainer(false)} />}
 
         {showUrlModal && (
           <AddUrlsModal


### PR DESCRIPTION
## Summary
- New `AutomationsExplainer` and `KnowledgeExplainer` components: animated, panel-contained landing-page-style overlays that explain what each feature does, research-admin use cases, and how to set one up.
- Subtle pill (`? What are automations?` / `? What are knowledge bases?`) at the bottom of each editor body; clicking opens the overlay. Reuses the existing `AutomationsTutorial` and `KnowledgeTutorial` D3 animations in the hero.
- ESC, close button, and CTA all dismiss. Staggered fade-up choreography across sections, ambient glow, gradient hero. Yellow palette for Automations, blue palette for KBs.

## Test plan
- [ ] Open an automation in the right-panel editor; scroll to the bottom and click `? What are automations?`. Verify the overlay slides in, animates, and is dismissible via close button, CTA, and Escape.
- [ ] Open a knowledge base in the workspace KB panel; scroll to the bottom of the editor body and click `? What are knowledge bases?`. Verify the same.
- [ ] Confirm the existing `AutomationsTutorial` and `KnowledgeTutorial` animations still play correctly inside the hero section.
- [ ] Confirm the editor underneath remains intact and reachable after dismissing the overlay (no leaked state).

🤖 Generated with [Claude Code](https://claude.com/claude-code)