### PR TITLE
Show original author on workflow cards (Workflows, Library, Explore)

### DIFF
--- a/backend/app/routers/workflows.py
+++ b/backend/app/routers/workflows.py
@@ -39,8 +39,16 @@ from app.schemas.workflows import (
 )
 from app.rate_limit import limiter
 from app.services import workflow_service as svc
+from app.services.user_lookup import resolve_author, resolve_authors
 
 router = APIRouter()
+
+
+async def _workflow_response_from_dict(wf: dict) -> WorkflowResponse:
+    """Build a WorkflowResponse from a workflow dict, resolving the author."""
+    creator_id = wf.get("created_by_user_id") or wf.get("user_id")
+    created_by = await resolve_author(creator_id)
+    return WorkflowResponse(**{**wf, "created_by": created_by})
 
 
 def _csv_cell(value) -> str:
@@ -304,9 +312,11 @@ async def _authorize_documents(document_uuids: list[str], user: User) -> list[st
 async def create_workflow(req: CreateWorkflowRequest, user: User = Depends(get_current_user)):
     team_id = str(user.current_team) if user.current_team else None
     wf = await svc.create_workflow(req.name, user.user_id, req.description, team_id=team_id)
+    created_by = await resolve_author(wf.created_by_user_id or wf.user_id)
     return WorkflowResponse(
         id=str(wf.id), name=wf.name, description=wf.description,
         user_id=wf.user_id, num_executions=wf.num_executions,
+        created_by=created_by,
     )
 
 
@@ -319,10 +329,14 @@ async def list_workflows(
     user: User = Depends(get_current_user),
 ):
     workflows = await svc.list_workflows(user=user, skip=skip, limit=limit, scope=scope, search=search)
+    author_map = await resolve_authors(
+        (wf.created_by_user_id or wf.user_id) for wf in workflows
+    )
     return [
         WorkflowResponse(
             id=str(wf.id), name=wf.name, description=wf.description,
             user_id=wf.user_id, num_executions=wf.num_executions,
+            created_by=author_map.get(wf.created_by_user_id or wf.user_id),
         )
         for wf in workflows
     ]
@@ -682,7 +696,7 @@ async def import_workflow(
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
 
-    return WorkflowResponse(**wf)
+    return await _workflow_response_from_dict(wf)
 
 
 @router.post("/{workflow_id}/import", response_model=WorkflowResponse)
@@ -714,7 +728,7 @@ async def import_into_workflow(
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
 
-    return WorkflowResponse(**wf)
+    return await _workflow_response_from_dict(wf)
 
 
 @router.get("/{workflow_id}", response_model=WorkflowResponse)
@@ -722,7 +736,7 @@ async def get_workflow(workflow_id: str, user: User = Depends(get_current_user))
     wf = await svc.get_workflow(workflow_id, user=user)
     if not wf:
         raise HTTPException(status_code=404, detail="Workflow not found")
-    return WorkflowResponse(**wf)
+    return await _workflow_response_from_dict(wf)
 
 
 @router.patch("/{workflow_id}", response_model=WorkflowResponse)
@@ -735,10 +749,12 @@ async def update_workflow(workflow_id: str, req: UpdateWorkflowRequest, user: Us
     # Flag stale verification if this workflow was verified
     from app.services.verification_service import check_and_flag_stale_verification
     await check_and_flag_stale_verification("workflow", str(wf.id))
+    created_by = await resolve_author(wf.created_by_user_id or wf.user_id)
     return WorkflowResponse(
         id=str(wf.id), name=wf.name, description=wf.description,
         user_id=wf.user_id, num_executions=wf.num_executions,
         input_config=wf.input_config,
+        created_by=created_by,
     )
 
 
@@ -756,7 +772,7 @@ async def duplicate_workflow(workflow_id: str, user: User = Depends(get_current_
     wf = await svc.duplicate_workflow(workflow_id, user=user, user_id=user.user_id, team_id=team_id)
     if not wf:
         raise HTTPException(status_code=404, detail="Workflow not found")
-    return WorkflowResponse(**wf)
+    return await _workflow_response_from_dict(wf)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/schemas/library.py
+++ b/backend/app/schemas/library.py
@@ -3,6 +3,8 @@
 from typing import Optional
 from pydantic import BaseModel
 
+from app.schemas.user import AuthorRef
+
 
 # ---------------------------------------------------------------------------
 # Library
@@ -50,6 +52,7 @@ class LibraryItemResponse(BaseModel):
     last_used_at: Optional[str] = None
     quality_tier: Optional[str] = None
     quality_score: Optional[float] = None
+    created_by: Optional[AuthorRef] = None
 
 
 class AddItemRequest(BaseModel):

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -1,0 +1,13 @@
+"""Shared user-related response schemas."""
+
+from typing import Optional
+
+from pydantic import BaseModel
+
+
+class AuthorRef(BaseModel):
+    """Lightweight reference to a user, used for author/creator badges in lists."""
+
+    user_id: str
+    name: Optional[str] = None
+    email: Optional[str] = None

--- a/backend/app/schemas/workflows.py
+++ b/backend/app/schemas/workflows.py
@@ -3,6 +3,8 @@
 from typing import Any, Optional
 from pydantic import BaseModel
 
+from app.schemas.user import AuthorRef
+
 
 # ---------------------------------------------------------------------------
 # Workflow
@@ -28,6 +30,7 @@ class WorkflowResponse(BaseModel):
     steps: list[dict] = []  # Dereferenced step objects
     input_config: dict = {}
     can_manage: bool = True
+    created_by: Optional[AuthorRef] = None
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/services/library_service.py
+++ b/backend/app/services/library_service.py
@@ -251,7 +251,7 @@ async def add_item(
     lib.updated_at = now
     await lib.save()
 
-    return await _dereference_item(li)
+    return await _attach_author(await _dereference_item(li))
 
 
 async def remove_item(library_id: str, item_id: str, user: User) -> bool:
@@ -297,7 +297,7 @@ async def update_item(
         item.favorited = favorited
     if updates:
         await item.set(updates)
-    return await _dereference_item(item)
+    return await _attach_author(await _dereference_item(item))
 
 
 async def touch_item(item_id: str, user: User) -> bool:
@@ -374,6 +374,7 @@ async def get_library_items(
 
             results.append(deref)
 
+    await _attach_authors(results)
     return results
 
 
@@ -629,12 +630,18 @@ def _item_created_at(item: LibraryItem) -> str | None:
 
 
 async def _dereference_item(item: LibraryItem) -> dict | None:
-    """Load the actual Workflow or SearchSet and return combined dict."""
+    """Load the actual Workflow or SearchSet and return combined dict.
+
+    Sets ``creator_user_id`` for workflow items (falling back to the workflow
+    owner when the dedicated field is missing). Use :func:`_attach_authors` to
+    expand it into a full ``created_by`` AuthorRef for response payloads.
+    """
     name = ""
     description = None
 
     set_type = None
     item_uuid = None
+    creator_user_id: str | None = None
 
     if item.kind == LibraryItemKind.WORKFLOW:
         wf = await Workflow.get(item.item_id)
@@ -642,6 +649,7 @@ async def _dereference_item(item: LibraryItem) -> dict | None:
             return None
         name = wf.name
         description = wf.description
+        creator_user_id = wf.created_by_user_id or wf.user_id
     elif item.kind == LibraryItemKind.SEARCH_SET:
         ss = await SearchSet.get(item.item_id)
         if not ss:
@@ -668,7 +676,33 @@ async def _dereference_item(item: LibraryItem) -> dict | None:
         "added_by_user_id": item.added_by_user_id,
         "created_at": _item_created_at(item),
         "last_used_at": _iso_utc(item.last_used_at),
+        "creator_user_id": creator_user_id,
     }
+
+
+async def _attach_authors(items: list[dict]) -> list[dict]:
+    """Batch-resolve creator_user_id → created_by AuthorRef for a list of dereffed items.
+
+    Mutates each dict to add ``created_by`` and remove the transient
+    ``creator_user_id`` key. Safe on items without a creator.
+    """
+    from app.services.user_lookup import resolve_authors
+
+    creator_ids = [i.get("creator_user_id") for i in items if i.get("creator_user_id")]
+    author_map = await resolve_authors(creator_ids) if creator_ids else {}
+    for entry in items:
+        cid = entry.pop("creator_user_id", None)
+        ref = author_map.get(cid) if cid else None
+        entry["created_by"] = ref.model_dump() if ref else None
+    return items
+
+
+async def _attach_author(item: dict | None) -> dict | None:
+    """Single-item variant of :func:`_attach_authors`."""
+    if not item:
+        return item
+    await _attach_authors([item])
+    return item
 
 
 async def _clone_underlying_object(item: LibraryItem, user_id: str, *, team_id: str | None = None) -> PydanticObjectId | None:

--- a/backend/app/services/user_lookup.py
+++ b/backend/app/services/user_lookup.py
@@ -1,0 +1,31 @@
+"""Batch resolution of user_ids to AuthorRef records for list endpoints."""
+
+from typing import Iterable, Optional
+
+from app.models.user import User
+from app.schemas.user import AuthorRef
+
+
+async def resolve_authors(user_ids: Iterable[str]) -> dict[str, AuthorRef]:
+    """Resolve a batch of user_ids to AuthorRef. Unknown ids get an AuthorRef with id only."""
+    ids = sorted({uid for uid in user_ids if uid})
+    if not ids:
+        return {}
+    users = await User.find({"user_id": {"$in": ids}}).to_list()
+    by_id = {u.user_id: u for u in users}
+    return {
+        uid: AuthorRef(
+            user_id=uid,
+            name=by_id[uid].name if uid in by_id else None,
+            email=by_id[uid].email if uid in by_id else None,
+        )
+        for uid in ids
+    }
+
+
+async def resolve_author(user_id: Optional[str]) -> Optional[AuthorRef]:
+    """Resolve a single user_id to an AuthorRef, or None if user_id is empty."""
+    if not user_id:
+        return None
+    refs = await resolve_authors([user_id])
+    return refs.get(user_id)

--- a/backend/app/services/verification_service.py
+++ b/backend/app/services/verification_service.py
@@ -455,10 +455,14 @@ async def list_verified_items(
     kb_ids = [i.item_id for i in items if i.kind == LibraryItemKind.KNOWLEDGE_BASE]
 
     name_map: dict[str, str] = {}
+    wf_creator_map: dict[str, str] = {}
     if wf_ids:
         wfs = await Workflow.find({"_id": {"$in": wf_ids}}).to_list()
         for wf in wfs:
             name_map[str(wf.id)] = wf.name
+            creator_id = wf.created_by_user_id or wf.user_id
+            if creator_id:
+                wf_creator_map[str(wf.id)] = creator_id
     ss_map: dict[str, SearchSet] = {}
     if ss_ids:
         ssets = await SearchSet.find({"_id": {"$in": ss_ids}}).to_list()
@@ -475,6 +479,10 @@ async def list_verified_items(
     meta_map: dict[tuple[str, str], VerifiedItemMetadata] = {}
     for m in all_meta:
         meta_map[(m.item_kind, m.item_id)] = m
+
+    # --- Batch-resolve workflow authors ---
+    from app.services.user_lookup import resolve_authors
+    author_map = await resolve_authors(wf_creator_map.values())
 
     # --- Batch-fetch KB metrics ---
     kb_map: dict[str, KnowledgeBase] = {}
@@ -551,6 +559,9 @@ async def list_verified_items(
         # Workflow: use MongoDB _id as source_uuid (workspace routes by _id)
         if item.kind == LibraryItemKind.WORKFLOW:
             entry["source_uuid"] = item_id_str
+            creator_id = wf_creator_map.get(item_id_str)
+            ref = author_map.get(creator_id) if creator_id else None
+            entry["created_by"] = ref.model_dump() if ref else None
 
         results.append(entry)
 

--- a/backend/app/services/workflow_service.py
+++ b/backend/app/services/workflow_service.py
@@ -149,6 +149,7 @@ async def get_workflow(workflow_id: str, user: User | None = None) -> dict | Non
         "validation_plan": _sanitize_for_json(wf.validation_plan),
         "validation_inputs": _sanitize_for_json(wf.validation_inputs),
         "can_manage": can_manage,
+        "created_by_user_id": wf.created_by_user_id or wf.user_id,
     }
 
 

--- a/backend/tests/test_workflow_authz.py
+++ b/backend/tests/test_workflow_authz.py
@@ -85,7 +85,8 @@ class TestWorkflowListScoping:
 
         with patch("app.dependencies.decode_token", return_value={"sub": "user1", "type": "access"}), \
              patch("app.dependencies.User") as MockUser, \
-             patch("app.routers.workflows.svc") as mock_svc:
+             patch("app.routers.workflows.svc") as mock_svc, \
+             patch("app.routers.workflows.resolve_authors", new_callable=AsyncMock, return_value={}):
             MockUser.find_one = AsyncMock(return_value=user)
             mock_svc.list_workflows = AsyncMock(return_value=[wf])
 
@@ -113,7 +114,8 @@ class TestWorkflowGetAuthz:
 
         with patch("app.dependencies.decode_token", return_value={"sub": "user1", "type": "access"}), \
              patch("app.dependencies.User") as MockUser, \
-             patch("app.routers.workflows.svc") as mock_svc:
+             patch("app.routers.workflows.svc") as mock_svc, \
+             patch("app.routers.workflows.resolve_author", new_callable=AsyncMock, return_value=None):
             MockUser.find_one = AsyncMock(return_value=user)
             # Service returns a dict for WorkflowResponse
             mock_svc.get_workflow = AsyncMock(return_value={
@@ -160,7 +162,8 @@ class TestWorkflowUpdateAuthz:
         with patch("app.dependencies.decode_token", return_value={"sub": "user1", "type": "access"}), \
              patch("app.dependencies.User") as MockUser, \
              patch("app.routers.workflows.svc") as mock_svc, \
-             patch("app.services.verification_service.check_and_flag_stale_verification", new_callable=AsyncMock, return_value=False):
+             patch("app.services.verification_service.check_and_flag_stale_verification", new_callable=AsyncMock, return_value=False), \
+             patch("app.routers.workflows.resolve_author", new_callable=AsyncMock, return_value=None):
             MockUser.find_one = AsyncMock(return_value=user)
             mock_svc.update_workflow = AsyncMock(return_value=updated_wf)
 
@@ -399,7 +402,8 @@ class TestWorkflowDuplicateAuthz:
 
         with patch("app.dependencies.decode_token", return_value={"sub": "user1", "type": "access"}), \
              patch("app.dependencies.User") as MockUser, \
-             patch("app.routers.workflows.svc") as mock_svc:
+             patch("app.routers.workflows.svc") as mock_svc, \
+             patch("app.routers.workflows.resolve_author", new_callable=AsyncMock, return_value=None):
             MockUser.find_one = AsyncMock(return_value=user)
             mock_svc.duplicate_workflow = AsyncMock(return_value={
                 "id": "wf-2", "name": "Test Workflow (copy)",

--- a/backend/tests/test_workflow_routes.py
+++ b/backend/tests/test_workflow_routes.py
@@ -64,7 +64,8 @@ class TestListWorkflows:
 
         with patch("app.dependencies.decode_token", return_value={"sub": "testuser", "type": "access"}), \
              patch("app.dependencies.User") as MockUser, \
-             patch("app.routers.workflows.svc") as mock_svc:
+             patch("app.routers.workflows.svc") as mock_svc, \
+             patch("app.routers.workflows.resolve_authors", AsyncMock(return_value={})):
             MockUser.find_one = AsyncMock(return_value=user)
             mock_svc.list_workflows = AsyncMock(return_value=[mock_wf])
 
@@ -104,7 +105,8 @@ class TestCreateWorkflow:
 
         with patch("app.dependencies.decode_token", return_value={"sub": "testuser", "type": "access"}), \
              patch("app.dependencies.User") as MockUser, \
-             patch("app.routers.workflows.svc") as mock_svc:
+             patch("app.routers.workflows.svc") as mock_svc, \
+             patch("app.routers.workflows.resolve_author", AsyncMock(return_value=None)):
             MockUser.find_one = AsyncMock(return_value=user)
             mock_svc.create_workflow = AsyncMock(return_value=mock_wf)
 

--- a/frontend/src/components/library/ExploreTab.tsx
+++ b/frontend/src/components/library/ExploreTab.tsx
@@ -10,6 +10,7 @@ import {
 import { useNavigate } from '@tanstack/react-router'
 import { QualityBadge } from './QualityBadge'
 import { AddToLibraryDialog } from './AddToLibraryDialog'
+import { AuthorChip } from '../shared/AuthorChip'
 import {
   listVerifiedItems, browseCollections, listFeaturedCollections,
   listLibraries,
@@ -148,6 +149,9 @@ export function ItemDetailModal({
             )}
             {item.kind === 'knowledge_base' && item.total_chunks != null && (
               <span className="text-white/70">{item.total_chunks.toLocaleString()} chunks</span>
+            )}
+            {item.created_by && (
+              <AuthorChip author={item.created_by} size="md" label="by" />
             )}
           </div>
         </div>
@@ -299,6 +303,12 @@ function CatalogCard({
 
       {item.description && (
         <p className="text-xs text-gray-600 mb-2">{item.description}</p>
+      )}
+
+      {item.created_by && (
+        <div className="mb-2">
+          <AuthorChip author={item.created_by} />
+        </div>
       )}
 
       {item.kind === 'knowledge_base' && (item.total_sources != null || item.total_chunks != null) && (

--- a/frontend/src/components/library/LibraryItemRow.test.tsx
+++ b/frontend/src/components/library/LibraryItemRow.test.tsx
@@ -7,6 +7,15 @@ vi.mock('../../api/library', () => ({
   submitForVerification: vi.fn(),
 }))
 
+vi.mock('../../hooks/useAuth', () => ({
+  useAuth: () => ({
+    user: { id: '1', user_id: 'viewer', email: 'viewer@example.com', name: 'Viewer', is_admin: false },
+    loading: false,
+    login: vi.fn(),
+    logout: vi.fn(),
+  }),
+}))
+
 function makeItem(overrides: Partial<LibraryItem> = {}): LibraryItem {
   return {
     id: 'item-1',

--- a/frontend/src/components/library/LibraryItemRow.tsx
+++ b/frontend/src/components/library/LibraryItemRow.tsx
@@ -14,6 +14,8 @@ import {
 } from 'lucide-react'
 import { QualityBadge } from './QualityBadge'
 import { VerificationSubmitModal } from './VerificationSubmitModal'
+import { AuthorChip } from '../shared/AuthorChip'
+import { useAuth } from '../../hooks/useAuth'
 import { relativeTime } from '../../utils/time'
 import type { LibraryItem, LibraryFolder } from '../../types/library'
 
@@ -34,6 +36,7 @@ interface Props {
 }
 
 export function LibraryItemRow({ item, scope, onPin, onFavorite, onClone, onShare, onRemove, onOpen, onEdit, onMoveToFolder, folders, qualityTier, qualityScore }: Props) {
+  const { user } = useAuth()
   const [hovered, setHovered] = useState(false)
   const [menuOpen, setMenuOpen] = useState(false)
   const [folderSubmenuOpen, setFolderSubmenuOpen] = useState(false)
@@ -121,7 +124,12 @@ export function LibraryItemRow({ item, scope, onPin, onFavorite, onClone, onShar
             <Pin size={12} style={{ color: 'var(--library-highlight, #eab308)', flexShrink: 0 }} />
           )}
         </div>
-        <div style={{ fontSize: 12, color: '#70757a', marginTop: 4 }}>{kindLabel}</div>
+        <div style={{ fontSize: 12, color: '#70757a', marginTop: 4, display: 'flex', alignItems: 'center', gap: 8 }}>
+          <span>{kindLabel}</span>
+          {item.created_by && item.created_by.user_id !== user?.user_id && (
+            <AuthorChip author={item.created_by} />
+          )}
+        </div>
         {item.tags.length > 0 && (
           <div style={{ marginTop: 4, display: 'flex', gap: 4 }}>
             {item.tags.slice(0, 3).map((tag) => (

--- a/frontend/src/components/shared/AuthorChip.tsx
+++ b/frontend/src/components/shared/AuthorChip.tsx
@@ -1,0 +1,84 @@
+import { User as UserIcon, Mail } from 'lucide-react'
+import type { AuthorRef } from '../../types/library'
+
+interface Props {
+  author: AuthorRef | null | undefined
+  /** Visual size: 'sm' for table rows / cards, 'md' for header areas. */
+  size?: 'sm' | 'md'
+  /** Optional override label prefix (e.g. "Author"). Default is no prefix. */
+  label?: string
+  className?: string
+}
+
+/**
+ * Small "by Jane Doe ✉" chip for surfacing the original author of a workflow,
+ * extraction, or library item. Renders nothing when no author is provided so
+ * callers can drop it in unconditionally.
+ *
+ * The chip is interactive: clicking opens the author's email so the viewer can
+ * reach out for refinement help. Stops propagation so it works inside cards
+ * that have their own click handler.
+ */
+export function AuthorChip({ author, size = 'sm', label, className }: Props) {
+  if (!author) return null
+
+  const display = author.name || author.email || author.user_id
+  const fontSize = size === 'sm' ? 11 : 12
+  const iconSize = size === 'sm' ? 10 : 12
+
+  const subject = encodeURIComponent('Question about your workflow')
+  const mailto = author.email ? `mailto:${author.email}?subject=${subject}` : null
+
+  const content = (
+    <>
+      <UserIcon size={iconSize} style={{ flexShrink: 0 }} />
+      {label && <span style={{ opacity: 0.7 }}>{label}</span>}
+      <span style={{ fontWeight: 500 }}>{display}</span>
+      {mailto && <Mail size={iconSize} style={{ flexShrink: 0, opacity: 0.6 }} />}
+    </>
+  )
+
+  const baseStyle: React.CSSProperties = {
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: 4,
+    fontSize,
+    color: '#5f6368',
+    background: 'rgba(0,0,0,0.04)',
+    padding: '2px 8px',
+    borderRadius: 999,
+    lineHeight: 1.4,
+    whiteSpace: 'nowrap',
+    maxWidth: '100%',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+  }
+
+  if (mailto) {
+    return (
+      <a
+        href={mailto}
+        onClick={(e) => e.stopPropagation()}
+        title={`Email ${display} about this workflow`}
+        className={className}
+        style={{
+          ...baseStyle,
+          textDecoration: 'none',
+          cursor: 'pointer',
+        }}
+      >
+        {content}
+      </a>
+    )
+  }
+
+  return (
+    <span
+      title={`Created by ${display}`}
+      className={className}
+      style={baseStyle}
+    >
+      {content}
+    </span>
+  )
+}

--- a/frontend/src/pages/Workflows.tsx
+++ b/frontend/src/pages/Workflows.tsx
@@ -4,6 +4,8 @@ import { Plus, Copy, Trash2, Search, ArrowUpDown } from 'lucide-react'
 import { PageLayout } from '../components/layout/PageLayout'
 import { useWorkflows } from '../hooks/useWorkflows'
 import { useToast } from '../contexts/ToastContext'
+import { useAuth } from '../hooks/useAuth'
+import { AuthorChip } from '../components/shared/AuthorChip'
 
 type SortKey = 'name' | 'runs' | 'steps'
 
@@ -11,6 +13,7 @@ export default function Workflows() {
   const navigate = useNavigate()
   const { workflows, loading, create, remove, duplicate, importFromFile } = useWorkflows()
   const { toast } = useToast()
+  const { user } = useAuth()
   const [newName, setNewName] = useState('')
   const [creating, setCreating] = useState(false)
   const [importing, setImporting] = useState(false)
@@ -167,8 +170,13 @@ export default function Workflows() {
                   {wf.description && (
                     <div className="text-sm text-gray-500 truncate">{wf.description}</div>
                   )}
-                  <div className="text-xs text-gray-400 mt-1">
-                    {wf.steps?.length || 0} steps &middot; {wf.num_executions} runs
+                  <div className="flex items-center gap-2 mt-1">
+                    <span className="text-xs text-gray-400">
+                      {wf.steps?.length || 0} steps &middot; {wf.num_executions} runs
+                    </span>
+                    {wf.created_by && wf.created_by.user_id !== user?.user_id && (
+                      <AuthorChip author={wf.created_by} />
+                    )}
                   </div>
                 </div>
                 <div className="flex items-center gap-1 ml-4 shrink-0">

--- a/frontend/src/types/library.ts
+++ b/frontend/src/types/library.ts
@@ -1,6 +1,12 @@
 export type LibraryScope = 'personal' | 'team' | 'verified'
 export type LibraryItemKind = 'workflow' | 'search_set' | 'knowledge_base'
 
+export interface AuthorRef {
+  user_id: string
+  name: string | null
+  email: string | null
+}
+
 export interface Library {
   id: string
   scope: LibraryScope
@@ -33,6 +39,7 @@ export interface LibraryItem {
   quality_tier?: string | null
   quality_score?: number | null
   last_validated_at?: string | null
+  created_by?: AuthorRef | null
 }
 
 export interface LibraryFolder {
@@ -118,6 +125,7 @@ export interface VerifiedCatalogItem {
   sources_ready?: number
   kb_status?: string
   source_uuid?: string
+  created_by?: AuthorRef | null
 }
 
 export interface VerifiedCollection {

--- a/frontend/src/types/workflow.ts
+++ b/frontend/src/types/workflow.ts
@@ -42,6 +42,12 @@ export interface WorkflowStep {
   tasks: WorkflowTask[];
 }
 
+export interface AuthorRef {
+  user_id: string;
+  name: string | null;
+  email: string | null;
+}
+
 export interface Workflow {
   id: string;
   uuid: string;
@@ -52,6 +58,7 @@ export interface Workflow {
   steps: WorkflowStep[];
   input_config?: { trigger_type?: string };
   can_manage?: boolean;
+  created_by?: AuthorRef | null;
 }
 
 export interface WorkflowStatus {


### PR DESCRIPTION
## Summary
- Surfaces the original author of a workflow (name + ✉ mailto) on cards in **Workflows**, **Library**, and **Explore** so reviewers can identify whose workflow it is and reach out for refinement.
- Author chip is hidden when the author is the current user (avoids "by myself" noise on personal workflows). Always shown on Explore catalog cards / detail modal where global/verified content is by definition someone else's.

## What's in it

**Backend**
- New `AuthorRef` schema (`backend/app/schemas/user.py`) and batch resolver in `backend/app/services/user_lookup.py` (`resolve_authors` / `resolve_author`).
- `created_by` threaded through `WorkflowResponse`, `LibraryItemResponse`, and the verified-catalog list endpoint.
- Canonical author = `Workflow.created_by_user_id`, with `user_id` as fallback for older rows that pre-date that field.
- List endpoints batch User lookups to avoid N+1 (single Mongo query per page).

**Frontend**
- New reusable `AuthorChip` component (`frontend/src/components/shared/AuthorChip.tsx`). When the author has an email, the chip becomes a `mailto:` link with a "Question about your workflow" subject line; click events `stopPropagation` so the chip works inside clickable cards.
- Wired into `pages/Workflows.tsx`, `components/library/LibraryItemRow.tsx`, and `components/library/ExploreTab.tsx` (both catalog grid card and detail modal stats row).

## Test plan
- [ ] Frontend `npm run typecheck` passes (verified locally)
- [ ] `make backend-static` (ruff) passes (verified locally)
- [ ] Backend unit tests for changed modules pass: `pytest tests/test_workflow_service.py tests/test_library_service.py tests/test_verification_service.py tests/test_workflow_authz.py` (verified locally — 152 passed, 4 skipped)
- [ ] Frontend `vitest` suite passes (verified locally — 135 passed)
- [ ] Manual smoke: navigate to **Workflows** → confirm author chip appears on team-shared workflows, hidden on personal
- [ ] Manual smoke: open team **Library** → confirm chip on rows authored by someone else
- [ ] Manual smoke: open **Explore** → confirm chip on catalog cards and in detail modal; clicking the ✉ icon opens the author's email

🤖 Generated with [Claude Code](https://claude.com/claude-code)