### PR TITLE
Add credentials store and OAuth client_credentials auth to API Node

### DIFF
--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -40,6 +40,7 @@ from app.models.notification import Notification
 from app.models.support import SupportTicket
 from app.models.feedback_prompt import FeedbackPrompt, FeedbackPromptResponse
 from app.models.email_log import EmailLog
+from app.models.credential import Credential
 
 ALL_MODELS = [
     User,
@@ -98,6 +99,7 @@ ALL_MODELS = [
     FeedbackPrompt,
     FeedbackPromptResponse,
     EmailLog,
+    Credential,
 ]
 
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -14,7 +14,7 @@ from app.database import init_db
 from app.exceptions import AppError
 from app.middleware.csrf import CSRFMiddleware
 from app.rate_limit import limiter
-from app.routers import activity, admin, approvals, audit, auth, automations, browser_automation, certification, chat, config, demo, documents, extractions, feedback, feedback_prompt, files, folders, graph_webhooks, knowledge, library, notifications, office, organizations, spaces, support, teams, verification, workflows
+from app.routers import activity, admin, approvals, audit, auth, automations, browser_automation, certification, chat, config, credentials, demo, documents, extractions, feedback, feedback_prompt, files, folders, graph_webhooks, knowledge, library, notifications, office, organizations, spaces, support, teams, verification, workflows
 
 
 @lru_cache
@@ -198,6 +198,7 @@ app.include_router(feedback.router, prefix="/api/feedback", tags=["feedback"])
 app.include_router(verification.router, prefix="/api/verification", tags=["verification"])
 app.include_router(office.router, prefix="/api/office", tags=["office"])
 app.include_router(automations.router, prefix="/api/automations", tags=["automations"])
+app.include_router(credentials.router, prefix="/api/credentials", tags=["credentials"])
 app.include_router(knowledge.router, prefix="/api/knowledge", tags=["knowledge"])
 if _boot_settings.enable_trial_system:
     app.include_router(demo.router, prefix="/api/demo", tags=["demo"])

--- a/backend/app/models/credential.py
+++ b/backend/app/models/credential.py
@@ -1,0 +1,36 @@
+"""Credential model — team-scoped secret store referenced by API Node and other integration surfaces."""
+
+import datetime
+from typing import Optional
+
+from beanie import Document
+from pydantic import Field
+
+
+CREDENTIAL_TYPES = ("static_header", "oauth_client_credentials")
+
+
+class Credential(Document):
+    """A stored credential, referenced by ID from workflow nodes.
+
+    The `payload` dict holds type-specific fields (each secret value is
+    individually Fernet-encrypted via app.utils.encryption.encrypt_value).
+    Routers must never echo `payload` back to clients — only metadata.
+    """
+
+    name: str
+    type: str  # one of CREDENTIAL_TYPES
+    description: Optional[str] = None
+    team_id: Optional[str] = None
+    user_id: str
+    payload: dict = {}
+    created_at: datetime.datetime = Field(default_factory=lambda: datetime.datetime.now(tz=datetime.timezone.utc))
+    updated_at: datetime.datetime = Field(default_factory=lambda: datetime.datetime.now(tz=datetime.timezone.utc))
+
+    class Settings:
+        name = "credential"
+        indexes = [
+            "team_id",
+            "user_id",
+            [("team_id", 1), ("name", 1)],
+        ]

--- a/backend/app/routers/credentials.py
+++ b/backend/app/routers/credentials.py
@@ -1,0 +1,206 @@
+"""Credentials API routes — team-scoped CRUD with secret payloads encrypted at rest."""
+
+import datetime
+import logging
+
+from beanie import PydanticObjectId
+from fastapi import APIRouter, Depends, HTTPException
+
+from app.dependencies import get_current_user
+from app.models.credential import Credential
+from app.models.team import TeamMembership
+from app.models.user import User
+from app.schemas.credentials import (
+    CreateCredentialRequest,
+    CredentialResponse,
+    UpdateCredentialRequest,
+)
+from app.services import credentials_service
+
+logger = logging.getLogger(__name__)
+router = APIRouter()
+
+
+def _now() -> datetime.datetime:
+    return datetime.datetime.now(tz=datetime.timezone.utc)
+
+
+def _to_response(cred: Credential, *, can_manage: bool = True) -> CredentialResponse:
+    safe = credentials_service.metadata_view({
+        "_id": cred.id,
+        "name": cred.name,
+        "type": cred.type,
+        "description": cred.description,
+        "team_id": cred.team_id,
+        "user_id": cred.user_id,
+        "payload": cred.payload,
+        "created_at": cred.created_at,
+        "updated_at": cred.updated_at,
+    })
+    return CredentialResponse(
+        id=str(cred.id),
+        name=safe["name"],
+        type=safe["type"],
+        description=safe["description"],
+        team_id=safe["team_id"],
+        user_id=safe["user_id"],
+        payload=safe["payload"],
+        created_at=cred.created_at.isoformat() if cred.created_at else None,
+        updated_at=cred.updated_at.isoformat() if cred.updated_at else None,
+        can_manage=can_manage,
+    )
+
+
+async def _can_manage_team(user: User, team_id: str | None) -> bool:
+    """User can manage credentials they own; team-scoped credentials require admin/owner role."""
+    if not team_id:
+        return True
+    if user.is_admin:
+        return True
+    try:
+        team_oid = PydanticObjectId(team_id)
+    except Exception:
+        return False
+    membership = await TeamMembership.find_one(
+        TeamMembership.team == team_oid,
+        TeamMembership.user_id == user.user_id,
+    )
+    return bool(membership and membership.role in ("owner", "admin"))
+
+
+async def _can_view_team(user: User, team_id: str | None) -> bool:
+    if not team_id:
+        return True
+    if user.is_admin:
+        return True
+    try:
+        team_oid = PydanticObjectId(team_id)
+    except Exception:
+        return False
+    membership = await TeamMembership.find_one(
+        TeamMembership.team == team_oid,
+        TeamMembership.user_id == user.user_id,
+    )
+    return membership is not None
+
+
+async def _load_for_manage(credential_id: str, user: User) -> Credential:
+    try:
+        cred = await Credential.get(PydanticObjectId(credential_id))
+    except Exception:
+        raise HTTPException(status_code=404, detail="Credential not found")
+    if not cred:
+        raise HTTPException(status_code=404, detail="Credential not found")
+    if cred.user_id != user.user_id:
+        if not await _can_manage_team(user, cred.team_id):
+            raise HTTPException(status_code=403, detail="You don't have permission to manage this credential")
+    return cred
+
+
+# ---------------------------------------------------------------------------
+# CRUD
+# ---------------------------------------------------------------------------
+
+@router.post("", response_model=CredentialResponse)
+async def create_credential(
+    req: CreateCredentialRequest,
+    user: User = Depends(get_current_user),
+) -> CredentialResponse:
+    try:
+        credentials_service.validate_payload(req.type, req.payload)
+    except credentials_service.CredentialError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+    team_id = req.team_id or (str(user.current_team) if user.current_team else None)
+    if team_id and not await _can_manage_team(user, team_id):
+        raise HTTPException(status_code=403, detail="Not allowed to create credentials for this team")
+
+    encrypted = credentials_service.encrypt_payload(req.type, req.payload)
+    cred = Credential(
+        name=req.name,
+        type=req.type,
+        description=req.description,
+        team_id=team_id,
+        user_id=user.user_id,
+        payload=encrypted,
+    )
+    await cred.insert()
+    return _to_response(cred)
+
+
+@router.get("", response_model=list[CredentialResponse])
+async def list_credentials(user: User = Depends(get_current_user)) -> list[CredentialResponse]:
+    """List credentials owned by the user or shared with their current team."""
+    team_id = str(user.current_team) if user.current_team else None
+    query: dict
+    if team_id:
+        query = {"$or": [{"user_id": user.user_id}, {"team_id": team_id}]}
+    else:
+        query = {"user_id": user.user_id}
+    creds = await Credential.find(query).to_list()
+    results: list[CredentialResponse] = []
+    for cred in creds:
+        can_manage = (
+            cred.user_id == user.user_id
+            or await _can_manage_team(user, cred.team_id)
+        )
+        results.append(_to_response(cred, can_manage=can_manage))
+    return results
+
+
+@router.get("/{credential_id}", response_model=CredentialResponse)
+async def get_credential(credential_id: str, user: User = Depends(get_current_user)) -> CredentialResponse:
+    try:
+        cred = await Credential.get(PydanticObjectId(credential_id))
+    except Exception:
+        raise HTTPException(status_code=404, detail="Credential not found")
+    if not cred:
+        raise HTTPException(status_code=404, detail="Credential not found")
+    if cred.user_id != user.user_id and not await _can_view_team(user, cred.team_id):
+        raise HTTPException(status_code=403, detail="You don't have permission to view this credential")
+    can_manage = (
+        cred.user_id == user.user_id
+        or await _can_manage_team(user, cred.team_id)
+    )
+    return _to_response(cred, can_manage=can_manage)
+
+
+@router.patch("/{credential_id}", response_model=CredentialResponse)
+async def update_credential(
+    credential_id: str,
+    req: UpdateCredentialRequest,
+    user: User = Depends(get_current_user),
+) -> CredentialResponse:
+    cred = await _load_for_manage(credential_id, user)
+    if req.name is not None:
+        cred.name = req.name
+    if req.description is not None:
+        cred.description = req.description
+    if req.payload is not None:
+        try:
+            credentials_service.validate_payload(cred.type, req.payload)
+        except credentials_service.CredentialError as e:
+            raise HTTPException(status_code=400, detail=str(e))
+        cred.payload = credentials_service.encrypt_payload(cred.type, req.payload)
+        # Drop any cached bearer keyed by this credential.
+        credentials_service.invalidate_cached_token(str(cred.id))
+    cred.updated_at = _now()
+    await cred.save()
+    return _to_response(cred)
+
+
+@router.delete("/{credential_id}")
+async def delete_credential(credential_id: str, user: User = Depends(get_current_user)) -> dict:
+    cred = await _load_for_manage(credential_id, user)
+    cred_id = str(cred.id)
+    await cred.delete()
+    credentials_service.invalidate_cached_token(cred_id)
+    return {"status": "deleted", "id": cred_id}
+
+
+@router.post("/{credential_id}/invalidate-cache")
+async def invalidate_cache(credential_id: str, user: User = Depends(get_current_user)) -> dict:
+    """Drop any cached bearer token for this credential. Useful after upstream rotations."""
+    cred = await _load_for_manage(credential_id, user)
+    credentials_service.invalidate_cached_token(str(cred.id))
+    return {"status": "invalidated", "id": str(cred.id)}

--- a/backend/app/schemas/credentials.py
+++ b/backend/app/schemas/credentials.py
@@ -1,0 +1,37 @@
+"""Request/response models for credentials endpoints."""
+
+from typing import Literal, Optional
+
+from pydantic import BaseModel
+
+
+CredentialType = Literal["static_header", "oauth_client_credentials"]
+
+
+class CreateCredentialRequest(BaseModel):
+    name: str
+    type: CredentialType
+    description: Optional[str] = None
+    payload: dict
+    team_id: Optional[str] = None
+
+
+class UpdateCredentialRequest(BaseModel):
+    name: Optional[str] = None
+    description: Optional[str] = None
+    # If provided, replaces the encrypted payload wholesale. Omit to keep
+    # existing secrets in place when only renaming.
+    payload: Optional[dict] = None
+
+
+class CredentialResponse(BaseModel):
+    id: str
+    name: str
+    type: str
+    description: Optional[str] = None
+    team_id: Optional[str] = None
+    user_id: str
+    payload: dict  # secret fields appear as "<set>" or ""
+    created_at: Optional[str] = None
+    updated_at: Optional[str] = None
+    can_manage: bool = True

--- a/backend/app/services/credentials_service.py
+++ b/backend/app/services/credentials_service.py
@@ -1,0 +1,291 @@
+"""Credentials service — payload encryption, OAuth client-credentials JWT exchange, bearer caching.
+
+Runs in sync context (called from Celery workers / APICallNode). The router
+layer uses the async wrappers at the bottom.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import secrets
+import time
+import uuid
+from typing import Any
+
+import httpx
+import jwt
+import redis
+
+from app.utils.encryption import decrypt_value, encrypt_value
+from app.utils.url_validation import validate_outbound_url
+
+logger = logging.getLogger(__name__)
+
+
+CREDENTIAL_TYPES = ("static_header", "oauth_client_credentials")
+
+# Encrypted-at-rest payload fields, per credential type. Anything in the
+# payload that isn't listed here is stored as plaintext (URLs, scopes, etc.).
+_ENCRYPTED_FIELDS: dict[str, tuple[str, ...]] = {
+    "static_header": ("header_value",),
+    "oauth_client_credentials": ("private_key", "client_secret"),
+}
+
+# Redis cache key prefix and skew window for bearer expiry.
+_TOKEN_CACHE_PREFIX = "credentials:bearer:"
+_BEARER_REFRESH_SKEW_SECONDS = 30
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+class CredentialError(Exception):
+    """Raised for malformed payloads, failed exchanges, etc."""
+
+
+def validate_payload(credential_type: str, payload: dict) -> None:
+    """Raise CredentialError if *payload* is missing required fields for *credential_type*."""
+    if credential_type not in CREDENTIAL_TYPES:
+        raise CredentialError(f"Unknown credential type: {credential_type!r}")
+
+    if credential_type == "static_header":
+        for field in ("header_name", "header_value"):
+            if not payload.get(field):
+                raise CredentialError(f"static_header credential is missing {field!r}")
+
+    elif credential_type == "oauth_client_credentials":
+        for field in ("client_id", "token_endpoint", "private_key"):
+            if not payload.get(field):
+                raise CredentialError(f"oauth_client_credentials credential is missing {field!r}")
+        # token_endpoint must be a safe outbound URL
+        try:
+            validate_outbound_url(payload["token_endpoint"])
+        except ValueError as e:
+            raise CredentialError(f"token_endpoint rejected: {e}") from e
+
+
+# ---------------------------------------------------------------------------
+# Payload encryption (round-trip helpers)
+# ---------------------------------------------------------------------------
+
+def encrypt_payload(credential_type: str, payload: dict) -> dict:
+    """Return a copy of *payload* with secret fields encrypted at rest."""
+    encrypted = dict(payload)
+    for field in _ENCRYPTED_FIELDS.get(credential_type, ()):
+        value = encrypted.get(field)
+        if value:
+            encrypted[field] = encrypt_value(value)
+    return encrypted
+
+
+def decrypt_payload(credential_type: str, payload: dict) -> dict:
+    """Return a copy of *payload* with secret fields decrypted."""
+    decrypted = dict(payload)
+    for field in _ENCRYPTED_FIELDS.get(credential_type, ()):
+        value = decrypted.get(field)
+        if value:
+            decrypted[field] = decrypt_value(value)
+    return decrypted
+
+
+def metadata_view(credential_doc: dict) -> dict:
+    """Strip secret payload fields, keeping only metadata safe to return to clients."""
+    payload = credential_doc.get("payload", {}) or {}
+    safe_payload: dict[str, Any] = {}
+    encrypted_fields = set(_ENCRYPTED_FIELDS.get(credential_doc.get("type", ""), ()))
+    for k, v in payload.items():
+        if k in encrypted_fields:
+            safe_payload[k] = "<set>" if v else ""
+        else:
+            safe_payload[k] = v
+    return {
+        "id": str(credential_doc["_id"]) if "_id" in credential_doc else credential_doc.get("id", ""),
+        "name": credential_doc.get("name", ""),
+        "type": credential_doc.get("type", ""),
+        "description": credential_doc.get("description"),
+        "team_id": credential_doc.get("team_id"),
+        "user_id": credential_doc.get("user_id", ""),
+        "payload": safe_payload,
+        "created_at": credential_doc.get("created_at"),
+        "updated_at": credential_doc.get("updated_at"),
+    }
+
+
+# ---------------------------------------------------------------------------
+# OAuth client_credentials JWT-assertion flow
+# ---------------------------------------------------------------------------
+
+def _redis_client() -> redis.Redis:
+    redis_host = os.environ.get("redis_host", "localhost")
+    return redis.Redis(host=redis_host, port=6379, db=0, decode_responses=True)
+
+
+def _build_client_assertion(payload: dict) -> str:
+    """Sign a short-lived JWT assertion for a client_credentials exchange.
+
+    Uses RS256 by default; honors `algorithm` field on the payload if set.
+    """
+    now = int(time.time())
+    claims = {
+        "iss": payload["client_id"],
+        "sub": payload["client_id"],
+        "aud": payload.get("audience") or payload["token_endpoint"],
+        "iat": now,
+        "exp": now + 300,
+        "jti": uuid.uuid4().hex,
+    }
+    algorithm = payload.get("algorithm") or "RS256"
+    return jwt.encode(claims, payload["private_key"], algorithm=algorithm)
+
+
+def _exchange_token(payload: dict) -> tuple[str, int]:
+    """POST a signed assertion to the token endpoint. Return (bearer, expires_in_seconds)."""
+    assertion = _build_client_assertion(payload)
+    body: dict[str, str] = {
+        "grant_type": "client_credentials",
+        "client_assertion_type": "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+        "client_assertion": assertion,
+        "client_id": payload["client_id"],
+    }
+    if payload.get("scope"):
+        body["scope"] = payload["scope"]
+    # Some servers expect client_secret even alongside JWT assertion; pass through
+    # if configured (decrypted upstream).
+    if payload.get("client_secret"):
+        body["client_secret"] = payload["client_secret"]
+
+    try:
+        with httpx.Client(timeout=30, follow_redirects=False) as client:
+            resp = client.post(
+                payload["token_endpoint"],
+                data=body,
+                headers={"Accept": "application/json"},
+            )
+            resp.raise_for_status()
+            data = resp.json()
+    except httpx.HTTPStatusError as e:
+        raise CredentialError(
+            f"Token endpoint returned {e.response.status_code}: {e.response.text[:500]}"
+        ) from e
+    except httpx.RequestError as e:
+        raise CredentialError(f"Token endpoint request failed: {e}") from e
+    except ValueError as e:
+        raise CredentialError(f"Token endpoint returned non-JSON response: {e}") from e
+
+    bearer = data.get("access_token")
+    if not bearer:
+        raise CredentialError("Token endpoint response missing access_token")
+    # expires_in is seconds-from-now per RFC 6749 §5.1; default to 5 minutes.
+    expires_in = int(data.get("expires_in") or 300)
+    return bearer, expires_in
+
+
+def get_bearer_token(credential_id: str, decrypted_payload: dict) -> str:
+    """Return a bearer token for *credential_id*, using Redis cache when fresh.
+
+    Re-exchanges within `_BEARER_REFRESH_SKEW_SECONDS` of expiry.
+    """
+    cache_key = f"{_TOKEN_CACHE_PREFIX}{credential_id}"
+    client = _redis_client()
+    try:
+        cached_raw: Any = client.get(cache_key)
+        if cached_raw:
+            try:
+                cached = json.loads(cached_raw)
+                if cached.get("expires_at", 0) - _BEARER_REFRESH_SKEW_SECONDS > int(time.time()):
+                    return str(cached["token"])
+            except (ValueError, KeyError):
+                pass  # fall through to re-exchange
+    except redis.RedisError as e:
+        logger.warning("Redis unavailable for bearer cache read: %s", e)
+
+    bearer, expires_in = _exchange_token(decrypted_payload)
+    expires_at = int(time.time()) + expires_in
+
+    try:
+        client.set(
+            cache_key,
+            json.dumps({"token": bearer, "expires_at": expires_at}),
+            ex=max(expires_in - _BEARER_REFRESH_SKEW_SECONDS, 30),
+        )
+    except redis.RedisError as e:
+        logger.warning("Redis unavailable for bearer cache write: %s", e)
+
+    return bearer
+
+
+def invalidate_cached_token(credential_id: str) -> None:
+    """Drop a cached bearer (e.g. after rotation or 401)."""
+    try:
+        client = _redis_client()
+        client.delete(f"{_TOKEN_CACHE_PREFIX}{credential_id}")
+    except redis.RedisError:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Auth-header application (called from APICallNode)
+# ---------------------------------------------------------------------------
+
+def apply_auth(
+    *,
+    credential_doc: dict,
+    headers: dict[str, str],
+) -> dict[str, str]:
+    """Mutate *headers* in place per the credential's auth strategy. Return headers.
+
+    Raises CredentialError on configuration or token-exchange failures.
+    """
+    cred_type = credential_doc.get("type")
+    payload = decrypt_payload(cred_type or "", credential_doc.get("payload", {}) or {})
+
+    if cred_type == "static_header":
+        name = payload.get("header_name") or ""
+        value = payload.get("header_value") or ""
+        if not name or not value:
+            raise CredentialError("static_header credential is incomplete")
+        headers[name] = value
+        return headers
+
+    if cred_type == "oauth_client_credentials":
+        validate_payload(cred_type, payload)
+        cred_id = str(credential_doc.get("_id") or credential_doc.get("id") or "")
+        if not cred_id:
+            raise CredentialError("Cannot apply OAuth credential without an id")
+        bearer = get_bearer_token(cred_id, payload)
+        headers["Authorization"] = f"Bearer {bearer}"
+        return headers
+
+    raise CredentialError(f"Unknown credential type: {cred_type!r}")
+
+
+# ---------------------------------------------------------------------------
+# Sync MongoDB lookup (for use inside Celery workers)
+# ---------------------------------------------------------------------------
+
+def fetch_credential_sync(db: Any, credential_id: str) -> dict | None:
+    """Return the raw credential doc from a pymongo db handle, or None.
+
+    `db` is a pymongo Database, matching the pattern in app/tasks/workflow_tasks.py.
+    """
+    from bson import ObjectId
+    from bson.errors import InvalidId
+
+    try:
+        oid = ObjectId(credential_id)
+    except (InvalidId, TypeError):
+        return None
+    result: dict | None = db.credential.find_one({"_id": oid})
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Misc helpers
+# ---------------------------------------------------------------------------
+
+def generate_random_jti() -> str:
+    """Exposed for tests."""
+    return secrets.token_hex(16)

--- a/backend/app/services/workflow_engine.py
+++ b/backend/app/services/workflow_engine.py
@@ -657,6 +657,16 @@ class ResearchNode(Node):
         return {"output": report, "input": inputs.get("output"), "step_name": self.name}
 
 
+def _open_sync_db():
+    """Open a pymongo handle for in-node credential lookups (sync context)."""
+    from pymongo import MongoClient
+
+    from app.config import Settings
+    settings = Settings()
+    client = MongoClient(settings.mongo_host)
+    return client[settings.mongo_db]
+
+
 class APICallNode(Node):
     def __init__(self, data: dict) -> None:
         super().__init__("APINode")
@@ -667,6 +677,8 @@ class APICallNode(Node):
         method = self.data.get("method", "GET").upper()
         headers_raw = self.data.get("headers", "")
         body_raw = self.data.get("body", "")
+        auth_strategy = (self.data.get("auth_strategy") or "none").lower()
+        credential_id = self.data.get("credential_id") or ""
         if not url:
             return {"output": "", "input": inputs.get("output"), "step_name": self.name}
 
@@ -678,12 +690,56 @@ class APICallNode(Node):
             return {"output": f"Blocked URL: {e}", "input": inputs.get("output"), "step_name": self.name}
 
         self.report_progress(f"{method} {url}")
-        headers = {}
+        headers: dict[str, str] = {}
         if headers_raw:
             try:
                 headers = json.loads(headers_raw)
             except json.JSONDecodeError:
                 pass
+
+        # Apply credential-based auth (overrides any conflicting header).
+        if auth_strategy != "none":
+            if not credential_id:
+                return {
+                    "output": f"API Node auth_strategy {auth_strategy!r} requires credential_id",
+                    "input": inputs.get("output"),
+                    "step_name": self.name,
+                }
+            from app.services import credentials_service
+
+            try:
+                db = _open_sync_db()
+                cred_doc = credentials_service.fetch_credential_sync(db, credential_id)
+            except Exception as e:
+                logger.exception("Credential lookup failed")
+                return {
+                    "output": f"Credential lookup failed: {e}",
+                    "input": inputs.get("output"),
+                    "step_name": self.name,
+                }
+            if not cred_doc:
+                return {
+                    "output": f"Credential {credential_id!r} not found",
+                    "input": inputs.get("output"),
+                    "step_name": self.name,
+                }
+            if cred_doc.get("type") != auth_strategy:
+                return {
+                    "output": (
+                        f"Credential type {cred_doc.get('type')!r} does not match "
+                        f"auth_strategy {auth_strategy!r}"
+                    ),
+                    "input": inputs.get("output"),
+                    "step_name": self.name,
+                }
+            try:
+                credentials_service.apply_auth(credential_doc=cred_doc, headers=headers)
+            except credentials_service.CredentialError as e:
+                return {
+                    "output": f"Auth setup failed: {e}",
+                    "input": inputs.get("output"),
+                    "step_name": self.name,
+                }
 
         body = None
         if body_raw and method in ("POST", "PUT", "PATCH"):

--- a/backend/tests/test_credentials_routes.py
+++ b/backend/tests/test_credentials_routes.py
@@ -1,0 +1,156 @@
+"""Integration tests for the /api/credentials endpoints.
+
+Mocks Beanie I/O and verifies:
+  * payload validation runs before insert
+  * secrets are encrypted at rest and never echoed back to clients
+  * list endpoint redacts secret fields
+"""
+
+import secrets
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.config import Settings
+from app.utils.security import create_access_token
+
+_TEST_SETTINGS = Settings(jwt_secret_key="test-secret-key", environment="development")
+
+
+def _make_user(user_id: str = "testuser", current_team=None, is_admin: bool = False):
+    user = MagicMock()
+    user.id = "fake-id"
+    user.user_id = user_id
+    user.email = f"{user_id}@example.com"
+    user.name = "Test User"
+    user.is_admin = is_admin
+    user.is_examiner = False
+    user.current_team = current_team
+    user.is_demo_user = False
+    user.demo_status = None
+    return user
+
+
+def _auth(user_id: str = "testuser"):
+    token = create_access_token(user_id, _TEST_SETTINGS)
+    csrf = secrets.token_urlsafe(32)
+    return {"access_token": token, "csrf_token": csrf}, {"X-CSRF-Token": csrf}
+
+
+@pytest.fixture
+async def client():
+    with patch("app.main.init_db", new_callable=AsyncMock):
+        from app.main import app
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        ) as ac:
+            yield ac
+
+
+class TestCreateCredential:
+    @pytest.mark.asyncio
+    async def test_payload_validation_rejects_missing_fields(self, client):
+        user = _make_user()
+        cookies, headers = _auth()
+
+        with (
+            patch("app.dependencies.decode_token", return_value={"sub": "testuser", "type": "access"}),
+            patch("app.dependencies.User") as MockUser,
+        ):
+            MockUser.find_one = AsyncMock(return_value=user)
+            resp = await client.post(
+                "/api/credentials",
+                cookies=cookies,
+                headers=headers,
+                json={
+                    "name": "Lakehouse",
+                    "type": "static_header",
+                    "payload": {"header_name": "X-Api-Key"},  # missing header_value
+                },
+            )
+
+        assert resp.status_code == 400
+        assert "header_value" in resp.json()["detail"]
+
+    @pytest.mark.asyncio
+    async def test_payload_is_encrypted_and_not_echoed(self, client):
+        user = _make_user()
+        cookies, headers = _auth()
+
+        captured: dict = {}
+
+        class _FakeCredential:
+            def __init__(self, **kwargs):
+                self.__dict__.update(kwargs)
+                self.id = "fake-credential-id"
+                self.created_at = None
+                self.updated_at = None
+
+            async def insert(self):
+                captured["payload"] = dict(self.payload)
+
+        with (
+            patch("app.dependencies.decode_token", return_value={"sub": "testuser", "type": "access"}),
+            patch("app.dependencies.User") as MockUser,
+            patch("app.routers.credentials.Credential", _FakeCredential),
+        ):
+            MockUser.find_one = AsyncMock(return_value=user)
+            resp = await client.post(
+                "/api/credentials",
+                cookies=cookies,
+                headers=headers,
+                json={
+                    "name": "API key",
+                    "type": "static_header",
+                    "payload": {"header_name": "X-Api-Key", "header_value": "TOPSECRET"},
+                },
+            )
+
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["payload"]["header_value"] == "<set>"
+        assert body["payload"]["header_name"] == "X-Api-Key"
+        # Secret value never appears in response.
+        assert "TOPSECRET" not in resp.text
+        # Persisted payload kept the header name; header_value is whatever
+        # encrypt_value returned (encrypted if Fernet key set, plaintext otherwise).
+        assert captured["payload"]["header_name"] == "X-Api-Key"
+
+
+class TestListCredentials:
+    @pytest.mark.asyncio
+    async def test_list_redacts_secrets(self, client):
+        user = _make_user()
+        cookies, headers = _auth()
+
+        fake_cred = MagicMock()
+        fake_cred.id = "id-1"
+        fake_cred.name = "key"
+        fake_cred.type = "static_header"
+        fake_cred.description = None
+        fake_cred.team_id = None
+        fake_cred.user_id = "testuser"
+        fake_cred.payload = {"header_name": "X-Api-Key", "header_value": "enc:abc"}
+        fake_cred.created_at = None
+        fake_cred.updated_at = None
+
+        find_result = MagicMock()
+        find_result.to_list = AsyncMock(return_value=[fake_cred])
+
+        with (
+            patch("app.dependencies.decode_token", return_value={"sub": "testuser", "type": "access"}),
+            patch("app.dependencies.User") as MockUser,
+            patch("app.routers.credentials.Credential.find", return_value=find_result),
+        ):
+            MockUser.find_one = AsyncMock(return_value=user)
+            resp = await client.get("/api/credentials", cookies=cookies, headers=headers)
+
+        assert resp.status_code == 200, resp.text
+        items = resp.json()
+        assert len(items) == 1
+        assert items[0]["payload"]["header_value"] == "<set>"
+        assert items[0]["payload"]["header_name"] == "X-Api-Key"
+        assert "enc:abc" not in resp.text

--- a/backend/tests/test_credentials_service.py
+++ b/backend/tests/test_credentials_service.py
@@ -1,0 +1,444 @@
+"""Unit tests for credentials_service.
+
+Covers payload validation, encrypt/decrypt round-trips, JWT-assertion
+construction, OAuth token exchange (mocked HTTP), Redis caching, and the
+apply_auth dispatcher used by APICallNode.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from unittest.mock import MagicMock, patch
+
+import jwt
+import pytest
+import redis
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+from app.services import credentials_service
+from app.services.credentials_service import (
+    CredentialError,
+    apply_auth,
+    decrypt_payload,
+    encrypt_payload,
+    get_bearer_token,
+    invalidate_cached_token,
+    metadata_view,
+    validate_payload,
+    _build_client_assertion,
+    _exchange_token,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module")
+def rsa_private_pem() -> str:
+    """Generate a fresh RSA private key for signing tests."""
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048, backend=default_backend())
+    return key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode()
+
+
+@pytest.fixture(scope="module")
+def rsa_public_pem(rsa_private_pem: str) -> str:
+    private = serialization.load_pem_private_key(
+        rsa_private_pem.encode(), password=None, backend=default_backend()
+    )
+    return private.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode()
+
+
+@pytest.fixture
+def fake_redis():
+    """In-process dict-backed Redis fake covering the methods we use."""
+    store: dict[str, tuple[str, float | None]] = {}
+
+    def _get(key):
+        item = store.get(key)
+        if item is None:
+            return None
+        value, expires_at = item
+        if expires_at is not None and time.time() > expires_at:
+            store.pop(key, None)
+            return None
+        return value
+
+    def _set(key, value, ex=None):
+        expires_at = time.time() + ex if ex else None
+        store[key] = (value, expires_at)
+        return True
+
+    def _delete(key):
+        store.pop(key, None)
+        return 1
+
+    client = MagicMock(spec=redis.Redis)
+    client.get.side_effect = _get
+    client.set.side_effect = _set
+    client.delete.side_effect = _delete
+    return client
+
+
+# ---------------------------------------------------------------------------
+# validate_payload
+# ---------------------------------------------------------------------------
+
+class TestValidatePayload:
+    def test_unknown_type(self):
+        with pytest.raises(CredentialError, match="Unknown credential type"):
+            validate_payload("nope", {})
+
+    def test_static_header_missing_field(self):
+        with pytest.raises(CredentialError, match="header_value"):
+            validate_payload("static_header", {"header_name": "X-Api-Key"})
+
+    def test_static_header_ok(self):
+        validate_payload("static_header", {"header_name": "X-Api-Key", "header_value": "secret"})
+
+    def test_oauth_missing_field(self):
+        with pytest.raises(CredentialError, match="private_key"):
+            validate_payload("oauth_client_credentials", {
+                "client_id": "abc",
+                "token_endpoint": "https://example.com/token",
+            })
+
+    @patch("app.services.credentials_service.validate_outbound_url", return_value="ok")
+    def test_oauth_ok(self, _mock_validate):
+        validate_payload("oauth_client_credentials", {
+            "client_id": "abc",
+            "token_endpoint": "https://example.com/token",
+            "private_key": "-----BEGIN-----",
+        })
+
+    @patch("app.services.credentials_service.validate_outbound_url", side_effect=ValueError("blocked"))
+    def test_oauth_blocked_token_endpoint(self, _mock_validate):
+        with pytest.raises(CredentialError, match="token_endpoint rejected"):
+            validate_payload("oauth_client_credentials", {
+                "client_id": "abc",
+                "token_endpoint": "http://10.0.0.1/token",
+                "private_key": "-----BEGIN-----",
+            })
+
+
+# ---------------------------------------------------------------------------
+# Encrypt / decrypt round-trip
+# ---------------------------------------------------------------------------
+
+class TestPayloadEncryption:
+    def test_static_header_round_trip(self):
+        original = {"header_name": "X-Key", "header_value": "topsecret"}
+        encrypted = encrypt_payload("static_header", original)
+        # Header name not encrypted; value is (assuming key configured) — in
+        # absence of a key the value passes through unchanged.
+        assert encrypted["header_name"] == "X-Key"
+        decrypted = decrypt_payload("static_header", encrypted)
+        assert decrypted["header_value"] == "topsecret"
+
+    def test_oauth_round_trip(self, rsa_private_pem):
+        original = {
+            "client_id": "abc",
+            "token_endpoint": "https://example.com/token",
+            "private_key": rsa_private_pem,
+            "scope": "read write",
+        }
+        encrypted = encrypt_payload("oauth_client_credentials", original)
+        assert encrypted["client_id"] == "abc"  # not a secret field
+        assert encrypted["scope"] == "read write"  # not a secret field
+        decrypted = decrypt_payload("oauth_client_credentials", encrypted)
+        assert decrypted["private_key"] == rsa_private_pem
+
+
+# ---------------------------------------------------------------------------
+# metadata_view never leaks secrets
+# ---------------------------------------------------------------------------
+
+class TestMetadataView:
+    def test_static_header_value_redacted(self):
+        doc = {
+            "_id": "abc123",
+            "name": "key",
+            "type": "static_header",
+            "team_id": None,
+            "user_id": "u1",
+            "payload": {"header_name": "X-Key", "header_value": "enc:xxx"},
+        }
+        view = metadata_view(doc)
+        assert view["payload"]["header_name"] == "X-Key"
+        assert view["payload"]["header_value"] == "<set>"
+
+    def test_oauth_secrets_redacted(self):
+        doc = {
+            "_id": "abc",
+            "name": "lakehouse",
+            "type": "oauth_client_credentials",
+            "team_id": "team-1",
+            "user_id": "u1",
+            "payload": {
+                "client_id": "client-abc",
+                "token_endpoint": "https://example.com/token",
+                "private_key": "enc:xxxx",
+                "scope": "lakehouse.read",
+            },
+        }
+        view = metadata_view(doc)
+        assert view["payload"]["client_id"] == "client-abc"
+        assert view["payload"]["token_endpoint"] == "https://example.com/token"
+        assert view["payload"]["private_key"] == "<set>"
+        assert view["payload"]["scope"] == "lakehouse.read"
+
+    def test_empty_secret_marked_blank(self):
+        doc = {
+            "_id": "abc",
+            "name": "x",
+            "type": "static_header",
+            "user_id": "u1",
+            "payload": {"header_name": "X", "header_value": ""},
+        }
+        view = metadata_view(doc)
+        assert view["payload"]["header_value"] == ""
+
+
+# ---------------------------------------------------------------------------
+# JWT assertion construction
+# ---------------------------------------------------------------------------
+
+class TestBuildClientAssertion:
+    def test_assertion_is_signed_and_decodable(self, rsa_private_pem, rsa_public_pem):
+        payload = {
+            "client_id": "client-abc",
+            "token_endpoint": "https://issuer/token",
+            "private_key": rsa_private_pem,
+        }
+        token = _build_client_assertion(payload)
+        decoded = jwt.decode(
+            token,
+            rsa_public_pem,
+            algorithms=["RS256"],
+            audience="https://issuer/token",
+        )
+        assert decoded["iss"] == "client-abc"
+        assert decoded["sub"] == "client-abc"
+        assert decoded["aud"] == "https://issuer/token"
+        assert decoded["exp"] > decoded["iat"]
+
+    def test_explicit_audience_used_when_provided(self, rsa_private_pem, rsa_public_pem):
+        payload = {
+            "client_id": "client-abc",
+            "token_endpoint": "https://issuer/token",
+            "audience": "https://api.lakehouse",
+            "private_key": rsa_private_pem,
+        }
+        token = _build_client_assertion(payload)
+        decoded = jwt.decode(
+            token, rsa_public_pem, algorithms=["RS256"], audience="https://api.lakehouse"
+        )
+        assert decoded["aud"] == "https://api.lakehouse"
+
+
+# ---------------------------------------------------------------------------
+# Token exchange
+# ---------------------------------------------------------------------------
+
+class TestExchangeToken:
+    @patch("app.services.credentials_service.httpx.Client")
+    def test_successful_exchange(self, mock_client_cls, rsa_private_pem):
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {"access_token": "abc123", "expires_in": 600}
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.post.return_value = mock_resp
+        mock_client_cls.return_value = mock_client
+
+        bearer, expires_in = _exchange_token({
+            "client_id": "client-abc",
+            "token_endpoint": "https://issuer/token",
+            "private_key": rsa_private_pem,
+            "scope": "read",
+        })
+        assert bearer == "abc123"
+        assert expires_in == 600
+
+        # Check body shape
+        post_args = mock_client.post.call_args
+        body = post_args[1]["data"]
+        assert body["grant_type"] == "client_credentials"
+        assert body["client_assertion_type"] == "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
+        assert body["client_id"] == "client-abc"
+        assert body["scope"] == "read"
+        assert body["client_assertion"]  # signed JWT present
+
+    @patch("app.services.credentials_service.httpx.Client")
+    def test_missing_access_token_raises(self, mock_client_cls, rsa_private_pem):
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {"token_type": "bearer"}  # no access_token
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.post.return_value = mock_resp
+        mock_client_cls.return_value = mock_client
+
+        with pytest.raises(CredentialError, match="missing access_token"):
+            _exchange_token({
+                "client_id": "abc",
+                "token_endpoint": "https://issuer/token",
+                "private_key": rsa_private_pem,
+            })
+
+    @patch("app.services.credentials_service.httpx.Client")
+    def test_default_expires_in(self, mock_client_cls, rsa_private_pem):
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {"access_token": "tok"}  # no expires_in
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.post.return_value = mock_resp
+        mock_client_cls.return_value = mock_client
+
+        _, expires_in = _exchange_token({
+            "client_id": "abc",
+            "token_endpoint": "https://issuer/token",
+            "private_key": rsa_private_pem,
+        })
+        assert expires_in == 300
+
+
+# ---------------------------------------------------------------------------
+# Bearer cache
+# ---------------------------------------------------------------------------
+
+class TestGetBearerToken:
+    @patch("app.services.credentials_service._exchange_token")
+    @patch("app.services.credentials_service._redis_client")
+    def test_cache_miss_then_hit(self, mock_redis_factory, mock_exchange, fake_redis, rsa_private_pem):
+        mock_redis_factory.return_value = fake_redis
+        mock_exchange.return_value = ("tok-1", 600)
+
+        payload = {"client_id": "abc", "token_endpoint": "https://x/t", "private_key": rsa_private_pem}
+        first = get_bearer_token("cred-1", payload)
+        second = get_bearer_token("cred-1", payload)
+
+        assert first == "tok-1"
+        assert second == "tok-1"
+        assert mock_exchange.call_count == 1  # second call served from cache
+
+    @patch("app.services.credentials_service._exchange_token")
+    @patch("app.services.credentials_service._redis_client")
+    def test_cache_invalidate(self, mock_redis_factory, mock_exchange, fake_redis, rsa_private_pem):
+        mock_redis_factory.return_value = fake_redis
+        mock_exchange.side_effect = [("tok-1", 600), ("tok-2", 600)]
+
+        payload = {"client_id": "abc", "token_endpoint": "https://x/t", "private_key": rsa_private_pem}
+        first = get_bearer_token("cred-1", payload)
+        invalidate_cached_token("cred-1")
+        second = get_bearer_token("cred-1", payload)
+
+        assert first == "tok-1"
+        assert second == "tok-2"
+        assert mock_exchange.call_count == 2
+
+    @patch("app.services.credentials_service._exchange_token")
+    @patch("app.services.credentials_service._redis_client")
+    def test_expired_cache_re_exchanges(self, mock_redis_factory, mock_exchange, rsa_private_pem):
+        # Pre-seed cache with an already-expired token.
+        client = MagicMock(spec=redis.Redis)
+        client.get.return_value = json.dumps({"token": "stale", "expires_at": int(time.time()) - 100})
+        client.set.return_value = True
+        client.delete.return_value = 1
+        mock_redis_factory.return_value = client
+        mock_exchange.return_value = ("fresh", 600)
+
+        payload = {"client_id": "abc", "token_endpoint": "https://x/t", "private_key": rsa_private_pem}
+        result = get_bearer_token("cred-1", payload)
+        assert result == "fresh"
+        mock_exchange.assert_called_once()
+
+    @patch("app.services.credentials_service._exchange_token")
+    @patch("app.services.credentials_service._redis_client")
+    def test_redis_unavailable_still_exchanges(self, mock_redis_factory, mock_exchange, rsa_private_pem):
+        client = MagicMock(spec=redis.Redis)
+        client.get.side_effect = redis.RedisError("connection refused")
+        client.set.side_effect = redis.RedisError("connection refused")
+        mock_redis_factory.return_value = client
+        mock_exchange.return_value = ("tok", 600)
+
+        payload = {"client_id": "abc", "token_endpoint": "https://x/t", "private_key": rsa_private_pem}
+        assert get_bearer_token("cred-1", payload) == "tok"
+
+
+# ---------------------------------------------------------------------------
+# apply_auth dispatcher
+# ---------------------------------------------------------------------------
+
+class TestApplyAuth:
+    def test_static_header_applied(self):
+        cred = {
+            "_id": "abc123",
+            "type": "static_header",
+            "payload": {"header_name": "X-Key", "header_value": "secret"},
+        }
+        headers: dict[str, str] = {}
+        apply_auth(credential_doc=cred, headers=headers)
+        assert headers == {"X-Key": "secret"}
+
+    def test_static_header_incomplete_raises(self):
+        cred = {
+            "_id": "abc",
+            "type": "static_header",
+            "payload": {"header_name": "X-Key"},
+        }
+        with pytest.raises(CredentialError, match="incomplete"):
+            apply_auth(credential_doc=cred, headers={})
+
+    @patch("app.services.credentials_service.get_bearer_token", return_value="tok-xyz")
+    @patch("app.services.credentials_service.validate_outbound_url", return_value="ok")
+    def test_oauth_applies_bearer(self, _mock_validate, _mock_token, rsa_private_pem):
+        cred = {
+            "_id": "abc123",
+            "type": "oauth_client_credentials",
+            "payload": {
+                "client_id": "c",
+                "token_endpoint": "https://issuer/token",
+                "private_key": rsa_private_pem,
+            },
+        }
+        headers: dict[str, str] = {}
+        apply_auth(credential_doc=cred, headers=headers)
+        assert headers == {"Authorization": "Bearer tok-xyz"}
+
+    def test_unknown_type_raises(self):
+        with pytest.raises(CredentialError, match="Unknown credential type"):
+            apply_auth(credential_doc={"_id": "abc", "type": "weird", "payload": {}}, headers={})
+
+
+# ---------------------------------------------------------------------------
+# fetch_credential_sync
+# ---------------------------------------------------------------------------
+
+class TestFetchCredentialSync:
+    def test_invalid_objectid_returns_none(self):
+        db = MagicMock()
+        result = credentials_service.fetch_credential_sync(db, "not-an-objectid")
+        assert result is None
+        db.credential.find_one.assert_not_called()
+
+    def test_lookup_passes_objectid(self):
+        db = MagicMock()
+        db.credential.find_one.return_value = {"_id": "abc", "type": "static_header"}
+        result = credentials_service.fetch_credential_sync(db, "507f1f77bcf86cd799439011")
+        assert result == {"_id": "abc", "type": "static_header"}
+        db.credential.find_one.assert_called_once()

--- a/backend/tests/test_workflow_nodes.py
+++ b/backend/tests/test_workflow_nodes.py
@@ -659,6 +659,142 @@ class TestAPICallNode:
         result = node.process({"output": "prev"})
         assert "HTTP error" in result["output"]
 
+    # -----------------------------------------------------------------------
+    # auth_strategy
+    # -----------------------------------------------------------------------
+
+    @patch("app.utils.url_validation.validate_outbound_url", return_value="ok")
+    def test_auth_strategy_requires_credential_id(self, _mock_validate):
+        node = APICallNode({
+            "url": "https://api.example.com",
+            "method": "GET",
+            "auth_strategy": "static_header",
+        })
+        result = node.process({"output": "prev"})
+        assert "requires credential_id" in result["output"]
+
+    @patch("app.utils.url_validation.validate_outbound_url")
+    @patch("app.services.workflow_engine._open_sync_db")
+    def test_auth_strategy_credential_not_found(self, mock_open_db, mock_validate):
+        mock_validate.return_value = "ok"
+        db = MagicMock()
+        db.credential.find_one.return_value = None
+        mock_open_db.return_value = db
+
+        node = APICallNode({
+            "url": "https://api.example.com",
+            "auth_strategy": "static_header",
+            "credential_id": "507f1f77bcf86cd799439011",
+        })
+        result = node.process({"output": "prev"})
+        assert "not found" in result["output"]
+
+    @patch("app.utils.url_validation.validate_outbound_url")
+    @patch("app.services.workflow_engine._open_sync_db")
+    def test_auth_strategy_type_mismatch(self, mock_open_db, mock_validate):
+        mock_validate.return_value = "ok"
+        db = MagicMock()
+        db.credential.find_one.return_value = {
+            "_id": "507f1f77bcf86cd799439011",
+            "type": "static_header",
+            "payload": {"header_name": "X", "header_value": "y"},
+        }
+        mock_open_db.return_value = db
+
+        node = APICallNode({
+            "url": "https://api.example.com",
+            "auth_strategy": "oauth_client_credentials",
+            "credential_id": "507f1f77bcf86cd799439011",
+        })
+        result = node.process({"output": "prev"})
+        assert "does not match" in result["output"]
+
+    @patch("app.services.credentials_service.decrypt_value", side_effect=lambda v: v)
+    @patch("app.utils.url_validation.validate_outbound_url")
+    @patch("app.services.workflow_engine._open_sync_db")
+    @patch("app.services.workflow_engine.httpx.Client")
+    def test_static_header_strategy_attaches_header(
+        self, mock_client_cls, mock_open_db, mock_validate, _mock_decrypt
+    ):
+        mock_validate.return_value = "ok"
+        db = MagicMock()
+        db.credential.find_one.return_value = {
+            "_id": "507f1f77bcf86cd799439011",
+            "type": "static_header",
+            "payload": {"header_name": "X-Api-Key", "header_value": "secret-value"},
+        }
+        mock_open_db.return_value = db
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"ok": True}
+        mock_response.raise_for_status = MagicMock()
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.request.return_value = mock_response
+        mock_client_cls.return_value = mock_client
+
+        node = APICallNode({
+            "url": "https://api.example.com",
+            "method": "GET",
+            "auth_strategy": "static_header",
+            "credential_id": "507f1f77bcf86cd799439011",
+        })
+        result = node.process({"output": "prev"})
+
+        sent_headers = mock_client.request.call_args[1]["headers"]
+        assert sent_headers["X-Api-Key"] == "secret-value"
+        assert result["output"] == {"ok": True}
+
+    @patch("app.services.credentials_service.get_bearer_token", return_value="bearer-xyz")
+    @patch("app.services.credentials_service.validate_outbound_url", return_value="ok")
+    @patch("app.services.credentials_service.decrypt_value", side_effect=lambda v: v)
+    @patch("app.utils.url_validation.validate_outbound_url")
+    @patch("app.services.workflow_engine._open_sync_db")
+    @patch("app.services.workflow_engine.httpx.Client")
+    def test_oauth_strategy_attaches_bearer(
+        self,
+        mock_client_cls,
+        mock_open_db,
+        mock_validate,
+        _mock_decrypt,
+        _mock_inner_validate,
+        _mock_token,
+    ):
+        mock_validate.return_value = "ok"
+        db = MagicMock()
+        db.credential.find_one.return_value = {
+            "_id": "507f1f77bcf86cd799439011",
+            "type": "oauth_client_credentials",
+            "payload": {
+                "client_id": "c",
+                "token_endpoint": "https://issuer/token",
+                "private_key": "-----BEGIN-----",
+            },
+        }
+        mock_open_db.return_value = db
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"ok": True}
+        mock_response.raise_for_status = MagicMock()
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.request.return_value = mock_response
+        mock_client_cls.return_value = mock_client
+
+        node = APICallNode({
+            "url": "https://api.example.com/data",
+            "method": "GET",
+            "auth_strategy": "oauth_client_credentials",
+            "credential_id": "507f1f77bcf86cd799439011",
+        })
+        result = node.process({"output": "prev"})
+
+        sent_headers = mock_client.request.call_args[1]["headers"]
+        assert sent_headers["Authorization"] == "Bearer bearer-xyz"
+        assert result["output"] == {"ok": True}
+
 
 # ---------------------------------------------------------------------------
 # FormFillerNode

--- a/frontend/src/api/credentials.ts
+++ b/frontend/src/api/credentials.ts
@@ -1,0 +1,45 @@
+import { apiFetch } from './client'
+import type { Credential, CredentialType } from '../types/credential'
+
+export function listCredentials() {
+  return apiFetch<Credential[]>('/api/credentials')
+}
+
+export function getCredential(id: string) {
+  return apiFetch<Credential>(`/api/credentials/${id}`)
+}
+
+export function createCredential(data: {
+  name: string
+  type: CredentialType
+  description?: string
+  payload: Record<string, string>
+  team_id?: string
+}) {
+  return apiFetch<Credential>('/api/credentials', {
+    method: 'POST',
+    body: JSON.stringify(data),
+  })
+}
+
+export function updateCredential(
+  id: string,
+  data: { name?: string; description?: string; payload?: Record<string, string> },
+) {
+  return apiFetch<Credential>(`/api/credentials/${id}`, {
+    method: 'PATCH',
+    body: JSON.stringify(data),
+  })
+}
+
+export function deleteCredential(id: string) {
+  return apiFetch<{ status: string; id: string }>(`/api/credentials/${id}`, {
+    method: 'DELETE',
+  })
+}
+
+export function invalidateCredentialCache(id: string) {
+  return apiFetch<{ status: string; id: string }>(`/api/credentials/${id}/invalidate-cache`, {
+    method: 'POST',
+  })
+}

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { BookOpen, ClipboardCheck, Cloud, FileText, Globe, MessageSquare, Shield, Users, Workflow, Zap } from 'lucide-react'
+import { BookOpen, ClipboardCheck, Cloud, FileText, Globe, KeyRound, MessageSquare, Shield, Users, Workflow, Zap } from 'lucide-react'
 import { Link, useRouterState } from '@tanstack/react-router'
 import { cn } from '../../lib/cn'
 import { useAuth } from '../../hooks/useAuth'
@@ -21,6 +21,7 @@ export function Sidebar() {
     { href: '/office', label: 'Office 365', icon: Cloud },
     { href: '/browser-automation', label: 'Browser', icon: Globe },
     { href: '/teams', label: 'Teams', icon: Users },
+    { href: '/credentials', label: 'Credentials', icon: KeyRound },
     ...(user?.is_examiner ? [{ href: '/verification', label: 'Verification', icon: ClipboardCheck }] : []),
     ...(showAdmin ? [{ href: '/admin', label: 'Admin', icon: Shield }] : []),
   ] as const

--- a/frontend/src/components/workspace/WorkflowEditorPanel.tsx
+++ b/frontend/src/components/workspace/WorkflowEditorPanel.tsx
@@ -27,6 +27,8 @@ import type { ValidationCheck, ValidationCheckDefinition, ValidationInputDefinit
 import { ItemPickerModal } from './ItemPickerModal'
 import { getModels } from '../../api/config'
 import { searchDocuments } from '../../api/documents'
+import { listCredentials } from '../../api/credentials'
+import type { Credential } from '../../types/credential'
 import { uploadFile } from '../../api/files'
 import { listKnowledgeBases } from '../../api/knowledge'
 import type { KnowledgeBase } from '../../types/knowledge'
@@ -1784,6 +1786,17 @@ function TaskEditModal({ task, selectedDocUuids, workflow, workflowId, onClose, 
   const [uploading, setUploading] = useState(false)
   const fileInputRef = useRef<HTMLInputElement>(null)
 
+  // Credentials (API Node auth_strategy picker)
+  const [credentials, setCredentials] = useState<Credential[] | null>(null)
+  useEffect(() => {
+    if (task.name !== 'APINode') return
+    let cancelled = false
+    listCredentials()
+      .then(list => { if (!cancelled) setCredentials(list) })
+      .catch(() => { if (!cancelled) setCredentials([]) })
+    return () => { cancelled = true }
+  }, [task.name])
+
   // Save fixed documents to workflow input_config
   const saveFixedDocs = async (docs: { uuid: string; title: string }[]) => {
     setFixedDocs(docs)
@@ -2635,12 +2648,72 @@ function TaskEditModal({ task, selectedDocUuids, workflow, workflowId, onClose, 
                 </div>
                 <div style={{ marginBottom: 16 }}>
                   <label style={{ display: 'block', fontSize: 13, fontWeight: 600, color: '#374151', marginBottom: 8 }}>
+                    Authentication
+                  </label>
+                  <div style={{ position: 'relative', marginBottom: 8 }}>
+                    <select
+                      value={(getTextValue('auth_strategy') || 'none')}
+                      onChange={e => {
+                        const strategy = e.target.value
+                        setTaskData(prev => ({
+                          ...prev,
+                          auth_strategy: strategy,
+                          ...(strategy === 'none' ? { credential_id: '' } : {}),
+                        }))
+                      }}
+                      style={{
+                        width: '100%', padding: '8px 12px', fontSize: 13, fontFamily: 'inherit',
+                        border: '1px solid #d1d5db', borderRadius: 6, backgroundColor: '#fff',
+                        color: '#374151', appearance: 'none', paddingRight: 32,
+                      }}
+                    >
+                      <option value="none">None / inline headers</option>
+                      <option value="static_header">Static header (from credentials)</option>
+                      <option value="oauth_client_credentials">OAuth client_credentials (JWT)</option>
+                    </select>
+                    <ChevronDown style={{
+                      position: 'absolute', right: 10, top: '50%', transform: 'translateY(-50%)',
+                      width: 14, height: 14, color: '#9ca3af', pointerEvents: 'none',
+                    }} />
+                  </div>
+                  {getTextValue('auth_strategy') && getTextValue('auth_strategy') !== 'none' && (
+                    <div style={{ position: 'relative' }}>
+                      <select
+                        value={getTextValue('credential_id') || ''}
+                        onChange={e => setTextValue('credential_id', e.target.value)}
+                        style={{
+                          width: '100%', padding: '8px 12px', fontSize: 13, fontFamily: 'inherit',
+                          border: '1px solid #d1d5db', borderRadius: 6, backgroundColor: '#fff',
+                          color: '#374151', appearance: 'none', paddingRight: 32,
+                        }}
+                      >
+                        <option value="">Select a credential...</option>
+                        {(credentials || [])
+                          .filter(c => c.type === getTextValue('auth_strategy'))
+                          .map(c => (
+                            <option key={c.id} value={c.id}>{c.name}</option>
+                          ))}
+                      </select>
+                      <ChevronDown style={{
+                        position: 'absolute', right: 10, top: '50%', transform: 'translateY(-50%)',
+                        width: 14, height: 14, color: '#9ca3af', pointerEvents: 'none',
+                      }} />
+                      {credentials && credentials.filter(c => c.type === getTextValue('auth_strategy')).length === 0 && (
+                        <p style={{ fontSize: 12, color: '#6b7280', marginTop: 6 }}>
+                          No matching credentials. Create one in Credentials.
+                        </p>
+                      )}
+                    </div>
+                  )}
+                </div>
+                <div style={{ marginBottom: 16 }}>
+                  <label style={{ display: 'block', fontSize: 13, fontWeight: 600, color: '#374151', marginBottom: 8 }}>
                     Headers (JSON)
                   </label>
                   <textarea
                     value={getTextValue('headers')}
                     onChange={e => setTextValue('headers', e.target.value)}
-                    placeholder={'{"Authorization": "Bearer ...", "Content-Type": "application/json"}'}
+                    placeholder={'{"Content-Type": "application/json"}'}
                     rows={3}
                     style={{
                       width: '100%', padding: '10px 12px', fontSize: 13,

--- a/frontend/src/pages/Credentials.tsx
+++ b/frontend/src/pages/Credentials.tsx
@@ -1,0 +1,371 @@
+import { useEffect, useMemo, useState } from 'react'
+import { KeyRound, Plus, Trash2, RefreshCw } from 'lucide-react'
+import { PageLayout } from '../components/layout/PageLayout'
+import {
+  createCredential,
+  deleteCredential,
+  invalidateCredentialCache,
+  listCredentials,
+} from '../api/credentials'
+import type { Credential, CredentialType } from '../types/credential'
+
+const TYPE_LABELS: Record<CredentialType, string> = {
+  static_header: 'Static header',
+  oauth_client_credentials: 'OAuth (client_credentials JWT)',
+}
+
+interface FormState {
+  name: string
+  type: CredentialType
+  description: string
+  // static_header
+  header_name: string
+  header_value: string
+  // oauth_client_credentials
+  client_id: string
+  token_endpoint: string
+  private_key: string
+  scope: string
+  audience: string
+  algorithm: string
+}
+
+const EMPTY_FORM: FormState = {
+  name: '',
+  type: 'static_header',
+  description: '',
+  header_name: '',
+  header_value: '',
+  client_id: '',
+  token_endpoint: '',
+  private_key: '',
+  scope: '',
+  audience: '',
+  algorithm: 'RS256',
+}
+
+function buildPayload(form: FormState): Record<string, string> {
+  if (form.type === 'static_header') {
+    return { header_name: form.header_name, header_value: form.header_value }
+  }
+  const payload: Record<string, string> = {
+    client_id: form.client_id,
+    token_endpoint: form.token_endpoint,
+    private_key: form.private_key,
+  }
+  if (form.scope) payload.scope = form.scope
+  if (form.audience) payload.audience = form.audience
+  if (form.algorithm && form.algorithm !== 'RS256') payload.algorithm = form.algorithm
+  return payload
+}
+
+export default function Credentials() {
+  const [creds, setCreds] = useState<Credential[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [showForm, setShowForm] = useState(false)
+  const [form, setForm] = useState<FormState>(EMPTY_FORM)
+  const [saving, setSaving] = useState(false)
+
+  const loadCreds = async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const list = await listCredentials()
+      setCreds(list)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load credentials')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    loadCreds()
+  }, [])
+
+  const handleCreate = async () => {
+    setSaving(true)
+    setError(null)
+    try {
+      await createCredential({
+        name: form.name,
+        type: form.type,
+        description: form.description || undefined,
+        payload: buildPayload(form),
+      })
+      setForm(EMPTY_FORM)
+      setShowForm(false)
+      await loadCreds()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to create credential')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const handleDelete = async (id: string) => {
+    if (!confirm('Delete this credential? Workflows referencing it will fail.')) return
+    try {
+      await deleteCredential(id)
+      await loadCreds()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to delete')
+    }
+  }
+
+  const handleInvalidate = async (id: string) => {
+    try {
+      await invalidateCredentialCache(id)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to invalidate cache')
+    }
+  }
+
+  const formValid = useMemo(() => {
+    if (!form.name.trim()) return false
+    if (form.type === 'static_header') {
+      return !!form.header_name && !!form.header_value
+    }
+    return !!form.client_id && !!form.token_endpoint && !!form.private_key
+  }, [form])
+
+  return (
+    <PageLayout>
+      <div className="mx-auto max-w-3xl space-y-6">
+        <div className="flex items-center justify-between">
+          <h2 className="text-xl font-semibold text-gray-900">Credentials</h2>
+          <button
+            onClick={() => setShowForm(s => !s)}
+            className="flex items-center gap-1.5 rounded-md bg-highlight px-3 py-1.5 text-sm font-bold text-highlight-text hover:brightness-90"
+          >
+            <Plus className="h-4 w-4" />
+            New credential
+          </button>
+        </div>
+
+        <p className="text-sm text-gray-600">
+          Credentials are referenced by ID from API Node steps in workflows. Secret values
+          are encrypted at rest and never returned by the API after creation.
+        </p>
+
+        {error && (
+          <div className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+            {error}
+          </div>
+        )}
+
+        {showForm && (
+          <div className="rounded-lg border border-gray-200 bg-white p-4 space-y-3">
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <label className="block text-xs font-medium uppercase text-gray-400 mb-1">Name</label>
+                <input
+                  type="text"
+                  value={form.name}
+                  onChange={e => setForm({ ...form, name: e.target.value })}
+                  className="w-full rounded-md border border-gray-300 px-3 py-1.5 text-sm focus:border-highlight focus:outline-none focus:ring-1 focus:ring-highlight"
+                  placeholder="e.g. Lakehouse OAuth"
+                />
+              </div>
+              <div>
+                <label className="block text-xs font-medium uppercase text-gray-400 mb-1">Type</label>
+                <select
+                  value={form.type}
+                  onChange={e => setForm({ ...form, type: e.target.value as CredentialType })}
+                  className="w-full rounded-md border border-gray-300 px-3 py-1.5 text-sm focus:border-highlight focus:outline-none focus:ring-1 focus:ring-highlight"
+                >
+                  <option value="static_header">{TYPE_LABELS.static_header}</option>
+                  <option value="oauth_client_credentials">
+                    {TYPE_LABELS.oauth_client_credentials}
+                  </option>
+                </select>
+              </div>
+            </div>
+
+            <div>
+              <label className="block text-xs font-medium uppercase text-gray-400 mb-1">Description</label>
+              <input
+                type="text"
+                value={form.description}
+                onChange={e => setForm({ ...form, description: e.target.value })}
+                className="w-full rounded-md border border-gray-300 px-3 py-1.5 text-sm focus:border-highlight focus:outline-none focus:ring-1 focus:ring-highlight"
+                placeholder="Optional"
+              />
+            </div>
+
+            {form.type === 'static_header' && (
+              <div className="grid grid-cols-2 gap-3">
+                <div>
+                  <label className="block text-xs font-medium uppercase text-gray-400 mb-1">Header name</label>
+                  <input
+                    type="text"
+                    value={form.header_name}
+                    onChange={e => setForm({ ...form, header_name: e.target.value })}
+                    className="w-full rounded-md border border-gray-300 px-3 py-1.5 text-sm font-mono focus:border-highlight focus:outline-none focus:ring-1 focus:ring-highlight"
+                    placeholder="X-Api-Key"
+                  />
+                </div>
+                <div>
+                  <label className="block text-xs font-medium uppercase text-gray-400 mb-1">Header value</label>
+                  <input
+                    type="password"
+                    value={form.header_value}
+                    onChange={e => setForm({ ...form, header_value: e.target.value })}
+                    className="w-full rounded-md border border-gray-300 px-3 py-1.5 text-sm font-mono focus:border-highlight focus:outline-none focus:ring-1 focus:ring-highlight"
+                    placeholder="secret"
+                  />
+                </div>
+              </div>
+            )}
+
+            {form.type === 'oauth_client_credentials' && (
+              <>
+                <div className="grid grid-cols-2 gap-3">
+                  <div>
+                    <label className="block text-xs font-medium uppercase text-gray-400 mb-1">Client ID</label>
+                    <input
+                      type="text"
+                      value={form.client_id}
+                      onChange={e => setForm({ ...form, client_id: e.target.value })}
+                      className="w-full rounded-md border border-gray-300 px-3 py-1.5 text-sm font-mono focus:border-highlight focus:outline-none focus:ring-1 focus:ring-highlight"
+                    />
+                  </div>
+                  <div>
+                    <label className="block text-xs font-medium uppercase text-gray-400 mb-1">Token endpoint</label>
+                    <input
+                      type="url"
+                      value={form.token_endpoint}
+                      onChange={e => setForm({ ...form, token_endpoint: e.target.value })}
+                      className="w-full rounded-md border border-gray-300 px-3 py-1.5 text-sm font-mono focus:border-highlight focus:outline-none focus:ring-1 focus:ring-highlight"
+                      placeholder="https://issuer/oauth/token"
+                    />
+                  </div>
+                </div>
+                <div className="grid grid-cols-3 gap-3">
+                  <div>
+                    <label className="block text-xs font-medium uppercase text-gray-400 mb-1">Scope</label>
+                    <input
+                      type="text"
+                      value={form.scope}
+                      onChange={e => setForm({ ...form, scope: e.target.value })}
+                      className="w-full rounded-md border border-gray-300 px-3 py-1.5 text-sm font-mono focus:border-highlight focus:outline-none focus:ring-1 focus:ring-highlight"
+                      placeholder="read write"
+                    />
+                  </div>
+                  <div>
+                    <label className="block text-xs font-medium uppercase text-gray-400 mb-1">Audience</label>
+                    <input
+                      type="text"
+                      value={form.audience}
+                      onChange={e => setForm({ ...form, audience: e.target.value })}
+                      className="w-full rounded-md border border-gray-300 px-3 py-1.5 text-sm font-mono focus:border-highlight focus:outline-none focus:ring-1 focus:ring-highlight"
+                      placeholder="(default: token endpoint)"
+                    />
+                  </div>
+                  <div>
+                    <label className="block text-xs font-medium uppercase text-gray-400 mb-1">Algorithm</label>
+                    <select
+                      value={form.algorithm}
+                      onChange={e => setForm({ ...form, algorithm: e.target.value })}
+                      className="w-full rounded-md border border-gray-300 px-3 py-1.5 text-sm focus:border-highlight focus:outline-none focus:ring-1 focus:ring-highlight"
+                    >
+                      <option value="RS256">RS256</option>
+                      <option value="RS384">RS384</option>
+                      <option value="RS512">RS512</option>
+                      <option value="ES256">ES256</option>
+                      <option value="ES384">ES384</option>
+                    </select>
+                  </div>
+                </div>
+                <div>
+                  <label className="block text-xs font-medium uppercase text-gray-400 mb-1">Private key (PEM)</label>
+                  <textarea
+                    value={form.private_key}
+                    onChange={e => setForm({ ...form, private_key: e.target.value })}
+                    rows={8}
+                    className="w-full rounded-md border border-gray-300 px-3 py-1.5 text-xs font-mono focus:border-highlight focus:outline-none focus:ring-1 focus:ring-highlight"
+                    placeholder="-----BEGIN PRIVATE KEY-----&#10;...&#10;-----END PRIVATE KEY-----"
+                  />
+                </div>
+              </>
+            )}
+
+            <div className="flex items-center gap-2 pt-2">
+              <button
+                onClick={handleCreate}
+                disabled={!formValid || saving}
+                className="rounded-md bg-highlight px-4 py-1.5 text-sm font-bold text-highlight-text hover:brightness-90 disabled:opacity-50"
+              >
+                {saving ? 'Saving...' : 'Save credential'}
+              </button>
+              <button
+                onClick={() => { setShowForm(false); setForm(EMPTY_FORM) }}
+                className="rounded-md border border-gray-300 bg-white px-4 py-1.5 text-sm text-gray-700 hover:bg-gray-50"
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        )}
+
+        <div className="rounded-lg border border-gray-200 bg-white">
+          <div className="flex items-center gap-2 border-b border-gray-200 px-4 py-3">
+            <KeyRound className="h-4 w-4 text-gray-400" />
+            <h3 className="font-medium text-gray-900">Stored credentials</h3>
+          </div>
+
+          {loading ? (
+            <div className="p-4 text-sm text-gray-500">Loading...</div>
+          ) : creds.length === 0 ? (
+            <div className="p-4 text-sm text-gray-500">No credentials yet.</div>
+          ) : (
+            <ul className="divide-y divide-gray-100">
+              {creds.map(cred => (
+                <li key={cred.id} className="flex items-center justify-between px-4 py-3">
+                  <div className="min-w-0">
+                    <div className="flex items-center gap-2">
+                      <span className="font-medium text-gray-900">{cred.name}</span>
+                      <span className="rounded bg-gray-100 px-1.5 py-0.5 text-xs font-mono text-gray-600">
+                        {TYPE_LABELS[cred.type]}
+                      </span>
+                      {cred.team_id && (
+                        <span className="rounded bg-blue-50 px-1.5 py-0.5 text-xs text-blue-700">team</span>
+                      )}
+                    </div>
+                    {cred.description && (
+                      <div className="mt-1 text-xs text-gray-500 truncate">{cred.description}</div>
+                    )}
+                    <div className="mt-1 text-xs font-mono text-gray-400">{cred.id}</div>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    {cred.type === 'oauth_client_credentials' && (
+                      <button
+                        onClick={() => handleInvalidate(cred.id)}
+                        title="Drop cached bearer token"
+                        className="flex items-center gap-1 rounded-md border border-gray-300 bg-white px-2 py-1 text-xs text-gray-700 hover:bg-gray-50"
+                      >
+                        <RefreshCw className="h-3 w-3" />
+                        Invalidate
+                      </button>
+                    )}
+                    {cred.can_manage && (
+                      <button
+                        onClick={() => handleDelete(cred.id)}
+                        title="Delete credential"
+                        className="flex items-center gap-1 rounded-md border border-red-200 bg-white px-2 py-1 text-xs text-red-600 hover:bg-red-50"
+                      >
+                        <Trash2 className="h-3 w-3" />
+                        Delete
+                      </button>
+                    )}
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </div>
+    </PageLayout>
+  )
+}

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -25,6 +25,7 @@ const Demo = lazy(() => import('./pages/Demo'))
 const DemoFeedback = lazy(() => import('./pages/DemoFeedback'))
 const InviteAccept = lazy(() => import('./pages/InviteAccept'))
 const Organizations = lazy(() => import('./pages/Organizations'))
+const Credentials = lazy(() => import('./pages/Credentials'))
 const Login = lazy(() => import('./pages/Login'))
 const ResetPassword = lazy(() => import('./pages/ResetPassword'))
 
@@ -272,6 +273,16 @@ const organizationsRoute = createRoute({
   ),
 })
 
+const credentialsRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/credentials',
+  component: () => (
+    <ProtectedRoute>
+      <Credentials />
+    </ProtectedRoute>
+  ),
+})
+
 // /audit and /approvals are now tabs in the Admin panel
 const auditLogRoute = createRoute({
   getParentRoute: () => rootRoute,
@@ -329,6 +340,7 @@ const routeTree = rootRoute.addChildren([
   demoFeedbackRoute,
   demoStatusRoute,
   organizationsRoute,
+  credentialsRoute,
   auditLogRoute,
   approvalsRoute,
 ])

--- a/frontend/src/types/credential.ts
+++ b/frontend/src/types/credential.ts
@@ -1,0 +1,14 @@
+export type CredentialType = 'static_header' | 'oauth_client_credentials'
+
+export interface Credential {
+  id: string
+  name: string
+  type: CredentialType
+  description: string | null
+  team_id: string | null
+  user_id: string
+  payload: Record<string, string>
+  created_at: string | null
+  updated_at: string | null
+  can_manage: boolean
+}


### PR DESCRIPTION
## Summary

- API Node previously took inline auth headers from the node config — secrets sat in workflow definitions in cleartext, duplicated across nodes, and could leak via exports/clones. It also couldn't talk to APIs (like the data lakehouse) that require a JWT-assertion → bearer exchange instead of a long-lived static token.
- Adds a **team-scoped Credential collection** with per-field Fernet encryption (using existing `CONFIG_ENCRYPTION_KEY`), a **credentials service** that signs short-lived JWT assertions (PyJWT, RS256 default) and caches the returned bearers in Redis with a 30s refresh skew, and an **`auth_strategy` selector on API Node** (`none` | `static_header` | `oauth_client_credentials`) that resolves credentials by ID at execution time.
- Secrets never round-trip back to clients — `list`/`get` responses redact encrypted fields as `"<set>"`. Workflow exports/clones carry the credential ID, not the value.
- Frontend ships a **Credentials management page** (list/create/delete + bearer-cache invalidation) and a **credential picker in the API Node config panel** that filters by selected strategy.

## What's in the box

**Backend**
- `app/models/credential.py` — Beanie `Credential` document, registered in `database.py`.
- `app/services/credentials_service.py` — payload validation, encrypt/decrypt round-trip, JWT client-assertion construction, token exchange via `httpx`, Redis-cached bearer keyed by credential ID, `apply_auth()` dispatcher used by API Node, `metadata_view()` redactor used by the router.
- `app/routers/credentials.py` + `app/schemas/credentials.py` — full CRUD at `/api/credentials`, team-admin gating for shared credentials, `/invalidate-cache` endpoint for post-rotation cleanup.
- `app/services/workflow_engine.py` — `APICallNode.process()` reads `auth_strategy` + `credential_id`, looks up the credential via pymongo (sync, matches surrounding workflow_tasks pattern), and applies the chosen auth.

**Frontend**
- `pages/Credentials.tsx`, `api/credentials.ts`, `types/credential.ts` — type-aware form (static_header vs OAuth fields), redacted indicators, OAuth bearer-cache invalidate button.
- New sidebar entry, new `/credentials` route in `router.tsx`.
- API Node config gains an "Authentication" dropdown + credential picker that filters credentials by selected strategy.

## Out of scope (intentional)

- Other OAuth flows (auth code, device code, refresh tokens). Add as new strategies if/when concrete use cases appear.
- mTLS / signed-request strategies.
- Per-user (vs per-team) credential ownership semantics — credentials owned by the user are also visible to that user; team-scoped credentials require team admin/owner to manage.
- General-purpose secrets manager UI beyond what API Node needs today.

## Test plan

- [x] backend unit tests for credentials_service (26 pass): validation, encrypt/decrypt round-trip, JWT assertion structure, mocked token exchange, Redis cache hit/miss/expiry/invalidate, apply_auth dispatch.
- [x] backend route tests for credentials (3 pass): validation rejects missing fields, secret never echoed in create response, list redacts secrets.
- [x] APICallNode auth-strategy tests (5 new, 14 total in TestAPICallNode pass): missing credential_id, credential not found, credential type mismatch, static_header attaches header, oauth_client_credentials attaches bearer.
- [x] Full backend suite: 1685 passed, 65 skipped, 0 failed.
- [x] Frontend typecheck clean, lint 0 errors, vitest 135/135 pass.
- [x] ruff and mypy clean on all new files.
- [ ] Manual: create a static_header credential in the UI, reference it from an API Node, run the workflow against a test API, confirm the header is sent and the secret is never visible in the workflow definition.
- [ ] Manual: create an oauth_client_credentials credential against a real token endpoint (lakehouse staging or an RFC 7523 test issuer), run an API Node that calls a protected endpoint, confirm bearer is exchanged once and reused on subsequent calls until expiry.
- [ ] Manual: rotate a credential, click "Invalidate cache", confirm the next call re-exchanges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)