### PR TITLE
Allow LLM workflow tasks to combine multiple input sources

### DIFF
--- a/backend/app/services/workflow_engine.py
+++ b/backend/app/services/workflow_engine.py
@@ -114,6 +114,130 @@ def _stringify_value(value):
 
 
 # ---------------------------------------------------------------------------
+# Input source resolution (shared by Prompt / Extraction / Format / etc.)
+# ---------------------------------------------------------------------------
+
+INPUT_SOURCE_LABELS = {
+    "step_input": "Previous Step Output",
+    "select_document": "Selected Document",
+    "workflow_documents": "Workflow Documents",
+}
+
+
+def _resolve_input_sources(data: dict, prev_step_name: str | None = None) -> list[str]:
+    """Return the ordered, deduped list of input sources for a node.
+
+    Prefers the new `input_sources` list if present; otherwise falls back to
+    the legacy single `input_source` (default `step_input`). When the previous
+    step is the Document trigger, `step_input` is swapped for
+    `workflow_documents` because the trigger emits doc UUIDs, not text.
+    """
+    raw = data.get("input_sources")
+    if isinstance(raw, list) and raw:
+        sources = [s for s in raw if s in INPUT_SOURCE_LABELS]
+    else:
+        legacy = data.get("input_source", "step_input")
+        sources = [legacy] if legacy in INPUT_SOURCE_LABELS else ["step_input"]
+
+    if prev_step_name == "Document":
+        sources = ["workflow_documents" if s == "step_input" else s for s in sources]
+
+    seen: set[str] = set()
+    deduped: list[str] = []
+    for s in sources:
+        if s not in seen:
+            seen.add(s)
+            deduped.append(s)
+    return deduped or ["step_input"]
+
+
+def _stringify_context(value) -> str:
+    if value is None or value == "":
+        return ""
+    if isinstance(value, str):
+        return value
+    try:
+        return json.dumps(value, indent=2, default=str)
+    except (TypeError, ValueError):
+        return str(value)
+
+
+def _join_doc_texts(doc_texts: list[str]) -> str:
+    if not doc_texts:
+        return ""
+    if len(doc_texts) == 1:
+        return doc_texts[0]
+    return "\n\n".join(f"=== Document {i} ===\n{dt}" for i, dt in enumerate(doc_texts, 1))
+
+
+def _build_combined_context(data: dict, inputs: dict, sources: list[str]):
+    """Build the data payload to feed an LLM node.
+
+    For a single source, returns the raw payload (str / dict / list) so the
+    downstream prompt template formats it the same as before. For multiple
+    sources, returns a labeled multi-section string. Empty sources are
+    skipped; if all are empty, returns "".
+    """
+    sections: list[tuple[str, str]] = []
+    raw_single = None
+    for src in sources:
+        if src == "step_input":
+            payload = inputs.get("output")
+            text = _stringify_context(payload)
+            if text:
+                sections.append((INPUT_SOURCE_LABELS[src], text))
+                raw_single = payload
+        elif src == "select_document":
+            doc = data.get("selected_doc_text") or ""
+            if doc:
+                sections.append((INPUT_SOURCE_LABELS[src], doc))
+                raw_single = doc
+        elif src == "workflow_documents":
+            joined = _join_doc_texts(data.get("doc_texts") or [])
+            if joined:
+                sections.append((INPUT_SOURCE_LABELS[src], joined))
+                raw_single = joined
+
+    if not sections:
+        return ""
+    if len(sections) == 1:
+        return raw_single
+    return "\n\n".join(f"=== {label} ===\n{content}" for label, content in sections)
+
+
+def _build_extraction_texts(data: dict, inputs: dict, sources: list[str]) -> list[str]:
+    """Build a list of texts for ExtractionEngine, one entry per source/document.
+
+    Each non-empty source contributes one entry, except `workflow_documents`
+    which expands to one entry per loaded document (preserving existing
+    multi-doc extraction behavior).
+    """
+    texts: list[str] = []
+    for src in sources:
+        if src == "step_input":
+            payload = inputs.get("output")
+            if isinstance(payload, dict):
+                # Defensive: if a Prompt-style dict ever lands here, prefer
+                # its "answer" field; otherwise fall back to JSON.
+                text = payload.get("answer") or _stringify_context(payload)
+            elif isinstance(payload, list):
+                text = "\n".join(str(x) for x in payload if x is not None)
+            else:
+                text = _stringify_context(payload)
+            if text:
+                texts.append(text)
+        elif src == "select_document":
+            doc = data.get("selected_doc_text") or ""
+            if doc:
+                texts.append(doc)
+        elif src == "workflow_documents":
+            for dt in data.get("doc_texts") or []:
+                if dt:
+                    texts.append(dt)
+    return texts
+
+
+# ---------------------------------------------------------------------------
 # LLM helper functions (sync, for nodes)
 # ---------------------------------------------------------------------------
 
@@ -121,11 +245,27 @@ def llm_chat_model(model: str, prompt: str, data=None, progress_callback=None,
                    include_next_step: bool = True, system_config_doc: dict | None = None,
                    usage_acc: UsageAccumulator | None = None):
     """Run a chat prompt via LLM. Sync context."""
-    full_text = json.dumps(data) if data is not None else ""
+    if data is None or data == "":
+        data_block = "(No data provided.)"
+    elif isinstance(data, str):
+        data_block = data
+    else:
+        try:
+            data_block = json.dumps(data, indent=2, default=str)
+        except (TypeError, ValueError):
+            data_block = str(data)
+
     output_prompt = (
-        f"Follow the instruction and output your answer as a nicely formatted markdown "
-        f"to display in a web interface chat bot. Only show the markdown output and add "
-        f"no text before it.\n\nInstruction: {prompt}\n\n {full_text}"
+        "You are completing one step of a multi-step workflow. Answer the "
+        "INSTRUCTION below using ONLY the CONTEXT block, which is the output "
+        "of the previous step. Do not draw on outside knowledge or invent "
+        "details that are not present in the CONTEXT. If the CONTEXT does not "
+        "contain what the instruction needs, say so explicitly rather than "
+        "guessing.\n\n"
+        "Format your answer as clean markdown for a web chat UI. Output only "
+        "the markdown — no preamble, no code fences around the whole reply.\n\n"
+        f"INSTRUCTION:\n{prompt}\n\n"
+        f"CONTEXT:\n{data_block}"
     )
     chat_agent = create_chat_agent(model, system_config_doc=system_config_doc)
     result = chat_agent.run_sync(output_prompt)
@@ -302,37 +442,24 @@ class ExtractionNode(Node):
                 keys = [s.strip() for s in raw.split(",") if s.strip()]
 
         prev_step_name = inputs.get("step_name")
-        doc_texts = None
-        full_text = None
 
         task_label = self.data.get("name")
         self.report_progress(f"Running {task_label}" if task_label else "Extraction running")
 
-        input_source = self.data.get("input_source", "step_input")
+        sources = _resolve_input_sources(self.data, prev_step_name)
+        texts = _build_extraction_texts(self.data, inputs, sources)
 
-        if input_source == "select_document" and self.data.get("selected_doc_text"):
-            full_text = self.data["selected_doc_text"]
-        elif input_source == "workflow_documents" or prev_step_name == "Document":
-            doc_texts = self.data.get("doc_texts")
-        elif prev_step_name == "Prompt":
-            step_input = inputs.get("output")
-            if isinstance(step_input, dict):
-                full_text = step_input.get("answer", str(step_input))
-            elif isinstance(step_input, list):
-                full_text = "\n".join(str(x) for x in step_input)
-            else:
-                full_text = str(step_input) if step_input else ""
-        else:
-            step_input = inputs.get("output")
-            if isinstance(step_input, str):
-                full_text = step_input
-            elif step_input:
-                full_text = json.dumps(step_input)
+        # Use `doc_texts` whenever the user picked a doc-list source or has
+        # more than one text; otherwise pass a single string via `full_text`.
+        # Functionally equivalent in the engine, but preserves call-shape
+        # expectations from older callers.
+        kwargs: dict = {"system_config_doc": self._sys_cfg, "usage_acc": self._usage_acc}
+        if "workflow_documents" in sources or len(texts) > 1:
+            kwargs["doc_texts"] = texts
+        elif texts:
+            kwargs["full_text"] = texts[0]
 
-        extraction_response = data_extraction_model(
-            self.model, keys, doc_texts=doc_texts, full_text=full_text,
-            system_config_doc=self._sys_cfg, usage_acc=self._usage_acc,
-        )
+        extraction_response = data_extraction_model(self.model, keys, **kwargs)
 
         raw_output = extraction_response.get("raw") if isinstance(extraction_response, dict) else extraction_response
         formatted_output = extraction_response.get("formatted") if isinstance(extraction_response, dict) else extraction_response
@@ -365,35 +492,14 @@ class PromptNode(Node):
         prev_step_name = inputs.get("step_name")
         self.report_progress(f"Prompt: {prompt}")
 
-        input_source = self.data.get("input_source", "step_input")
+        sources = _resolve_input_sources(self.data, prev_step_name)
+        context = _build_combined_context(self.data, inputs, sources)
 
-        if input_source == "select_document" and self.data.get("selected_doc_text"):
-            chat_response = llm_chat_model(
-                model=self.model, prompt=prompt, data=self.data["selected_doc_text"],
-                include_next_step=False, system_config_doc=self._sys_cfg,
-                usage_acc=self._usage_acc,
-            )
-        elif input_source == "workflow_documents" or prev_step_name == "Document":
-            doc_texts = self.data.get("doc_texts", [])
-            if len(doc_texts) > 1:
-                sections = []
-                for i, dt in enumerate(doc_texts, 1):
-                    sections.append(f"=== Document {i} ===\n{dt}")
-                full_text = "\n\n".join(sections)
-            else:
-                full_text = doc_texts[0] if doc_texts else ""
-            chat_response = llm_chat_model(
-                model=self.model, prompt=prompt, data=full_text,
-                include_next_step=False, system_config_doc=self._sys_cfg,
-                usage_acc=self._usage_acc,
-            )
-        else:
-            data = inputs.get("output")
-            chat_response = llm_chat_model(
-                model=self.model, prompt=prompt, data=data,
-                include_next_step=False, system_config_doc=self._sys_cfg,
-                usage_acc=self._usage_acc,
-            )
+        chat_response = llm_chat_model(
+            model=self.model, prompt=prompt, data=context,
+            include_next_step=False, system_config_doc=self._sys_cfg,
+            usage_acc=self._usage_acc,
+        )
 
         return {"output": chat_response, "input": prompt, "step_name": self.name}
 
@@ -406,27 +512,11 @@ class FormatNode(Node):
 
     def process(self, inputs):
         formatting_prompt = self.data.get("format_template") or self.data.get("prompt", "")
-        data = inputs.get("output")
         prev_step_name = inputs.get("step_name")
         self.report_progress(f"Formatter: {formatting_prompt}")
 
-        input_source = self.data.get("input_source", "step_input")
-
-        if input_source == "select_document" and self.data.get("selected_doc_text"):
-            text = self.data["selected_doc_text"]
-        elif input_source == "workflow_documents" or prev_step_name == "Document":
-            doc_texts = self.data.get("doc_texts", [])
-            if len(doc_texts) > 1:
-                sections = []
-                for i, dt in enumerate(doc_texts, 1):
-                    sections.append(f"=== Document {i} ===\n{dt}")
-                text = "\n\n".join(sections)
-            else:
-                text = doc_texts[0] if doc_texts else ""
-        elif prev_step_name == "Prompt":
-            text = data.get("formatted_answer", "") if isinstance(data, dict) else data
-        else:
-            text = data
+        sources = _resolve_input_sources(self.data, prev_step_name)
+        text = _build_combined_context(self.data, inputs, sources)
 
         _, output = format_model(self.model, formatting_prompt, text, system_config_doc=self._sys_cfg,
                                  usage_acc=self._usage_acc)
@@ -616,19 +706,9 @@ class ResearchNode(Node):
     def process(self, inputs):
         question = self.data.get("question", "")
         prev_step_name = inputs.get("step_name")
-        input_source = self.data.get("input_source", "step_input")
 
-        if input_source == "select_document" and self.data.get("selected_doc_text"):
-            input_data = self.data["selected_doc_text"]
-        elif input_source == "workflow_documents" or prev_step_name == "Document":
-            doc_texts = self.data.get("doc_texts", [])
-            if len(doc_texts) > 1:
-                sections = [f"=== Document {i} ===\n{dt}" for i, dt in enumerate(doc_texts, 1)]
-                input_data = "\n\n".join(sections)
-            else:
-                input_data = doc_texts[0] if doc_texts else ""
-        else:
-            input_data = inputs.get("output")
+        sources = _resolve_input_sources(self.data, prev_step_name)
+        input_data = _build_combined_context(self.data, inputs, sources)
 
         self.report_progress("Pass 1: Analyzing data")
 
@@ -797,19 +877,9 @@ class FormFillerNode(Node):
     def process(self, inputs):
         template = self.data.get("template", "")
         prev_step_name = inputs.get("step_name")
-        input_source = self.data.get("input_source", "step_input")
 
-        if input_source == "select_document" and self.data.get("selected_doc_text"):
-            input_data = self.data["selected_doc_text"]
-        elif input_source == "workflow_documents" or prev_step_name == "Document":
-            doc_texts = self.data.get("doc_texts", [])
-            if len(doc_texts) > 1:
-                sections = [f"=== Document {i} ===\n{dt}" for i, dt in enumerate(doc_texts, 1)]
-                input_data = "\n\n".join(sections)
-            else:
-                input_data = doc_texts[0] if doc_texts else ""
-        else:
-            input_data = inputs.get("output")
+        sources = _resolve_input_sources(self.data, prev_step_name)
+        input_data = _build_combined_context(self.data, inputs, sources)
 
         self.report_progress("Filling template")
 

--- a/backend/app/tasks/workflow_tasks.py
+++ b/backend/app/tasks/workflow_tasks.py
@@ -12,6 +12,18 @@ from app.tasks import TRANSIENT_EXCEPTIONS
 logger = logging.getLogger(__name__)
 
 
+def _wants_selected_document(task_data: dict) -> bool:
+    """Whether the task expects `selected_doc_text` to be pre-loaded.
+
+    True if `select_document` appears in the new `input_sources` list, or
+    in the legacy single `input_source` field.
+    """
+    sources = task_data.get("input_sources")
+    if isinstance(sources, list) and "select_document" in sources:
+        return True
+    return task_data.get("input_source") == "select_document"
+
+
 def _notify_approval_reviewers_sync(
     db, assigned_user_ids: list[str], workflow_name: str,
     step_name: str, instructions: str, approval_uuid: str,
@@ -161,8 +173,8 @@ def execute_workflow_task(self, workflow_result_id, workflow_id, trigger_step_da
                         )
                     task_data["doc_texts"] = doc_texts
 
-                # Pre-load specific document text when input_source is "select_document"
-                if task_data.get("input_source") == "select_document" and task_data.get("selected_document_uuid"):
+                # Pre-load specific document text when select_document is selected
+                if _wants_selected_document(task_data) and task_data.get("selected_document_uuid"):
                     sel_doc = db.smart_document.find_one({"uuid": task_data["selected_document_uuid"]})
                     if sel_doc and sel_doc.get("raw_text"):
                         task_data["selected_doc_text"] = sel_doc["raw_text"]
@@ -399,8 +411,8 @@ def execute_task_step_test(self, task_name, task_data, doc_uuids):
             doc_texts.append(doc["raw_text"])
     task_data["doc_texts"] = doc_texts
 
-    # Pre-load specific document text when input_source is "select_document"
-    if task_data.get("input_source") == "select_document" and task_data.get("selected_document_uuid"):
+    # Pre-load specific document text when select_document is selected
+    if _wants_selected_document(task_data) and task_data.get("selected_document_uuid"):
         sel_doc = db.smart_document.find_one({"uuid": task_data["selected_document_uuid"]})
         if sel_doc and sel_doc.get("raw_text"):
             task_data["selected_doc_text"] = sel_doc["raw_text"]
@@ -531,7 +543,7 @@ def resume_workflow_after_approval(self, approval_uuid):
                             len(doc_uuids),
                         )
                     task_data["doc_texts"] = doc_texts
-                if task_data.get("input_source") == "select_document" and task_data.get("selected_document_uuid"):
+                if _wants_selected_document(task_data) and task_data.get("selected_document_uuid"):
                     sel_doc = db.smart_document.find_one({"uuid": task_data["selected_document_uuid"]})
                     if sel_doc and sel_doc.get("raw_text"):
                         task_data["selected_doc_text"] = sel_doc["raw_text"]

--- a/backend/tests/test_workflow_nodes.py
+++ b/backend/tests/test_workflow_nodes.py
@@ -121,6 +121,20 @@ class TestExtractionNode:
         node.process({"output": [], "step_name": "Document"})
         assert any("Extraction" in str(p) for p in progress)
 
+    @patch("app.services.workflow_engine.data_extraction_model")
+    def test_extraction_multi_source_step_and_documents(self, mock_extract):
+        """Combining step_input + workflow_documents extracts from each text."""
+        mock_extract.return_value = {"raw": [], "formatted": ""}
+        node = ExtractionNode({
+            "model": "gpt-4o",
+            "keys": ["X"],
+            "input_sources": ["step_input", "workflow_documents"],
+            "doc_texts": ["doc one", "doc two"],
+        })
+        node.process({"output": "step text", "step_name": "APINode"})
+        kwargs = mock_extract.call_args.kwargs
+        assert kwargs.get("doc_texts") == ["step text", "doc one", "doc two"]
+
 
 # ---------------------------------------------------------------------------
 # PromptNode
@@ -188,6 +202,69 @@ class TestPromptNode:
         args, kwargs = mock_llm.call_args
         assert kwargs.get("prompt") == "Enter prompt" or args[1] == "Enter prompt"
 
+    @patch("app.services.workflow_engine.llm_chat_model")
+    def test_prompt_multi_source_step_and_document(self, mock_llm):
+        """input_sources combining step output + a selected document yields a labeled context."""
+        mock_llm.return_value = "Response"
+        node = PromptNode({
+            "prompt": "Pick the best title",
+            "model": "gpt-4o",
+            "input_sources": ["step_input", "select_document"],
+            "selected_doc_text": "The grant proposal text.",
+        })
+        node.process({"output": {"titles": ["Title 1", "Title 2"]}, "step_name": "APINode"})
+        data = mock_llm.call_args.kwargs.get("data", "")
+        assert "Previous Step Output" in data
+        assert "Selected Document" in data
+        assert "Title 1" in data
+        assert "grant proposal text" in data
+
+    @patch("app.services.workflow_engine.llm_chat_model")
+    def test_prompt_multi_source_skips_empty(self, mock_llm):
+        """An empty source is dropped from the combined context."""
+        mock_llm.return_value = "Response"
+        node = PromptNode({
+            "prompt": "Use what's there",
+            "model": "gpt-4o",
+            "input_sources": ["step_input", "select_document"],
+            "selected_doc_text": "",  # empty
+        })
+        node.process({"output": "step output", "step_name": "Prev"})
+        data = mock_llm.call_args.kwargs.get("data", "")
+        # Single non-empty source -> raw payload, no section headers
+        assert data == "step output"
+
+    @patch("app.services.workflow_engine.llm_chat_model")
+    def test_prompt_input_sources_takes_precedence_over_legacy(self, mock_llm):
+        """When both `input_sources` and `input_source` are set, the new field wins."""
+        mock_llm.return_value = "Response"
+        node = PromptNode({
+            "prompt": "Test",
+            "model": "gpt-4o",
+            "input_source": "step_input",  # legacy
+            "input_sources": ["select_document"],  # new wins
+            "selected_doc_text": "doc body",
+        })
+        node.process({"output": "step output", "step_name": "Prev"})
+        data = mock_llm.call_args.kwargs.get("data", "")
+        assert data == "doc body"
+
+    @patch("app.services.workflow_engine.llm_chat_model")
+    def test_prompt_step_input_after_document_trigger_swaps_to_workflow_docs(self, mock_llm):
+        """When the previous step is the Document trigger, step_input is replaced
+        with workflow_documents (the trigger emits UUIDs, not text)."""
+        mock_llm.return_value = "Response"
+        node = PromptNode({
+            "prompt": "Summarize",
+            "model": "gpt-4o",
+            "input_sources": ["step_input"],
+            "doc_texts": ["doc body"],
+        })
+        node.process({"output": ["uuid-1"], "step_name": "Document"})
+        data = mock_llm.call_args.kwargs.get("data", "")
+        assert "doc body" in data
+        assert "uuid-1" not in data
+
 
 # ---------------------------------------------------------------------------
 # FormatNode
@@ -233,7 +310,9 @@ class TestFormatNode:
     def test_format_from_prompt_step(self, mock_format):
         mock_format.return_value = ("p", "formatted")
         node = FormatNode({"prompt": "Format", "model": "gpt-4o"})
-        result = node.process({"output": {"formatted_answer": "nice text"}, "step_name": "Prompt"})
+        # PromptNode now always returns a string output, so FormatNode
+        # receives that string directly.
+        result = node.process({"output": "nice text", "step_name": "Prompt"})
         args = mock_format.call_args[0]
         assert args[2] == "nice text"
 
@@ -244,6 +323,23 @@ class TestFormatNode:
         result = node.process({"output": "plain text", "step_name": "Prompt"})
         args = mock_format.call_args[0]
         assert args[2] == "plain text"
+
+    @patch("app.services.workflow_engine.format_model")
+    def test_format_multi_source(self, mock_format):
+        """input_sources combining step + selected document yields a labeled blob."""
+        mock_format.return_value = ("p", "out")
+        node = FormatNode({
+            "prompt": "Format",
+            "model": "gpt-4o",
+            "input_sources": ["step_input", "select_document"],
+            "selected_doc_text": "doc body",
+        })
+        node.process({"output": "step output", "step_name": "Prev"})
+        text = mock_format.call_args[0][2]
+        assert "Previous Step Output" in text
+        assert "Selected Document" in text
+        assert "step output" in text
+        assert "doc body" in text
 
 
 # ---------------------------------------------------------------------------
@@ -495,6 +591,24 @@ class TestResearchNode:
         })
         for call in mock_llm.call_args_list:
             assert call.kwargs["data"] == "The RFA seeks proposals for AI safety research."
+
+    @patch("app.services.workflow_engine.llm_chat_model")
+    def test_research_multi_source(self, mock_llm):
+        """ResearchNode honors input_sources by passing combined context to both passes."""
+        mock_llm.side_effect = ["findings", "report"]
+        node = ResearchNode({
+            "question": "Q?",
+            "model": "gpt-4o",
+            "input_sources": ["step_input", "workflow_documents"],
+            "doc_texts": ["doc body"],
+        })
+        node.process({"output": "step text", "step_name": "Prev"})
+        for call in mock_llm.call_args_list:
+            data = call.kwargs["data"]
+            assert "Previous Step Output" in data
+            assert "Workflow Documents" in data
+            assert "step text" in data
+            assert "doc body" in data
 
 
 # ---------------------------------------------------------------------------
@@ -834,6 +948,23 @@ class TestFormFillerNode:
             "output": ["d41d8cd98f00b204e9800998ecf8427e"],
         })
         assert mock_llm.call_args.kwargs["data"] == "Project title: AI Safety Initiative."
+
+    @patch("app.services.workflow_engine.llm_chat_model")
+    def test_form_filler_multi_source(self, mock_llm):
+        """FormFillerNode combines step_input and selected document into labeled context."""
+        mock_llm.return_value = "filled"
+        node = FormFillerNode({
+            "template": "{{x}}",
+            "model": "gpt-4o",
+            "input_sources": ["step_input", "select_document"],
+            "selected_doc_text": "doc body",
+        })
+        node.process({"output": "step output", "step_name": "Prev"})
+        data = mock_llm.call_args.kwargs["data"]
+        assert "Previous Step Output" in data
+        assert "Selected Document" in data
+        assert "step output" in data
+        assert "doc body" in data
 
 
 # ---------------------------------------------------------------------------

--- a/frontend/src/components/workspace/WorkflowEditorPanel.tsx
+++ b/frontend/src/components/workspace/WorkflowEditorPanel.tsx
@@ -1763,10 +1763,24 @@ function TaskEditModal({ task, selectedDocUuids, workflow, workflowId, onClose, 
   const [saving, setSaving] = useState(false)
   const [subTab, setSubTab] = useState<TaskSubTab>('design')
 
-  // Input source config
-  const [inputSource, setInputSource] = useState<TaskInputSource>(
-    (task.data.input_source as TaskInputSource) || 'step_input'
-  )
+  // Input source config — multi-select. Migrate legacy single `input_source`
+  // when the new `input_sources` list is absent.
+  const [inputSources, setInputSources] = useState<TaskInputSource[]>(() => {
+    const list = task.data.input_sources as TaskInputSource[] | undefined
+    if (Array.isArray(list) && list.length > 0) return list
+    const legacy = (task.data.input_source as TaskInputSource) || 'step_input'
+    return [legacy]
+  })
+  const inputSource: TaskInputSource = inputSources[0] || 'step_input'
+  const toggleInputSource = (src: TaskInputSource) => {
+    setInputSources(prev => {
+      if (prev.includes(src)) {
+        const next = prev.filter(s => s !== src)
+        return next.length > 0 ? next : [src]  // never empty
+      }
+      return [...prev, src]
+    })
+  }
   const [selectedDocUuid, setSelectedDocUuid] = useState<string>(
     (task.data.selected_document_uuid as string) || ''
   )
@@ -1845,8 +1859,10 @@ function TaskEditModal({ task, selectedDocUuids, workflow, workflowId, onClose, 
   // Fixed doc search debounce — empty query loads recent docs so the field
   // doubles as a browsable picker.
   const fixedSearchTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const wantsWorkflowDocs = inputSources.includes('workflow_documents')
+  const wantsSelectDocument = inputSources.includes('select_document')
   useEffect(() => {
-    if (inputSource !== 'workflow_documents') return
+    if (!wantsWorkflowDocs) return
     if (fixedSearchTimeoutRef.current) clearTimeout(fixedSearchTimeoutRef.current)
     const query = fixedDocSearch.trim()
     fixedSearchTimeoutRef.current = setTimeout(async () => {
@@ -1863,7 +1879,7 @@ function TaskEditModal({ task, selectedDocUuids, workflow, workflowId, onClose, 
       }
     }, query ? 250 : 0)
     return () => { if (fixedSearchTimeoutRef.current) clearTimeout(fixedSearchTimeoutRef.current) }
-  }, [fixedDocSearch, fixedDocs, inputSource])
+  }, [fixedDocSearch, fixedDocs, wantsWorkflowDocs])
 
   // Output post-process
   const [postProcessEnabled, setPostProcessEnabled] = useState(
@@ -1914,7 +1930,7 @@ function TaskEditModal({ task, selectedDocUuids, workflow, workflowId, onClose, 
   // Empty query loads recent docs so the field doubles as a browsable picker.
   const searchTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   useEffect(() => {
-    if (inputSource !== 'select_document') return
+    if (!wantsSelectDocument) return
     if (searchTimeoutRef.current) clearTimeout(searchTimeoutRef.current)
     const query = docSearchQuery.trim()
     searchTimeoutRef.current = setTimeout(async () => {
@@ -1927,7 +1943,7 @@ function TaskEditModal({ task, selectedDocUuids, workflow, workflowId, onClose, 
       }
     }, query ? 250 : 0)
     return () => { if (searchTimeoutRef.current) clearTimeout(searchTimeoutRef.current) }
-  }, [docSearchQuery, inputSource])
+  }, [docSearchQuery, wantsSelectDocument])
 
   // Cleanup test intervals on unmount
   useEffect(() => {
@@ -1942,8 +1958,11 @@ function TaskEditModal({ task, selectedDocUuids, workflow, workflowId, onClose, 
     try {
       const finalData = {
         ...taskData,
-        input_source: inputSource,
-        ...(inputSource === 'select_document' ? { selected_document_uuid: selectedDocUuid } : {}),
+        input_sources: inputSources,
+        // Keep `input_source` for backward compatibility — set to the first
+        // selected source so older code paths still see something sensible.
+        input_source: inputSources[0] || 'step_input',
+        ...(inputSources.includes('select_document') ? { selected_document_uuid: selectedDocUuid } : {}),
         ...(postProcessEnabled ? { post_process_prompt: postProcessPrompt } : { post_process_prompt: undefined }),
       }
       onSave(task.id, finalData)
@@ -2935,21 +2954,23 @@ function TaskEditModal({ task, selectedDocUuids, workflow, workflowId, onClose, 
         {/* ===== INPUT SUB-TAB ===== */}
         {subTab === 'input' && (
           <div>
-            <div style={{ fontSize: 13, fontWeight: 600, color: '#374151', marginBottom: 12 }}>
-              Data Source
+            <div style={{ fontSize: 13, fontWeight: 600, color: '#374151', marginBottom: 4 }}>
+              Data Sources
+            </div>
+            <div style={{ fontSize: 12, color: '#6b7280', marginBottom: 12 }}>
+              Pick one or more. When multiple are selected, the LLM sees each in a labeled section.
             </div>
             <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
               {/* Step Input */}
               <label style={{
                 display: 'flex', alignItems: 'flex-start', gap: 10, padding: 12,
-                border: inputSource === 'step_input' ? '2px solid var(--highlight-color, #eab308)' : '1px solid #e5e7eb',
+                border: inputSources.includes('step_input') ? '2px solid var(--highlight-color, #eab308)' : '1px solid #e5e7eb',
                 borderRadius: 8, cursor: 'pointer', backgroundColor: '#fff',
               }}>
                 <input
-                  type="radio"
-                  name="input_source"
-                  checked={inputSource === 'step_input'}
-                  onChange={() => setInputSource('step_input')}
+                  type="checkbox"
+                  checked={inputSources.includes('step_input')}
+                  onChange={() => toggleInputSource('step_input')}
                   style={{ marginTop: 2 }}
                 />
                 <div>
@@ -2963,14 +2984,13 @@ function TaskEditModal({ task, selectedDocUuids, workflow, workflowId, onClose, 
               {/* Select a Document */}
               <label style={{
                 display: 'flex', alignItems: 'flex-start', gap: 10, padding: 12,
-                border: inputSource === 'select_document' ? '2px solid var(--highlight-color, #eab308)' : '1px solid #e5e7eb',
+                border: wantsSelectDocument ? '2px solid var(--highlight-color, #eab308)' : '1px solid #e5e7eb',
                 borderRadius: 8, cursor: 'pointer', backgroundColor: '#fff',
               }}>
                 <input
-                  type="radio"
-                  name="input_source"
-                  checked={inputSource === 'select_document'}
-                  onChange={() => setInputSource('select_document')}
+                  type="checkbox"
+                  checked={wantsSelectDocument}
+                  onChange={() => toggleInputSource('select_document')}
                   style={{ marginTop: 2 }}
                 />
                 <div style={{ flex: 1 }}>
@@ -2978,7 +2998,7 @@ function TaskEditModal({ task, selectedDocUuids, workflow, workflowId, onClose, 
                   <div style={{ fontSize: 12, color: '#6b7280', marginTop: 2 }}>
                     Choose a specific document to use as input.
                   </div>
-                  {inputSource === 'select_document' && (
+                  {wantsSelectDocument && (
                     <div style={{ marginTop: 8, position: 'relative' }}>
                       <input
                         type="text"
@@ -3051,14 +3071,13 @@ function TaskEditModal({ task, selectedDocUuids, workflow, workflowId, onClose, 
               {/* Workflow Documents */}
               <label style={{
                 display: 'flex', alignItems: 'flex-start', gap: 10, padding: 12,
-                border: inputSource === 'workflow_documents' ? '2px solid var(--highlight-color, #eab308)' : '1px solid #e5e7eb',
+                border: wantsWorkflowDocs ? '2px solid var(--highlight-color, #eab308)' : '1px solid #e5e7eb',
                 borderRadius: 8, cursor: 'pointer', backgroundColor: '#fff',
               }}>
                 <input
-                  type="radio"
-                  name="input_source"
-                  checked={inputSource === 'workflow_documents'}
-                  onChange={() => setInputSource('workflow_documents')}
+                  type="checkbox"
+                  checked={wantsWorkflowDocs}
+                  onChange={() => toggleInputSource('workflow_documents')}
                   style={{ marginTop: 2 }}
                 />
                 <div style={{ flex: 1 }}>
@@ -3067,7 +3086,7 @@ function TaskEditModal({ task, selectedDocUuids, workflow, workflowId, onClose, 
                     Use the documents selected when the workflow runs, plus any fixed documents.
                   </div>
 
-                  {inputSource === 'workflow_documents' && (
+                  {wantsWorkflowDocs && (
                     <div style={{ marginTop: 10 }} onClick={e => e.stopPropagation()}>
                       {/* Fixed documents list */}
                       {fixedDocs.length > 0 && (


### PR DESCRIPTION
## Summary

- Workflow Prompt / Extraction / Format / Research / FormFiller tasks could only use one of `step_input`, `select_document`, or `workflow_documents` at a time. Workflows that need both an API result *and* a document had no way to pass both to the LLM, so it would either fall back to training data or refuse with "no data was supplied" depending on which prompt phrasing won out.
- Adds an `input_sources` list (multi-select) alongside the legacy single `input_source` field. Each LLM node now resolves the selected sources and feeds the model a labeled `=== Source ===` context blob when more than one is chosen. Single-source paths preserve their existing call shapes (e.g. `ExtractionNode` still uses `full_text=` for one text and `doc_texts=` for many).
- Frontend swaps the radio buttons for checkboxes in the task editor's Input tab and migrates old single-value configs on load. Both `input_sources` and `input_source` are persisted so older clients keep working.
- Also tightens the workflow LLM prompt template — explicit `INSTRUCTION` / `CONTEXT` framing with anti-hallucination wording — so the model stops inventing answers when the provided data doesn't cover the question. This is the part that should immediately help workflows like Nathan Layman's eCFR ticket where the model was ignoring the API step's output and answering from training.

## Origin

User report: an eCFR-titles workflow (API → Prompt → Format) was producing "No eCFR API data was supplied in the prior step" about half the time, and otherwise answering with stale training data instead of the API response. Two compounding root causes: a weak prompt template that left the previous-step JSON unlabeled, and the architectural mutual-exclusion of input sources.

## Test plan

- [x] `make backend-test-integration-t1` (workflow node + engine + tasks tests) — 197 passed locally
- [x] `npx tsc --noEmit` — clean
- [ ] Re-run Nathan's API → Prompt → Format workflow on staging once deployed; confirm consistent use of API context
- [ ] Open the task editor for a Prompt step on an existing workflow; verify the legacy single-source value migrates and the UI shows the corresponding checkbox checked
- [ ] Multi-select Step Input + Select a Document on a Prompt task; verify the test-step run feeds both into the LLM

🤖 Generated with [Claude Code](https://claude.com/claude-code)