### PR TITLE
Notify the team (bell + email) when content is shared

### DIFF
--- a/backend/app/routers/knowledge.py
+++ b/backend/app/routers/knowledge.py
@@ -22,6 +22,7 @@ from app.schemas.knowledge import (
     KBResponse,
     KBSourceResponse,
     KBStatusResponse,
+    ShareKBRequest,
     UpdateKBRequest,
 )
 from app.services import knowledge_service as svc
@@ -250,9 +251,19 @@ async def update_knowledge_base(uuid: str, req: UpdateKBRequest, user: User = De
 
 
 @router.post("/{uuid}/share")
-async def share_knowledge_base(uuid: str, user: User = Depends(get_current_user)):
+async def share_knowledge_base(
+    uuid: str,
+    req: ShareKBRequest | None = None,
+    user: User = Depends(get_current_user),
+):
     user_org_ancestry = await organization_service.get_user_org_ancestry(user)
-    kb = await svc.share_with_team(uuid, user, user_org_ancestry=user_org_ancestry)
+    comment = req.comment if req else None
+    kb = await svc.share_with_team(
+        uuid,
+        user,
+        user_org_ancestry=user_org_ancestry,
+        comment=comment,
+    )
     if not kb:
         raise HTTPException(status_code=404, detail="Knowledge base not found")
     return {"ok": True, "shared_with_team": kb.shared_with_team}

--- a/backend/app/routers/library.py
+++ b/backend/app/routers/library.py
@@ -98,7 +98,7 @@ _SHARE_ERROR_MESSAGES = {
 @router.post("/share", response_model=LibraryItemResponse)
 async def share_to_team(req: ShareToTeamRequest, user: User = Depends(get_current_user)):
     try:
-        item = await svc.share_to_team(req.item_id, user, req.team_id)
+        item = await svc.share_to_team(req.item_id, user, req.team_id, comment=req.comment)
     except svc.ShareError as exc:
         detail = _SHARE_ERROR_MESSAGES.get(exc.code, exc.code)
         raise HTTPException(status_code=exc.status, detail=detail)

--- a/backend/app/schemas/knowledge.py
+++ b/backend/app/schemas/knowledge.py
@@ -21,6 +21,10 @@ class AddDocumentsRequest(BaseModel):
     document_uuids: list[str]
 
 
+class ShareKBRequest(BaseModel):
+    comment: Optional[str] = None
+
+
 class AddUrlsRequest(BaseModel):
     urls: list[str]
     crawl_enabled: bool = False

--- a/backend/app/schemas/library.py
+++ b/backend/app/schemas/library.py
@@ -103,6 +103,7 @@ class CloneRequest(BaseModel):
 class ShareToTeamRequest(BaseModel):
     item_id: str
     team_id: str
+    comment: Optional[str] = None
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/services/email_service.py
+++ b/backend/app/services/email_service.py
@@ -498,6 +498,55 @@ def approval_resolved_email(
 # ---------------------------------------------------------------------------
 
 
+_KIND_LABELS = {
+    "workflow": "workflow",
+    "extraction": "extraction",
+    "search_set": "search set",
+    "knowledge_base": "knowledge base",
+}
+
+
+def team_share_email(
+    sharer_name: str,
+    item_kind: str,
+    item_name: str,
+    team_name: str,
+    comment: str | None,
+    view_url: str,
+) -> tuple[str, str]:
+    """Returns (subject, html_body) when a teammate shares an item with the team."""
+    import html as html_lib
+
+    kind_label = _KIND_LABELS.get(item_kind, item_kind.replace("_", " "))
+    safe_sharer = html_lib.escape(sharer_name)
+    safe_item = html_lib.escape(item_name)
+    safe_team = html_lib.escape(team_name)
+    safe_kind = html_lib.escape(kind_label)
+
+    subject = f'{sharer_name} shared "{item_name}" with {team_name}'
+
+    comment_block = ""
+    if comment:
+        safe_comment = html_lib.escape(comment).replace("\n", "<br/>")
+        comment_block = f"""
+      <div style="margin:16px 0;padding:12px 16px;background:rgba(255,255,255,0.05);border-left:3px solid #f1b300;border-radius:4px;">
+        <p style="margin:0;font-size:14px;color:#d1d5db;"><strong style="color:#fff;">Note from {safe_sharer}:</strong><br/>{safe_comment}</p>
+      </div>"""
+
+    html = f"""<!DOCTYPE html><html><head>{_BASE_STYLE}</head><body>
+    <div class="container"><div class="card">
+      <div class="logo">Vandalizer</div>
+      <h1>New {safe_kind} shared with your team</h1>
+      <p><span class="highlight">{safe_sharer}</span> shared the {safe_kind}
+         <span class="highlight">{safe_item}</span> with
+         <strong style="color:#fff">{safe_team}</strong>.</p>
+      {comment_block}
+      <p style="margin-top:24px"><a class="btn" href="{view_url}">Open in Vandalizer</a></p>
+      <div class="footer">Vandalizer</div>
+    </div></div></body></html>"""
+    return subject, html
+
+
 def team_member_joined_email(
     inviter_name: str, member_name: str, team_name: str, frontend_url: str,
 ) -> tuple[str, str]:

--- a/backend/app/services/knowledge_service.py
+++ b/backend/app/services/knowledge_service.py
@@ -186,8 +186,13 @@ async def share_with_team(
     user: User,
     *,
     user_org_ancestry: list[str] | None = None,
+    comment: str | None = None,
 ) -> KnowledgeBase | None:
-    """Toggle shared_with_team for an authorized knowledge base."""
+    """Toggle shared_with_team for an authorized knowledge base.
+
+    When toggling from unshared → shared, notifies the user's current team
+    (bell + email). Untoggling is silent.
+    """
     kb = await get_knowledge_base(
         uuid,
         user,
@@ -197,9 +202,37 @@ async def share_with_team(
     )
     if not kb:
         return None
+    was_shared = bool(kb.shared_with_team)
     kb.shared_with_team = not kb.shared_with_team
     kb.updated_at = datetime.datetime.now(tz=datetime.timezone.utc)
     await kb.save()
+
+    if not was_shared and kb.shared_with_team:
+        try:
+            from app.models.team import Team
+            from app.services.team_service import notify_team_share
+
+            team = None
+            if kb.team_id:
+                try:
+                    team = await Team.get(kb.team_id)
+                except Exception:
+                    team = None
+            if team is None and user.current_team:
+                team = await Team.get(user.current_team)
+            if team:
+                await notify_team_share(
+                    sharer=user,
+                    team=team,
+                    item_kind="knowledge_base",
+                    item_name=kb.title,
+                    item_id=kb.uuid,
+                    link="/library",
+                    comment=comment,
+                )
+        except Exception:
+            logger.exception("Failed to notify team of knowledge base share")
+
     return kb
 
 

--- a/backend/app/services/library_service.py
+++ b/backend/app/services/library_service.py
@@ -421,7 +421,13 @@ async def clone_to_personal(item_id: str, user: User) -> dict | None:
     )
 
 
-async def share_to_team(item_id: str, user: User, team_id: str) -> dict:
+async def share_to_team(
+    item_id: str,
+    user: User,
+    team_id: str,
+    *,
+    comment: str | None = None,
+) -> dict:
     item = await access_control.get_authorized_library_item(item_id, user)
     if not item:
         raise ShareError("item_not_found", 404)
@@ -447,6 +453,26 @@ async def share_to_team(item_id: str, user: User, team_id: str) -> dict:
     )
     if not result:
         raise ShareError("clone_failed", 500)
+
+    try:
+        from app.services.team_service import notify_team_share
+
+        team = await Team.get(team_oid)
+        if team:
+            await notify_team_share(
+                sharer=user,
+                team=team,
+                item_kind=result.get("kind") or item.kind.value,
+                item_name=result.get("name") or "Untitled",
+                item_id=result.get("id") or str(new_obj_id),
+                link="/library",
+                comment=comment,
+            )
+    except Exception:
+        # Notification failure should never break the share itself.
+        import logging
+        logging.getLogger(__name__).exception("Failed to notify team of library share")
+
     return result
 
 

--- a/backend/app/services/team_service.py
+++ b/backend/app/services/team_service.py
@@ -289,6 +289,74 @@ async def _notify_invite_accepted(
         await send_email(inviter.email, subject, html, settings, email_type="team_member_joined")
 
 
+async def notify_team_share(
+    *,
+    sharer: User,
+    team: Team,
+    item_kind: str,
+    item_name: str,
+    item_id: str,
+    link: str,
+    comment: str | None = None,
+) -> None:
+    """Fan out a bell notification + email to every team member (except the sharer).
+
+    `item_kind` should match values used elsewhere: "workflow", "extraction",
+    "search_set", "knowledge_base". `link` is a frontend path (e.g. "/library").
+    """
+    from app.config import Settings
+    from app.services.email_service import send_email, team_share_email
+    from app.services.notification_service import create_notification
+
+    sharer_name = sharer.name or sharer.user_id
+    kind_labels = {
+        "workflow": "workflow",
+        "extraction": "extraction",
+        "search_set": "search set",
+        "knowledge_base": "knowledge base",
+    }
+    kind_label = kind_labels.get(item_kind, item_kind.replace("_", " "))
+    title = f'{sharer_name} shared a {kind_label} with {team.name}'
+    body = f'"{item_name}"'
+    if comment:
+        # Keep notification body compact for the bell dropdown
+        snippet = comment.strip().replace("\n", " ")
+        body = f'"{item_name}" — {snippet[:160]}'
+
+    members = await get_team_members(team.id)
+    settings: Settings | None = None
+    for m in members:
+        recipient_id = m.get("user_id")
+        if not recipient_id or recipient_id == sharer.user_id:
+            continue
+
+        await create_notification(
+            user_id=recipient_id,
+            kind="team_share",
+            title=title,
+            body=body,
+            link=link,
+            item_kind=item_kind,
+            item_id=item_id,
+            item_name=item_name,
+        )
+
+        email = m.get("email")
+        if email:
+            if settings is None:
+                settings = Settings()
+            view_url = f"{settings.frontend_url}{link}"
+            subject, html = team_share_email(
+                sharer_name=sharer_name,
+                item_kind=item_kind,
+                item_name=item_name,
+                team_name=team.name,
+                comment=comment,
+                view_url=view_url,
+            )
+            await send_email(email, subject, html, settings, email_type="team_share")
+
+
 async def switch_team(team_uuid: str, user: User) -> Team:
     """Switch the user's current team."""
     team = await Team.find_one(Team.uuid == team_uuid)

--- a/frontend/src/api/knowledge.ts
+++ b/frontend/src/api/knowledge.ts
@@ -86,9 +86,10 @@ export function removeKBSource(uuid: string, sourceUuid: string) {
   })
 }
 
-export function shareKnowledgeBase(uuid: string) {
+export function shareKnowledgeBase(uuid: string, comment?: string) {
   return apiFetch<{ ok: boolean; shared_with_team: boolean }>(`/api/knowledge/${uuid}/share`, {
     method: 'POST',
+    body: JSON.stringify({ comment: comment || undefined }),
   })
 }
 

--- a/frontend/src/api/library.ts
+++ b/frontend/src/api/library.ts
@@ -57,8 +57,11 @@ export function cloneToPersonal(itemId: string) {
   return apiFetch<LibraryItem>('/api/library/clone', { method: 'POST', body: JSON.stringify({ item_id: itemId }) })
 }
 
-export function shareToTeam(itemId: string, teamId: string) {
-  return apiFetch<LibraryItem>('/api/library/share', { method: 'POST', body: JSON.stringify({ item_id: itemId, team_id: teamId }) })
+export function shareToTeam(itemId: string, teamId: string, comment?: string) {
+  return apiFetch<LibraryItem>('/api/library/share', {
+    method: 'POST',
+    body: JSON.stringify({ item_id: itemId, team_id: teamId, comment: comment || undefined }),
+  })
 }
 
 // Folders

--- a/frontend/src/components/layout/NotificationBell.tsx
+++ b/frontend/src/components/layout/NotificationBell.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { Bell, CheckCheck, Headphones, MessageSquare, ShieldCheck, ShieldX, RotateCcw, Eye } from 'lucide-react'
+import { Bell, CheckCheck, Headphones, MessageSquare, ShieldCheck, ShieldX, RotateCcw, Eye, Share2 } from 'lucide-react'
 import { useNavigate } from '@tanstack/react-router'
 import { listNotifications, markRead, markAllRead, getUnreadCount } from '../../api/notifications'
 import type { Notification } from '../../api/notifications'
@@ -15,6 +15,7 @@ const kindIcons: Record<string, typeof ShieldCheck> = {
   support_new_message: MessageSquare,
   support_reply: MessageSquare,
   support_status: Headphones,
+  team_share: Share2,
 }
 
 const kindColors: Record<string, string> = {
@@ -26,6 +27,7 @@ const kindColors: Record<string, string> = {
   support_new_message: '#7c3aed',
   support_reply: '#2563eb',
   support_status: '#059669',
+  team_share: '#f1b300',
 }
 
 const SUPPORT_KINDS = new Set([

--- a/frontend/src/components/library/LibraryItemsPanel.tsx
+++ b/frontend/src/components/library/LibraryItemsPanel.tsx
@@ -7,6 +7,7 @@ import type { Library } from '../../types/library'
 import type { LibraryItem } from '../../types/library'
 import { LibraryItemRow } from './LibraryItemRow'
 import { LibraryItemDetails } from './LibraryItemDetails'
+import { ShareWithTeamDialog } from './ShareWithTeamDialog'
 import { useToast } from '../../contexts/ToastContext'
 
 interface Props {
@@ -37,18 +38,26 @@ export function LibraryItemsPanel({ library, teamId }: Props) {
     refresh()
   }
 
-  const handleShare = async (itemId: string) => {
+  const [shareDialogItem, setShareDialogItem] = useState<{ id: string; name: string } | null>(null)
+  const handleShare = (itemId: string) => {
     if (!teamId) {
       toast('Switch to a team before sharing items.', 'info')
       return
     }
+    const item = items.find((i) => i.id === itemId)
+    setShareDialogItem({ id: itemId, name: item?.name ?? 'this item' })
+  }
+  const confirmShare = async (comment: string) => {
+    if (!shareDialogItem || !teamId) return
     try {
-      await shareToTeam(itemId, teamId)
+      await shareToTeam(shareDialogItem.id, teamId, comment || undefined)
       toast('Shared to team library', 'success')
       refresh()
     } catch (err) {
       const msg = err instanceof ApiError ? err.message : 'Failed to share to team'
       toast(msg, 'error')
+    } finally {
+      setShareDialogItem(null)
     }
   }
 
@@ -134,6 +143,14 @@ export function LibraryItemsPanel({ library, teamId }: Props) {
           item={selectedItem}
           onClose={() => setSelectedItem(null)}
           onRemove={handleRemove}
+        />
+      )}
+
+      {shareDialogItem && (
+        <ShareWithTeamDialog
+          itemName={shareDialogItem.name}
+          onCancel={() => setShareDialogItem(null)}
+          onConfirm={confirmShare}
         />
       )}
     </div>

--- a/frontend/src/components/library/ShareWithTeamDialog.tsx
+++ b/frontend/src/components/library/ShareWithTeamDialog.tsx
@@ -1,0 +1,78 @@
+import { useState } from 'react'
+import { X } from 'lucide-react'
+
+interface Props {
+  itemName: string
+  teamName?: string
+  busy?: boolean
+  onCancel: () => void
+  onConfirm: (comment: string) => void | Promise<void>
+}
+
+export function ShareWithTeamDialog({ itemName, teamName, busy, onCancel, onConfirm }: Props) {
+  const [comment, setComment] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+
+  const handleSubmit = async () => {
+    setSubmitting(true)
+    try {
+      await onConfirm(comment.trim())
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  const isBusy = busy || submitting
+
+  return (
+    <div className="fixed inset-0 flex items-center justify-center bg-black/40" style={{ zIndex: 700 }}>
+      <div className="bg-white rounded-lg shadow-xl w-full max-w-md p-6">
+        <div className="flex items-center justify-between mb-4">
+          <h3 className="text-lg font-semibold text-gray-900">Share with team</h3>
+          <button onClick={onCancel} className="p-1 text-gray-400 hover:text-gray-600 rounded" disabled={isBusy}>
+            <X size={18} />
+          </button>
+        </div>
+
+        <p className="text-sm text-gray-700 mb-4">
+          Sharing <span className="font-medium">{itemName}</span>
+          {teamName ? <> with <span className="font-medium">{teamName}</span></> : null}.
+          Teammates will get a bell notification and an email.
+        </p>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            Add a note (optional)
+          </label>
+          <textarea
+            value={comment}
+            onChange={e => setComment(e.target.value)}
+            rows={4}
+            maxLength={1000}
+            placeholder="Why are you sharing this? Anything teammates should know?"
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-highlight resize-none"
+            autoFocus
+          />
+          <div className="text-xs text-gray-400 text-right mt-1">{comment.length}/1000</div>
+        </div>
+
+        <div className="flex justify-end gap-2 mt-4">
+          <button
+            onClick={onCancel}
+            disabled={isBusy}
+            className="px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 rounded-lg disabled:opacity-50"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleSubmit}
+            disabled={isBusy}
+            className="px-4 py-2 text-sm font-bold text-highlight-text bg-highlight hover:brightness-90 rounded-lg disabled:opacity-50"
+          >
+            {isBusy ? 'Sharing…' : 'Share'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/workspace/KnowledgePanel.tsx
+++ b/frontend/src/components/workspace/KnowledgePanel.tsx
@@ -15,6 +15,7 @@ import { DocumentPickerModal } from '../knowledge/DocumentPickerModal'
 import { KBSearchBar } from '../knowledge/KBSearchBar'
 import { KBListView } from '../knowledge/KBListView'
 import { KnowledgeExplainer } from './KnowledgeExplainer'
+import { ShareWithTeamDialog } from '../library/ShareWithTeamDialog'
 import { useToast } from '../../contexts/ToastContext'
 
 type TabKey = 'mine' | 'team' | 'explore'
@@ -213,14 +214,36 @@ export function KnowledgePanel() {
     activateKB(selectedKB.uuid, selectedKB.title)
   }
 
+  const [shareKBDialogOpen, setShareKBDialogOpen] = useState(false)
+
   const handleToggleShare = async () => {
     if (!selectedKB) return
+    // Sharing for the first time → prompt for a note. Unsharing is silent.
+    if (!selectedKB.shared_with_team) {
+      setShareKBDialogOpen(true)
+      return
+    }
     try {
       await api.shareKnowledgeBase(selectedKB.uuid)
       loadDetail(selectedKB.uuid)
       refresh()
     } catch (err) {
       console.error('Failed to toggle sharing:', err)
+    }
+  }
+
+  const confirmShareKB = async (comment: string) => {
+    if (!selectedKB) return
+    try {
+      await api.shareKnowledgeBase(selectedKB.uuid, comment || undefined)
+      toast('Shared with team', 'success')
+      loadDetail(selectedKB.uuid)
+      refresh()
+    } catch (err) {
+      console.error('Failed to share KB:', err)
+      toast('Failed to share knowledge base', 'error')
+    } finally {
+      setShareKBDialogOpen(false)
     }
   }
 
@@ -1057,6 +1080,14 @@ export function KnowledgePanel() {
           setExploreDetail(null)
           activateKB(item.source_uuid, item.display_name || item.name)
         }}
+      />
+    )}
+
+    {shareKBDialogOpen && selectedKB && (
+      <ShareWithTeamDialog
+        itemName={selectedKB.title}
+        onCancel={() => setShareKBDialogOpen(false)}
+        onConfirm={confirmShareKB}
       />
     )}
     </>

--- a/frontend/src/components/workspace/KnowledgePanel.tsx
+++ b/frontend/src/components/workspace/KnowledgePanel.tsx
@@ -348,6 +348,7 @@ export function KnowledgePanel() {
   if (selectedKB) {
     const badge = STATUS_BADGE[selectedKB.status] || STATUS_BADGE.empty
     return (
+      <>
       <div style={{ height: '100%', display: 'flex', flexDirection: 'column', background: '#1e1e1e', position: 'relative' }}>
         {/* Header */}
         <div
@@ -893,6 +894,15 @@ export function KnowledgePanel() {
           </div>
         )}
       </div>
+
+      {shareKBDialogOpen && (
+        <ShareWithTeamDialog
+          itemName={selectedKB.title}
+          onCancel={() => setShareKBDialogOpen(false)}
+          onConfirm={confirmShareKB}
+        />
+      )}
+      </>
     )
   }
 
@@ -1080,14 +1090,6 @@ export function KnowledgePanel() {
           setExploreDetail(null)
           activateKB(item.source_uuid, item.display_name || item.name)
         }}
-      />
-    )}
-
-    {shareKBDialogOpen && selectedKB && (
-      <ShareWithTeamDialog
-        itemName={selectedKB.title}
-        onCancel={() => setShareKBDialogOpen(false)}
-        onConfirm={confirmShareKB}
       />
     )}
     </>

--- a/frontend/src/components/workspace/LibraryTab.tsx
+++ b/frontend/src/components/workspace/LibraryTab.tsx
@@ -6,6 +6,7 @@ import { useToast } from '../../contexts/ToastContext'
 import { useLibraries, useLibraryItems } from '../../hooks/useLibrary'
 import { LibraryItemRow } from '../library/LibraryItemRow'
 import { ExploreTab } from '../library/ExploreTab'
+import { ShareWithTeamDialog } from '../library/ShareWithTeamDialog'
 import { cloneToPersonal, shareToTeam, addItem as addItemToLibrary, touchItem, listCollections } from '../../api/library'
 import { ApiError } from '../../api/client'
 import { createWorkflow, importWorkflow } from '../../api/workflows'
@@ -139,18 +140,26 @@ export function LibraryTab() {
     await cloneToPersonal(itemId)
     refreshItems()
   }
-  const handleShare = async (itemId: string) => {
+  const [shareDialogItem, setShareDialogItem] = useState<{ id: string; name: string } | null>(null)
+  const handleShare = (itemId: string) => {
     if (!teamId) {
       toast('Switch to a team before sharing items.', 'info')
       return
     }
+    const item = items.find((i) => i.id === itemId)
+    setShareDialogItem({ id: itemId, name: item?.name ?? 'this item' })
+  }
+  const confirmShare = async (comment: string) => {
+    if (!shareDialogItem || !teamId) return
     try {
-      await shareToTeam(itemId, teamId)
+      await shareToTeam(shareDialogItem.id, teamId, comment || undefined)
       toast('Shared to team library', 'success')
       refreshItems()
     } catch (err) {
       const msg = err instanceof ApiError ? err.message : 'Failed to share to team'
       toast(msg, 'error')
+    } finally {
+      setShareDialogItem(null)
     }
   }
   const handleRemove = async (itemId: string) => {
@@ -1351,6 +1360,14 @@ export function LibraryTab() {
             </div>
           </div>
         </div>
+      )}
+
+      {shareDialogItem && (
+        <ShareWithTeamDialog
+          itemName={shareDialogItem.name}
+          onCancel={() => setShareDialogItem(null)}
+          onConfirm={confirmShare}
+        />
       )}
     </div>
   )


### PR DESCRIPTION
## Summary
- Sharing a library item or flipping a knowledge base to shared-with-team now opens a comment dialog and fans out a bell notification + email to every other team member. The optional note rides along in both.
- Backend: new `team_share_email` template, `notify_team_share` helper in `team_service`, library/knowledge share endpoints accept and forward the comment. KB notifies only on unshared → shared (untoggling stays silent). Notification failures are caught and logged so they can never break the share itself.
- Frontend: new `ShareWithTeamDialog` (1000-char textarea) wired into `LibraryTab`, `LibraryItemsPanel`, and `KnowledgePanel`. `NotificationBell` renders the new `team_share` kind with a yellow Share2 icon.

Before this PR, sharing silently succeeded — teammates had no way to know unless they happened to visit the team library.

## Test plan
- [ ] Share a workflow or extraction with your team from the library; confirm the dialog opens, the bell entry appears for teammates (not the sharer), and the email arrives with the note.
- [ ] Toggle a knowledge base to shared with a note; confirm same fanout.
- [ ] Toggle the same KB back to unshared; confirm no notification or email is sent.
- [ ] Share without filling in the comment; confirm both notification and email render correctly without the note block.
- [ ] Email comment is HTML-escaped (try `<script>` in the textarea).

🤖 Generated with [Claude Code](https://claude.com/claude-code)