### PR TITLE
Guide oversize-doc users to Knowledge Base + show page-level citations

### DIFF
--- a/backend/app/models/document.py
+++ b/backend/app/models/document.py
@@ -27,6 +27,18 @@ class SmartDocument(Document):
     token_count: int = 0
     num_pages: int = 0
 
+    # Retrieval readiness — set by perform_semantic_ingestion. A document is
+    # only safe to use via Knowledge Base retrieval once chromadb_ready is True.
+    chromadb_ready: bool = False
+    chunk_count: int = 0
+    ingest_error: Optional[str] = None
+
+    # Per-location char-offset markers from text extraction, used to attach
+    # page (PDF) or sheet (XLSX) metadata to chunks for citations. Empty for
+    # formats with no location structure (docx, txt, html, code).
+    # Shape: [{"char_offset": int, "kind": "page"|"sheet", "value": int|str}]
+    text_markers: list[dict] = []
+
     # Data classification (FERPA, CUI, etc.)
     classification: Optional[str] = None  # unrestricted | internal | ferpa | cui | itar
     classification_confidence: Optional[float] = None

--- a/backend/app/models/workflow.py
+++ b/backend/app/models/workflow.py
@@ -82,6 +82,12 @@ class WorkflowResult(Document):
     output_step_names: list[str] = []
     start_time: datetime.datetime = Field(default_factory=lambda: datetime.datetime.now(tz=datetime.timezone.utc))
     status: str = "running"
+    error: Optional[str] = None
+    # Machine-readable error payload set by the runner when the failure has a
+    # suggested user action (e.g. oversize-context with a convert-to-KB hint).
+    # Schema: {"code": "context_over_budget", "suggested_action": "convert_to_kb",
+    #          "oversize_documents": [{"uuid": ..., "title": ..., "token_count": ...}]}
+    error_payload: Optional[dict] = None
     session_id: str
     current_step_name: Optional[str] = None
     current_step_detail: Optional[str] = None
@@ -95,6 +101,10 @@ class WorkflowResult(Document):
     # Batch run fields
     batch_id: Optional[str] = None
     document_title: Optional[str] = None
+    # Citations aggregated from every KnowledgeBaseQuery step that ran. Each
+    # entry: {document_id, document_title, page, sheet, chunk_id, score,
+    # content_preview}. The frontend renders these as citation chips.
+    retrieved_sources: list[dict] = []
 
     class Settings:
         name = "workflow_result"

--- a/backend/app/routers/knowledge.py
+++ b/backend/app/routers/knowledge.py
@@ -13,6 +13,7 @@ from app.schemas.knowledge import (
     AddDocumentsRequest,
     AddUrlsRequest,
     AdoptKBRequest,
+    ConvertDocumentsRequest,
     CreateKBRequest,
     ImportKBRequest,
     ImportKBResponse,
@@ -174,6 +175,44 @@ async def create_knowledge_base(req: CreateKBRequest, user: User = Depends(get_c
         title=req.title, user_id=user.user_id,
         team_id=team_id, description=req.description,
     )
+    return _kb_response(kb)
+
+
+@router.post("/convert_documents", response_model=KBResponse)
+async def convert_documents_to_kb(
+    req: ConvertDocumentsRequest, user: User = Depends(get_current_user),
+):
+    """One-click "Convert to Knowledge Base" for oversized documents.
+
+    Creates a new KB with a sensible default title, then attaches the given
+    SmartDocuments via the standard add_documents pipeline. The frontend uses
+    this to recover from a context-over-budget error without making the user
+    navigate to the KB UI.
+    """
+    if not req.document_uuids:
+        raise HTTPException(status_code=400, detail="No documents provided")
+
+    # Pick a default title from the first doc when the client didn't supply one.
+    title = (req.title or "").strip()
+    if not title:
+        from app.models.document import SmartDocument
+
+        first = await SmartDocument.find_one(SmartDocument.uuid == req.document_uuids[0])
+        if first and first.title:
+            title = first.title if len(req.document_uuids) == 1 else f"{first.title} (and {len(req.document_uuids) - 1} more)"
+        else:
+            title = "Reference documents"
+
+    team_id = str(user.current_team) if user.current_team else None
+    kb = await svc.create_knowledge_base(
+        title=title, user_id=user.user_id, team_id=team_id, description=None,
+    )
+    kb.status = "building"
+    await kb.save()
+    try:
+        await svc.add_documents(kb, req.document_uuids, user)
+    except ValueError as e:
+        raise HTTPException(status_code=404, detail=str(e))
     return _kb_response(kb)
 
 

--- a/backend/app/schemas/documents.py
+++ b/backend/app/schemas/documents.py
@@ -9,11 +9,15 @@ class DocumentResponse(BaseModel):
     extension: str
     processing: bool
     valid: bool
+    validation_feedback: Optional[str] = None
     task_status: Optional[str] = None
     folder: Optional[str] = None
     created_at: str
     token_count: int = 0
     num_pages: int = 0
+    chromadb_ready: bool = False
+    chunk_count: int = 0
+    ingest_error: Optional[str] = None
 
 
 class FolderResponse(BaseModel):

--- a/backend/app/schemas/knowledge.py
+++ b/backend/app/schemas/knowledge.py
@@ -21,6 +21,15 @@ class AddDocumentsRequest(BaseModel):
     document_uuids: list[str]
 
 
+class ConvertDocumentsRequest(BaseModel):
+    """Wrap one or more SmartDocuments in a new KB so they can be retrieved
+    instead of inlined. Used by the chat / workflow "Convert to Knowledge
+    Base" affordance shown when a doc is too large for the current model.
+    """
+    document_uuids: list[str]
+    title: Optional[str] = None  # defaults to the first doc's title
+
+
 class ShareKBRequest(BaseModel):
     comment: Optional[str] = None
 

--- a/backend/app/schemas/workflows.py
+++ b/backend/app/schemas/workflows.py
@@ -81,6 +81,10 @@ class WorkflowStatusResponse(BaseModel):
     final_output: Optional[Any] = None
     steps_output: Optional[dict] = None
     output_step_names: list[str] = []
+    approval_request_id: Optional[str] = None
+    error: Optional[str] = None
+    error_payload: Optional[dict] = None
+    retrieved_sources: list[dict] = []
 
 
 class BatchStatusItem(BaseModel):

--- a/backend/app/services/chat_service.py
+++ b/backend/app/services/chat_service.py
@@ -302,6 +302,7 @@ async def chat_stream(
         )
 
     # KB context: query ChromaDB for relevant chunks and add as a segment.
+    kb_sources: list[dict] = []
     if kb_uuid:
         try:
             from app.services.document_manager import DocumentManager
@@ -310,8 +311,25 @@ async def chat_stream(
             if kb_results:
                 kb_text = "\n\n## Knowledge Base Context:\n"
                 for r in kb_results:
-                    src = r.get("metadata", {}).get("source_name", "Unknown")
-                    kb_text += f"\n**Source: {src}**\n{r['content']}\n"
+                    meta = r.get("metadata") or {}
+                    src = meta.get("source_name", "Unknown")
+                    page = meta.get("page")
+                    sheet = meta.get("sheet")
+                    label = src
+                    if isinstance(page, int):
+                        label = f"{src} (p. {page})"
+                    elif isinstance(sheet, str) and sheet:
+                        label = f"{src} ({sheet})"
+                    kb_text += f"\n**Source: {label}**\n{r['content']}\n"
+                    kb_sources.append({
+                        "document_id": meta.get("source_id"),
+                        "document_title": src,
+                        "page": page if isinstance(page, int) else None,
+                        "sheet": sheet if isinstance(sheet, str) else None,
+                        "chunk_id": r.get("chunk_id"),
+                        "score": r.get("score"),
+                        "content_preview": (r.get("content") or "")[:240],
+                    })
                 doc_segments.insert(0, DocumentSegment(label="kb", text=kb_text))
             else:
                 logger.warning("KB query returned no results for kb_uuid=%s", kb_uuid)
@@ -369,21 +387,60 @@ async def chat_stream(
             "tokens_dropped": action.tokens_dropped,
         }) + "\n"
 
+    # Emit KB sources before the LLM streams its answer so the UI can render
+    # citation chips alongside (or just before) the response.
+    if kb_sources:
+        yield json.dumps({
+            "kind": "sources",
+            "content": "",
+            "sources": kb_sources,
+        }) + "\n"
+
     if compacted.fatal:
         logger.warning(
             "Chat context over budget for model=%s: plan=%s actions=%s",
             model_name, compacted.plan.to_dict(),
             [a.to_dict() for a in compacted.actions],
         )
-        yield json.dumps({
-            "kind": "error",
-            "content": (
-                "This request is too large for the selected model "
-                f"(~{compacted.plan.total_input_tokens} tokens vs "
-                f"{compacted.plan.input_budget} token input budget). "
-                "Remove some documents or switch to a larger model."
-            ),
-        }) + "\n"
+        # Identify which attached documents are individually too large for the
+        # model — those are the ones the user should convert to a Knowledge
+        # Base. If none qualify, the prompt is just generically too big and we
+        # fall back to the plain error.
+        from app.services.context_budget import find_oversize_documents
+        oversize = find_oversize_documents(
+            documents=[
+                {"uuid": d.uuid, "title": d.title, "token_count": d.token_count}
+                for d in documents
+            ],
+            model_name=model_name,
+            model_config=model_config,
+        )
+        if oversize:
+            titles = ", ".join(o.title for o in oversize[:3])
+            if len(oversize) > 3:
+                titles += f", and {len(oversize) - 3} more"
+            content = (
+                f"{titles} is too large to read inline with the selected model. "
+                "Convert it to a Knowledge Base and chat will search it instead."
+            )
+            yield json.dumps({
+                "kind": "error",
+                "code": "context_over_budget_convertible",
+                "content": content,
+                "suggested_action": "convert_to_kb",
+                "oversize_documents": [o.to_dict() for o in oversize],
+            }) + "\n"
+        else:
+            yield json.dumps({
+                "kind": "error",
+                "code": "context_over_budget",
+                "content": (
+                    "This request is too large for the selected model "
+                    f"(~{compacted.plan.total_input_tokens} tokens vs "
+                    f"{compacted.plan.input_budget} token input budget). "
+                    "Remove some documents or switch to a larger model."
+                ),
+            }) + "\n"
         await _save_failed_assistant_turn(
             conversation,
             "_(no response — request exceeded the model's context budget)_",

--- a/backend/app/services/context_budget.py
+++ b/backend/app/services/context_budget.py
@@ -501,3 +501,54 @@ def plan_and_compact_context(
         plan=plan,
         actions=actions,
     )
+
+
+# ---------------------------------------------------------------------------
+# Pre-flight oversize check (no LLM call required)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class OversizeDocument:
+    uuid: str
+    title: str
+    token_count: int
+
+    def to_dict(self) -> dict:
+        return {"uuid": self.uuid, "title": self.title, "token_count": self.token_count}
+
+
+def find_oversize_documents(
+    *,
+    documents: list[dict],
+    model_name: str,
+    model_config: Optional[dict] = None,
+    overhead_tokens: int = 1024,
+) -> list[OversizeDocument]:
+    """Return docs whose token_count alone would not fit the model's input budget.
+
+    A doc is "oversize" if its `token_count` exceeds the per-request budget
+    after reserving room for the response and a small overhead (system prompt,
+    user message, scaffolding). Returns docs sorted largest-first. The caller
+    uses this to recommend "Convert to Knowledge Base" rather than running
+    compaction and silently truncating.
+
+    ``documents`` is a list of dicts each with at least ``uuid``, ``title``,
+    ``token_count``. Accepting dicts (not the Beanie model) keeps this usable
+    from sync Celery code.
+    """
+    context_window = resolve_context_window(model_name, model_config)
+    reserve = _default_response_reserve(context_window)
+    budget = max(1, context_window - reserve - overhead_tokens)
+
+    oversize: list[OversizeDocument] = []
+    for d in documents:
+        tc = int(d.get("token_count") or 0)
+        if tc > budget:
+            oversize.append(OversizeDocument(
+                uuid=str(d.get("uuid") or ""),
+                title=str(d.get("title") or d.get("uuid") or "Untitled"),
+                token_count=tc,
+            ))
+    oversize.sort(key=lambda o: o.token_count, reverse=True)
+    return oversize

--- a/backend/app/services/document_manager.py
+++ b/backend/app/services/document_manager.py
@@ -84,11 +84,21 @@ def get_chroma_client(persist_directory: str | None = None) -> chromadb.ClientAP
 
 def _split_text(text: str, chunk_size: int, chunk_overlap: int) -> list[str]:
     """Split text into overlapping chunks without external dependencies."""
+    return [c for c, _ in _split_text_with_offsets(text, chunk_size, chunk_overlap)]
+
+
+def _split_text_with_offsets(
+    text: str, chunk_size: int, chunk_overlap: int,
+) -> list[tuple[str, int]]:
+    """Same as _split_text but also returns each chunk's start offset in the
+    normalized source text. The offset lets callers map a chunk back to its
+    location (page number, sheet name, etc.) when source markers are known.
+    """
     normalized = text.strip()
     if not normalized:
         return []
 
-    chunks: list[str] = []
+    chunks: list[tuple[str, int]] = []
     start = 0
     step = max(1, chunk_size - chunk_overlap)
     text_length = len(normalized)
@@ -102,9 +112,13 @@ def _split_text(text: str, chunk_size: int, chunk_overlap: int) -> list[str]:
             if preferred_break > start:
                 end = preferred_break
 
-        chunk = normalized[start:end].strip()
+        # Track where the *stripped* chunk actually starts in the source so
+        # marker lookup matches a meaningful position.
+        chunk_raw = normalized[start:end]
+        chunk = chunk_raw.strip()
         if chunk:
-            chunks.append(chunk)
+            leading = len(chunk_raw) - len(chunk_raw.lstrip())
+            chunks.append((chunk, start + leading))
 
         if end >= text_length:
             break
@@ -115,6 +129,22 @@ def _split_text(text: str, chunk_size: int, chunk_overlap: int) -> list[str]:
         start = next_start
 
     return chunks
+
+
+def _location_for_offset(offset: int, markers: list[dict]) -> dict:
+    """Return the most recent marker at or before *offset*.
+
+    Used by add_document to tag each chunk with the page (or sheet) it came
+    from. Returns an empty dict when no markers apply.
+    """
+    if not markers:
+        return {}
+    location: dict = {}
+    for m in markers:
+        if m.get("char_offset", 0) > offset:
+            break
+        location = m
+    return location
 
 
 class DocumentManager:
@@ -151,35 +181,58 @@ class DocumentManager:
         document_name: str,
         document_id: str,
         raw_text: Optional[str] = None,
-    ) -> None:
+        text_markers: Optional[list[dict]] = None,
+    ) -> int:
+        """Chunk and embed *raw_text* into the user's collection.
+
+        ``text_markers`` is the optional output of
+        ``document_readers.extract_text_with_markers`` — when present, each
+        chunk's metadata is tagged with the page or sheet it came from so
+        retrieval results can render citations like "PAPPG p. 234".
+
+        Returns the number of chunks written. ``0`` means the document had no
+        extractable text — callers should treat that as "not retrieval-ready"
+        rather than an error.
+        """
         text = raw_text or ""
         if not text:
-            return
+            return 0
 
-        text_splits = _split_text(text, self.chunk_size, self.chunk_overlap)
+        text_splits = _split_text_with_offsets(text, self.chunk_size, self.chunk_overlap)
         if not text_splits:
-            return
+            return 0
 
         collection = self.get_user_collection(user_id)
+        markers = sorted(
+            (m for m in (text_markers or []) if isinstance(m, dict)),
+            key=lambda m: m.get("char_offset", 0),
+        )
 
         ids = []
         documents = []
         metadatas = []
-        for i, chunk in enumerate(text_splits):
+        for i, (chunk, offset) in enumerate(text_splits):
             ids.append(f"{document_id}_chunk_{i}")
             documents.append(chunk)
-            metadatas.append(
-                {
-                    "document_id": document_id,
-                    "document_name": document_name,
-                    "chunk_index": i,
-                    "total_chunks": len(text_splits),
-                    "timestamp": datetime.now().isoformat(),
-                    "user_id": user_id,
-                }
-            )
+            meta: dict = {
+                "document_id": document_id,
+                "document_name": document_name,
+                "chunk_index": i,
+                "total_chunks": len(text_splits),
+                "timestamp": datetime.now().isoformat(),
+                "user_id": user_id,
+            }
+            location = _location_for_offset(offset, markers)
+            kind = location.get("kind")
+            value = location.get("value")
+            if kind == "page" and isinstance(value, int):
+                meta["page"] = value
+            elif kind == "sheet" and isinstance(value, str):
+                meta["sheet"] = value
+            metadatas.append(meta)
 
         collection.add(ids=ids, documents=documents, metadatas=metadatas)
+        return len(text_splits)
 
     def query_documents(
         self,
@@ -203,11 +256,18 @@ class DocumentManager:
 
         output = []
         if results and results.get("documents"):
+            ids_list = (results.get("ids") or [[]])[0]
+            dists_list = (results.get("distances") or [[]])[0]
             for i, doc in enumerate(results["documents"][0]):
                 metadata = (
                     results["metadatas"][0][i] if results.get("metadatas") else {}
                 )
-                output.append({"content": doc, "metadata": metadata})
+                output.append({
+                    "content": doc,
+                    "metadata": metadata,
+                    "chunk_id": ids_list[i] if i < len(ids_list) else None,
+                    "score": dists_list[i] if i < len(dists_list) else None,
+                })
 
         return output
 
@@ -238,27 +298,45 @@ class DocumentManager:
         source_id: str,
         source_name: str,
         raw_text: str,
+        text_markers: Optional[list[dict]] = None,
     ) -> int:
-        """Chunk text, embed, and add to a KB collection. Returns chunk count."""
-        text_splits = _split_text(raw_text, self.chunk_size, self.chunk_overlap)
+        """Chunk text, embed, and add to a KB collection. Returns chunk count.
+
+        ``text_markers`` lets KB ingestion preserve page/sheet citations the
+        same way per-user ingestion does. Sources without markers (web URLs,
+        plaintext) just omit the page metadata.
+        """
+        text_splits = _split_text_with_offsets(raw_text, self.chunk_size, self.chunk_overlap)
         if not text_splits:
             return 0
 
         collection = self.get_kb_collection(kb_uuid)
+        markers = sorted(
+            (m for m in (text_markers or []) if isinstance(m, dict)),
+            key=lambda m: m.get("char_offset", 0),
+        )
 
         ids = []
         documents = []
         metadatas = []
-        for i, chunk in enumerate(text_splits):
+        for i, (chunk, offset) in enumerate(text_splits):
             ids.append(f"{source_id}_chunk_{i}")
             documents.append(chunk)
-            metadatas.append({
+            meta: dict = {
                 "source_id": source_id,
                 "source_name": source_name,
                 "chunk_index": i,
                 "total_chunks": len(text_splits),
                 "timestamp": datetime.now().isoformat(),
-            })
+            }
+            location = _location_for_offset(offset, markers)
+            kind = location.get("kind")
+            value = location.get("value")
+            if kind == "page" and isinstance(value, int):
+                meta["page"] = value
+            elif kind == "sheet" and isinstance(value, str):
+                meta["sheet"] = value
+            metadatas.append(meta)
 
         collection.add(ids=ids, documents=documents, metadatas=metadatas)
         return len(text_splits)
@@ -275,9 +353,16 @@ class DocumentManager:
 
         output = []
         if results and results.get("documents"):
+            ids_list = (results.get("ids") or [[]])[0]
+            dists_list = (results.get("distances") or [[]])[0]
             for i, doc in enumerate(results["documents"][0]):
                 metadata = results["metadatas"][0][i] if results.get("metadatas") else {}
-                output.append({"content": doc, "metadata": metadata})
+                output.append({
+                    "content": doc,
+                    "metadata": metadata,
+                    "chunk_id": ids_list[i] if i < len(ids_list) else None,
+                    "score": dists_list[i] if i < len(dists_list) else None,
+                })
         return output
 
     def delete_kb_collection(self, kb_uuid: str) -> None:

--- a/backend/app/services/document_readers.py
+++ b/backend/app/services/document_readers.py
@@ -45,19 +45,31 @@ def convert_to_markdown(doc_path: str, keep_data_uris: bool = True) -> str:
 
 
 def extract_text_from_pdf(pdf_path: str) -> str:
-    """Extract text from a PDF using PyMuPDF.
+    """Extract text from a PDF using PyMuPDF. See _pymupdf_extract_with_pages for the page-aware variant."""
+    text, _ = _pymupdf_extract_with_pages(pdf_path)
+    return text
 
-    PyMuPDF preserves reading order in multi-column layouts and exposes
-    form field values that PyPDF2 misses (NIH biosketches, NSF Current
-    & Pending forms, etc. are common research-admin uploads).
+
+def _pymupdf_extract_with_pages(pdf_path: str) -> tuple[str, list[dict]]:
+    """Extract PDF text via PyMuPDF, returning text plus per-page char offsets.
+
+    Markers are ``[{"char_offset": int, "kind": "page", "value": page_number}]``
+    one per page of the source PDF. Used by ``extract_text_with_markers`` so
+    chunks can be tagged with their source page for citations.
+
+    PyMuPDF preserves reading order in multi-column layouts and exposes form
+    field values that PyPDF2 misses (NIH biosketches, NSF Current & Pending
+    forms, etc. are common research-admin uploads).
     """
     import pymupdf
 
-    chunks: list[str] = []
-    with pymupdf.open(pdf_path) as doc:
-        for page in doc:
-            chunks.append(page.get_text("text"))
+    parts: list[str] = []
+    markers: list[dict] = []
+    cursor = 0
 
+    with pymupdf.open(pdf_path) as doc:
+        for i, page in enumerate(doc, start=1):
+            page_text = page.get_text("text")
             field_lines: list[str] = []
             for widget in page.widgets() or []:
                 value = (widget.field_value or "").strip()
@@ -66,9 +78,20 @@ def extract_text_from_pdf(pdf_path: str) -> str:
                 label = (widget.field_label or widget.field_name or "").strip()
                 field_lines.append(f"- {label}: {value}" if label else f"- {value}")
             if field_lines:
-                chunks.append("[Form fields]\n" + "\n".join(field_lines))
+                page_text = (page_text or "") + "\n[Form fields]\n" + "\n".join(field_lines)
 
-    return "\n".join(c for c in chunks if c)
+            if not page_text:
+                continue
+
+            # Page marker points at the start of this page's text.
+            markers.append({"char_offset": cursor, "kind": "page", "value": i})
+            if parts:
+                # The "\n" join we add below contributes one character.
+                cursor += 1
+            parts.append(page_text)
+            cursor += len(page_text)
+
+    return "\n".join(parts), markers
 
 
 def ocr_extract_text_from_pdf(pdf_path: str, retries: int = 3) -> str:
@@ -498,6 +521,84 @@ def remove_images_from_markdown(markdown_text: str) -> str:
     text = re.sub(r"\n\s*\n\s*\n", "\n\n", text)
     text = re.sub(r"^\s+$", "", text, flags=re.MULTILINE)
     return text.strip()
+
+
+def _xlsx_sheet_markers(text: str) -> list[dict]:
+    """Recover per-sheet char offsets from extract_text_from_xlsx output.
+
+    The xlsx extractor uses unique ``## {sheet_name}`` headers as section
+    boundaries. Parsing them back out is cheaper than refactoring the whole
+    builder to thread markers through every branch.
+    """
+    markers: list[dict] = []
+    for m in re.finditer(r"(?m)^## (.+?)$", text):
+        markers.append({"char_offset": m.start(), "kind": "sheet", "value": m.group(1).strip()})
+    return markers
+
+
+def _interpolate_page_markers(text: str, num_pages: int) -> list[dict]:
+    """Approximate page boundaries by spreading them evenly across the text.
+
+    Used when we know the page count (from PyMuPDF) but the text body came
+    from a service that didn't preserve page structure (the OCR endpoint).
+    Treats the text as uniformly dense — a rough heuristic, but good enough
+    for "this answer is from somewhere around page 234" citations.
+    """
+    if num_pages <= 0 or not text:
+        return []
+    length = len(text)
+    step = max(1, length // num_pages)
+    return [
+        {"char_offset": min(length - 1, i * step), "kind": "page", "value": i + 1}
+        for i in range(num_pages)
+    ]
+
+
+def _pdf_page_count(pdf_path: str) -> int:
+    """Cheap page-count read via PyMuPDF. Returns 0 if it can't open the file."""
+    try:
+        import pymupdf
+        with pymupdf.open(pdf_path) as doc:
+            return doc.page_count
+    except Exception as e:
+        logger.warning("Could not read PDF page count for %s: %s", pdf_path, e)
+        return 0
+
+
+def extract_text_with_markers(file_path: str, file_extension: str) -> tuple[str, list[dict]]:
+    """Like extract_text_from_file, but also returns per-location char offsets.
+
+    Markers are a list of ``{"char_offset": int, "kind": "page"|"sheet",
+    "value": int|str}`` entries. Used by the chunker to attach page / sheet
+    metadata to ChromaDB chunks so retrieval results can cite their source.
+
+    Locations that can't preserve structure (DOCX text, plaintext, code
+    files) return an empty marker list — chunks from those documents simply
+    omit page metadata in citations.
+    """
+    ext = file_extension.lower().lstrip(".")
+
+    if ext == "pdf":
+        # Prefer OCR text for accuracy. When OCR is used we lose true page
+        # boundaries, so fall back to interpolating against PyMuPDF's page
+        # count — approximate, but enough for "around page N" citations.
+        try:
+            ocr_text = ocr_extract_text_from_pdf(file_path)
+        except Exception as e:
+            logger.warning("OCR raised, falling back to PyMuPDF: %s", e)
+            ocr_text = ""
+        if ocr_text and len(ocr_text.strip()) >= MIN_PDF_TEXT_LENGTH:
+            num_pages = _pdf_page_count(file_path)
+            return ocr_text, _interpolate_page_markers(ocr_text, num_pages)
+        # OCR unavailable / too little text — PyMuPDF gives us exact boundaries.
+        return _pymupdf_extract_with_pages(file_path)
+
+    if ext == "xlsx":
+        text = extract_text_from_xlsx(file_path)
+        return text, _xlsx_sheet_markers(text)
+
+    # Other formats (docx, txt, html, code) — extract as text, no markers.
+    return extract_text_from_file(file_path, ext), []
 
 
 def extract_text_from_file(file_path: str, file_extension: str) -> str:

--- a/backend/app/services/document_service.py
+++ b/backend/app/services/document_service.py
@@ -103,6 +103,9 @@ async def list_contents(
                 "classified_by": d.classified_by,
                 "retention_hold": d.retention_hold,
                 "soft_deleted": d.soft_deleted,
+                "chromadb_ready": d.chromadb_ready,
+                "chunk_count": d.chunk_count,
+                "ingest_error": d.ingest_error,
             }
             for d in documents
         ],

--- a/backend/app/services/knowledge_service.py
+++ b/backend/app/services/knowledge_service.py
@@ -879,6 +879,7 @@ async def _ingest_document_source(source: KnowledgeBaseSource, kb: KnowledgeBase
         dm = _get_dm()
         chunk_count = await asyncio.to_thread(
             dm.add_to_kb, kb.uuid, source.uuid, doc.title, doc.raw_text,
+            list(doc.text_markers or []),
         )
         source.chunk_count = chunk_count
         source.status = "ready"

--- a/backend/app/services/workflow_engine.py
+++ b/backend/app/services/workflow_engine.py
@@ -1103,12 +1103,35 @@ class KnowledgeBaseQueryNode(Node):
 
         # Format as plain text context block so downstream LLM steps can use it naturally
         parts = []
+        sources: list[dict] = []
         for i, r in enumerate(results, 1):
-            source = r["metadata"].get("source_name", "Unknown source")
-            parts.append(f"[{i}] {source}\n{r['content']}")
+            meta = r.get("metadata") or {}
+            source_name = meta.get("source_name", "Unknown source")
+            page = meta.get("page")
+            sheet = meta.get("sheet")
+            label = source_name
+            if isinstance(page, int):
+                label = f"{source_name} · p. {page}"
+            elif isinstance(sheet, str) and sheet:
+                label = f"{source_name} · {sheet}"
+            parts.append(f"[{i}] {label}\n{r['content']}")
+            sources.append({
+                "document_id": meta.get("source_id"),
+                "document_title": source_name,
+                "page": page if isinstance(page, int) else None,
+                "sheet": sheet if isinstance(sheet, str) else None,
+                "chunk_id": r.get("chunk_id"),
+                "score": r.get("score"),
+                "content_preview": (r.get("content") or "")[:240],
+            })
 
         output = "\n\n---\n\n".join(parts)
-        return {"output": output, "input": inputs.get("output"), "step_name": self.name}
+        return {
+            "output": output,
+            "input": inputs.get("output"),
+            "step_name": self.name,
+            "retrieved_sources": sources,
+        }
 
 
 # ---------------------------------------------------------------------------
@@ -1182,11 +1205,15 @@ class WorkflowEngine:
                     "num_steps_completed": idx,
                 })
 
-            data.append({
+            entry = {
                 "name": node.name,
                 "output": latest_output.get("output"),
                 "input": latest_output.get("input"),
-            })
+            }
+            sources = latest_output.get("retrieved_sources")
+            if isinstance(sources, list) and sources:
+                entry["retrieved_sources"] = sources
+            data.append(entry)
 
         if latest_output is None:
             return None, data

--- a/backend/app/services/workflow_service.py
+++ b/backend/app/services/workflow_service.py
@@ -512,6 +512,9 @@ async def get_workflow_status(session_id: str, user: User | None = None) -> dict
         "steps_output": result.steps_output,
         "output_step_names": result.output_step_names,
         "approval_request_id": result.approval_request_id,
+        "error": result.error,
+        "error_payload": result.error_payload,
+        "retrieved_sources": result.retrieved_sources,
         "workflow_name": workflow_name,
         "document_title": result.document_title,
     }

--- a/backend/app/tasks/document_tasks.py
+++ b/backend/app/tasks/document_tasks.py
@@ -44,7 +44,6 @@ def perform_extraction_and_update(self, document_uuid: str, extension: str) -> s
         convert_to_markdown,
         extract_docx_extras,
         extract_text_from_file,
-        extract_text_from_xlsx,
         remove_images_from_markdown,
     )
 
@@ -69,9 +68,11 @@ def perform_extraction_and_update(self, document_uuid: str, extension: str) -> s
         )
 
         raw_text = ""
+        text_markers: list[dict] = []
 
         if extension == "xlsx":
-            raw_text = extract_text_from_xlsx(str(absolute_path))
+            from app.services.document_readers import extract_text_with_markers
+            raw_text, text_markers = extract_text_with_markers(str(absolute_path), extension)
 
         elif extension == "xls":
             raw_text = convert_to_markdown(str(absolute_path))
@@ -90,11 +91,17 @@ def perform_extraction_and_update(self, document_uuid: str, extension: str) -> s
                 if extras:
                     raw_text = (raw_text or "").rstrip() + "\n\n" + extras
 
+        elif extension == "pdf":
+            from app.services.document_readers import extract_text_with_markers
+            raw_text, text_markers = extract_text_with_markers(str(absolute_path), extension)
+
         else:
             raw_text = extract_text_from_file(str(absolute_path), extension)
 
-        # Count tokens (rough estimate: ~4 chars per token)
-        token_count = len(raw_text) // 4 if raw_text else 0
+        # Count tokens using the same tokenizer the budget planner uses so the
+        # pre-flight oversize check is accurate.
+        from app.services.context_budget import count_tokens
+        token_count = count_tokens(raw_text) if raw_text else 0
 
         db.smart_document.update_one(
             {"uuid": document_uuid},
@@ -103,6 +110,7 @@ def perform_extraction_and_update(self, document_uuid: str, extension: str) -> s
                     "raw_text": raw_text,
                     "processing": False,
                     "token_count": token_count,
+                    "text_markers": text_markers,
                 }
             },
         )
@@ -386,7 +394,11 @@ def cleanup_document(self, document_uuid: str) -> None:
     default_retry_delay=5,
 )
 def perform_semantic_ingestion(self, raw_text: str, document_uuid: str, user_id: str) -> str:
-    """Chunk text and embed into ChromaDB for RAG search."""
+    """Chunk text and embed into ChromaDB for RAG search.
+
+    Writes back ``chromadb_ready`` / ``chunk_count`` / ``ingest_error`` so the
+    frontend can show a meaningful retrieval state on the document.
+    """
 
     from app.services.document_manager import DocumentManager
 
@@ -401,21 +413,49 @@ def perform_semantic_ingestion(self, raw_text: str, document_uuid: str, user_id:
         {"$set": {"task_status": "readying"}},
     )
 
+    # If the caller passed empty raw_text, fall back to whatever the
+    # extraction task already wrote to the DB.
+    text = raw_text or doc.get("raw_text", "") or ""
+    markers = doc.get("text_markers") or []
+
     from app.config import Settings
 
     settings = Settings()
-    dm = DocumentManager(persist_directory=settings.chromadb_persist_dir)
-    dm.add_document(
-        user_id=user_id,
-        document_name=doc.get("title", ""),
-        document_id=document_uuid,
-        doc_path=doc.get("path", ""),
-        raw_text=raw_text,
-    )
+    try:
+        dm = DocumentManager(persist_directory=settings.chromadb_persist_dir)
+        chunk_count = dm.add_document(
+            user_id=user_id,
+            document_name=doc.get("title", ""),
+            document_id=document_uuid,
+            doc_path=doc.get("path", ""),
+            raw_text=text,
+            text_markers=markers,
+        )
+    except Exception as e:
+        logger.exception("Semantic ingestion failed for %s", document_uuid)
+        db.smart_document.update_one(
+            {"uuid": document_uuid},
+            {
+                "$set": {
+                    "task_status": "complete",
+                    "chromadb_ready": False,
+                    "chunk_count": 0,
+                    "ingest_error": str(e)[:500],
+                }
+            },
+        )
+        raise
 
     db.smart_document.update_one(
         {"uuid": document_uuid},
-        {"$set": {"task_status": "complete"}},
+        {
+            "$set": {
+                "task_status": "complete",
+                "chromadb_ready": chunk_count > 0,
+                "chunk_count": chunk_count,
+                "ingest_error": None,
+            }
+        },
     )
 
     return document_uuid

--- a/backend/app/tasks/workflow_tasks.py
+++ b/backend/app/tasks/workflow_tasks.py
@@ -234,6 +234,92 @@ def execute_workflow_task(self, workflow_result_id, workflow_id, trigger_step_da
         allow_code_execution=is_admin,
     )
 
+    # Pre-flight oversize check: refuse the run cleanly when an attached
+    # document's token_count would blow the model's input budget on its own.
+    # The user sees a guided "Convert to Knowledge Base" affordance instead
+    # of a mid-step 400 from the LLM gateway.
+    try:
+        from app.services.context_budget import find_oversize_documents
+
+        attached_uuids: set[str] = set()
+        for step in steps_data:
+            for task in step.get("tasks", []):
+                td = task.get("data", {}) or {}
+                sel = td.get("selected_document_uuid")
+                if sel:
+                    attached_uuids.add(sel)
+            for u in (step.get("data", {}) or {}).get("doc_uuids", []) or []:
+                if u:
+                    attached_uuids.add(u)
+
+        candidate_docs: list[dict] = []
+        for uuid in attached_uuids:
+            d = db.smart_document.find_one(
+                {"uuid": uuid},
+                {"uuid": 1, "title": 1, "token_count": 1},
+            )
+            if d:
+                candidate_docs.append({
+                    "uuid": d.get("uuid"),
+                    "title": d.get("title") or d.get("uuid"),
+                    "token_count": d.get("token_count") or 0,
+                })
+
+        # Resolve the actual model config so context_window override is honored.
+        model_cfg = None
+        for m in (sys_config.get("llm_models") or []):
+            if m.get("name") == model:
+                model_cfg = m
+                break
+
+        oversize = find_oversize_documents(
+            documents=candidate_docs,
+            model_name=model,
+            model_config=model_cfg,
+        )
+        if oversize:
+            titles = ", ".join(o.title for o in oversize[:3])
+            if len(oversize) > 3:
+                titles += f", and {len(oversize) - 3} more"
+            error_msg = (
+                f"{titles} is too large to read inline with the selected model. "
+                "Convert it to a Knowledge Base and use a Knowledge Base Query step instead."
+            )
+            error_payload = {
+                "code": "context_over_budget_convertible",
+                "suggested_action": "convert_to_kb",
+                "oversize_documents": [o.to_dict() for o in oversize],
+            }
+            db.workflow_result.update_one(
+                {"_id": ObjectId(workflow_result_id)},
+                {"$set": {
+                    "status": "error",
+                    "error": error_msg,
+                    "error_payload": error_payload,
+                }},
+            )
+            if activity_id:
+                from datetime import datetime, timezone
+                try:
+                    db.activity_event.update_one(
+                        {"_id": ObjectId(activity_id)},
+                        {"$set": {
+                            "status": "failed",
+                            "error": error_msg[:2000],
+                            "finished_at": datetime.now(timezone.utc),
+                        }},
+                    )
+                except Exception:
+                    pass
+            logger.warning(
+                "Workflow %s aborted pre-flight: oversize docs %s for model=%s",
+                workflow_id, [o.uuid for o in oversize], model,
+            )
+            return
+    except Exception:
+        # The pre-flight is best-effort; don't let it block a valid run.
+        logger.exception("Pre-flight oversize check failed for workflow %s", workflow_id)
+
     # Mark activity as running
     if activity_id:
         try:
@@ -352,12 +438,22 @@ def execute_workflow_task(self, workflow_result_id, workflow_id, trigger_step_da
             "result_id": workflow_result_id,
         }
 
+    # Aggregate citations from every step that produced retrieved_sources so
+    # the frontend can render them next to the workflow output without
+    # walking the steps_output dict itself.
+    retrieved_sources: list[dict] = []
+    for step in data or []:
+        sources = step.get("retrieved_sources") if isinstance(step, dict) else None
+        if isinstance(sources, list):
+            retrieved_sources.extend(sources)
+
     # Save final result
     db.workflow_result.update_one(
         {"_id": ObjectId(workflow_result_id)},
         {"$set": {
             "status": "completed",
             "final_output": {"output": final_output, "data": data},
+            "retrieved_sources": retrieved_sources,
         }},
     )
 

--- a/backend/tests/test_auth_routes.py
+++ b/backend/tests/test_auth_routes.py
@@ -148,7 +148,8 @@ class TestAuthLogin:
              patch("app.routers.auth.audit_service") as mock_audit, \
              patch("app.routers.auth.get_settings", return_value=_TEST_SETTINGS), \
              patch("app.routers.auth._user_response", new_callable=AsyncMock, return_value=mock_user_resp):
-            mock_svc.authenticate = AsyncMock(return_value=user)
+            # The route uses authenticate_with_reason(...) -> (user, reason).
+            mock_svc.authenticate_with_reason = AsyncMock(return_value=(user, None))
             mock_audit.log_event = AsyncMock()
             resp = await client.post("/api/auth/login", json={
                 "user_id": "testuser",
@@ -167,14 +168,16 @@ class TestAuthLogin:
     @pytest.mark.asyncio
     async def test_login_invalid_credentials(self, client):
         with patch("app.routers.auth.auth_service") as mock_svc:
-            mock_svc.authenticate = AsyncMock(return_value=None)
+            mock_svc.authenticate_with_reason = AsyncMock(return_value=(None, None))
             resp = await client.post("/api/auth/login", json={
                 "user_id": "testuser",
                 "password": "wrong-password",
             })
 
+        # Route returns a generic "couldn't sign you in" message for the
+        # unknown-reason case; the older "Invalid credentials" literal is gone.
         assert resp.status_code == 401
-        assert "Invalid credentials" in resp.json()["detail"]
+        assert "sign you in" in resp.json()["detail"].lower()
 
 
 # ---------------------------------------------------------------------------
@@ -326,7 +329,7 @@ class TestCSRFProtection:
     async def test_csrf_exempt_endpoints_work_without_token(self, client):
         """Login and other exempt endpoints should work without CSRF."""
         with patch("app.routers.auth.auth_service") as mock_svc:
-            mock_svc.authenticate = AsyncMock(return_value=None)
+            mock_svc.authenticate_with_reason = AsyncMock(return_value=(None, None))
             resp = await client.post("/api/auth/login", json={
                 "user_id": "test", "password": "test",
             })

--- a/backend/tests/test_context_budget.py
+++ b/backend/tests/test_context_budget.py
@@ -228,3 +228,60 @@ def test_last_ditch_trim_handles_multiple_rounds():
     # Should not be fatal — we should have compacted enough to fit.
     assert not result.fatal
     assert result.plan.total_input_tokens <= result.plan.input_budget
+
+
+# ---------------------------------------------------------------------------
+# find_oversize_documents
+# ---------------------------------------------------------------------------
+
+
+def test_find_oversize_documents_flags_giants():
+    from app.services.context_budget import find_oversize_documents
+
+    # A 50k-token doc against a 16k-window model is clearly oversize.
+    docs = [
+        {"uuid": "a", "title": "small.txt", "token_count": 500},
+        {"uuid": "b", "title": "huge.pdf", "token_count": 50_000},
+    ]
+    oversize = find_oversize_documents(
+        documents=docs,
+        model_name="gpt-3.5",  # 16k context per fallback table
+    )
+    assert [o.uuid for o in oversize] == ["b"]
+    assert oversize[0].title == "huge.pdf"
+    assert oversize[0].token_count == 50_000
+
+
+def test_find_oversize_documents_respects_model_config_override():
+    from app.services.context_budget import find_oversize_documents
+
+    docs = [{"uuid": "a", "title": "doc.txt", "token_count": 50_000}]
+    # Override the window to 1M — same doc is now small enough.
+    oversize = find_oversize_documents(
+        documents=docs,
+        model_name="gpt-3.5",
+        model_config={"context_window": 1_000_000},
+    )
+    assert oversize == []
+
+
+def test_find_oversize_documents_sorted_largest_first():
+    from app.services.context_budget import find_oversize_documents
+
+    docs = [
+        {"uuid": "a", "title": "medium", "token_count": 20_000},
+        {"uuid": "b", "title": "huge", "token_count": 80_000},
+        {"uuid": "c", "title": "big", "token_count": 30_000},
+    ]
+    oversize = find_oversize_documents(documents=docs, model_name="gpt-3.5")
+    # All three exceed 16k - 4k reserve - 1k overhead = ~11k; largest first.
+    assert [o.uuid for o in oversize] == ["b", "c", "a"]
+
+
+def test_find_oversize_documents_handles_missing_token_count():
+    from app.services.context_budget import find_oversize_documents
+
+    # Documents with missing/zero token_count should never be flagged.
+    docs = [{"uuid": "a", "title": "no-count"}, {"uuid": "b", "title": "zero", "token_count": 0}]
+    oversize = find_oversize_documents(documents=docs, model_name="gpt-3.5")
+    assert oversize == []

--- a/backend/tests/test_csrf_middleware.py
+++ b/backend/tests/test_csrf_middleware.py
@@ -130,7 +130,7 @@ class TestCSRFMiddleware:
     async def test_post_to_exempt_path_bypasses_csrf(self, client):
         """POST to an exempt path (e.g., /api/auth/login) does not require CSRF."""
         with patch("app.routers.auth.auth_service") as mock_auth_svc:
-            mock_auth_svc.authenticate = AsyncMock(return_value=None)
+            mock_auth_svc.authenticate_with_reason = AsyncMock(return_value=(None, None))
 
             resp = await client.post(
                 "/api/auth/login",

--- a/backend/tests/test_document_pipeline.py
+++ b/backend/tests/test_document_pipeline.py
@@ -148,3 +148,74 @@ class TestExtractTextFromFileFallback:
                 os.unlink(path)
             except OSError:
                 pass
+
+
+# ---------------------------------------------------------------------------
+# Phase 1: page-aware chunking and citation metadata
+# ---------------------------------------------------------------------------
+
+
+class TestSplitTextWithOffsets:
+    """The offset variant has to return chunks AND each chunk's start
+    position in the source so callers can map chunks back to page markers."""
+
+    def test_offsets_track_chunk_positions(self):
+        from app.services.document_manager import _split_text_with_offsets
+
+        # Build a deterministic input that will produce multiple chunks.
+        text = ("aaaa " * 60).strip()  # 299 chars
+        chunks = _split_text_with_offsets(text, chunk_size=100, chunk_overlap=20)
+        assert len(chunks) >= 2
+        # Each entry is (chunk_text, start_offset).
+        for chunk, offset in chunks:
+            assert isinstance(chunk, str) and chunk
+            assert isinstance(offset, int)
+            assert text[offset:offset + len(chunk)].startswith(chunk[:20])
+
+    def test_split_text_string_variant_still_works(self):
+        from app.services.document_manager import _split_text
+
+        # The legacy wrapper must still return a list[str] for callers that
+        # don't care about offsets (chunking-only tests, KB ingest paths).
+        chunks = _split_text("hello world " * 30, 80, 16)
+        assert all(isinstance(c, str) for c in chunks)
+        assert chunks
+
+
+class TestLocationForOffset:
+    def test_returns_most_recent_marker(self):
+        from app.services.document_manager import _location_for_offset
+
+        markers = [
+            {"char_offset": 0, "kind": "page", "value": 1},
+            {"char_offset": 1000, "kind": "page", "value": 2},
+            {"char_offset": 2500, "kind": "page", "value": 3},
+        ]
+        # Offset just past the page-2 marker should map to page 2.
+        assert _location_for_offset(1200, markers)["value"] == 2
+        # Offset past the last marker stays on the last page.
+        assert _location_for_offset(99_999, markers)["value"] == 3
+        # Offset at zero with markers starting at zero maps to the first page.
+        assert _location_for_offset(0, markers)["value"] == 1
+
+    def test_returns_empty_dict_when_no_markers(self):
+        from app.services.document_manager import _location_for_offset
+
+        assert _location_for_offset(42, []) == {}
+
+
+class TestPageMarkerInterpolation:
+    def test_interpolation_spreads_pages_uniformly(self):
+        from app.services.document_readers import _interpolate_page_markers
+
+        # 100 chars across 4 pages → markers at 0, 25, 50, 75.
+        markers = _interpolate_page_markers("x" * 100, 4)
+        assert [m["value"] for m in markers] == [1, 2, 3, 4]
+        assert [m["char_offset"] for m in markers] == [0, 25, 50, 75]
+        assert all(m["kind"] == "page" for m in markers)
+
+    def test_handles_zero_pages(self):
+        from app.services.document_readers import _interpolate_page_markers
+
+        assert _interpolate_page_markers("anything", 0) == []
+        assert _interpolate_page_markers("", 5) == []

--- a/backend/tests/test_document_tasks.py
+++ b/backend/tests/test_document_tasks.py
@@ -89,7 +89,10 @@ class TestPerformExtractionAndUpdate:
 
     @patch("app.tasks.document_tasks.get_sync_db")
     @patch("app.config.Settings")
-    @patch("app.services.document_readers.extract_text_from_file", return_value="Extracted text content")
+    @patch(
+        "app.services.document_readers.extract_text_with_markers",
+        return_value=("Extracted text content", [{"char_offset": 0, "kind": "page", "value": 1}]),
+    )
     def test_extracts_text_for_pdf(self, mock_extract, MockSettings, mock_get_db):
         from app.tasks.document_tasks import perform_extraction_and_update
 
@@ -104,12 +107,13 @@ class TestPerformExtractionAndUpdate:
         result = perform_extraction_and_update(document_uuid="doc-1", extension="pdf")
 
         assert result == "Extracted text content"
-        # Should set raw_text and token_count
+        # Should set raw_text, token_count, and text_markers (Phase 1 citations).
         update_call = db.smart_document.update_one.call_args_list[-1]
         update_set = update_call[0][1]["$set"]
         assert update_set["raw_text"] == "Extracted text content"
         assert update_set["processing"] is False
         assert update_set["token_count"] > 0
+        assert update_set["text_markers"] == [{"char_offset": 0, "kind": "page", "value": 1}]
 
     @patch("app.tasks.document_tasks.get_sync_db")
     @patch("app.config.Settings")
@@ -381,6 +385,8 @@ class TestPerformSemanticIngestion:
         MockSettings.return_value = settings
 
         dm_instance = MagicMock()
+        # add_document now returns an int chunk count for the writeback step.
+        dm_instance.add_document.return_value = 5
         MockDM.return_value = dm_instance
 
         result = perform_semantic_ingestion(raw_text="content", document_uuid="doc-1", user_id="user1")
@@ -392,7 +398,12 @@ class TestPerformSemanticIngestion:
             document_id="doc-1",
             doc_path="uploads/report.pdf",
             raw_text="content",
+            text_markers=[],
         )
+        # The final update should reflect the chunk count and ready flag.
+        final_update = db.smart_document.update_one.call_args_list[-1][0][1]["$set"]
+        assert final_update["chromadb_ready"] is True
+        assert final_update["chunk_count"] == 5
 
     @patch("app.services.document_manager.DocumentManager")
     @patch("app.config.Settings")
@@ -406,7 +417,9 @@ class TestPerformSemanticIngestion:
             "uuid": "doc-1", "title": "Doc", "path": "p",
         }
         MockSettings.return_value = MagicMock(chromadb_persist_dir="/data")
-        MockDM.return_value = MagicMock()
+        dm = MagicMock()
+        dm.add_document.return_value = 3
+        MockDM.return_value = dm
 
         perform_semantic_ingestion(raw_text="text", document_uuid="doc-1", user_id="u1")
 
@@ -414,3 +427,28 @@ class TestPerformSemanticIngestion:
         updates = db.smart_document.update_one.call_args_list
         assert updates[0][0][1]["$set"]["task_status"] == "readying"
         assert updates[1][0][1]["$set"]["task_status"] == "complete"
+
+    @patch("app.services.document_manager.DocumentManager")
+    @patch("app.config.Settings")
+    @patch("app.tasks.document_tasks.get_sync_db")
+    def test_writes_ingest_error_on_failure(self, mock_get_db, MockSettings, MockDM):
+        """When chunking fails, chromadb_ready stays False and ingest_error is
+        written so the UI can surface a meaningful state."""
+        from app.tasks.document_tasks import perform_semantic_ingestion
+
+        db = MagicMock()
+        mock_get_db.return_value = db
+        db.smart_document.find_one.return_value = {
+            "uuid": "doc-1", "title": "Doc", "path": "p",
+        }
+        MockSettings.return_value = MagicMock(chromadb_persist_dir="/data")
+        dm = MagicMock()
+        dm.add_document.side_effect = RuntimeError("embedding service down")
+        MockDM.return_value = dm
+
+        with pytest.raises(RuntimeError):
+            perform_semantic_ingestion(raw_text="text", document_uuid="doc-1", user_id="u1")
+
+        final_update = db.smart_document.update_one.call_args_list[-1][0][1]["$set"]
+        assert final_update["chromadb_ready"] is False
+        assert "embedding service down" in final_update["ingest_error"]

--- a/backend/tests/test_knowledge_routes.py
+++ b/backend/tests/test_knowledge_routes.py
@@ -813,3 +813,122 @@ class TestKnowledgeReference:
             )
 
         assert resp.status_code == 404
+
+
+class TestConvertDocumentsToKB:
+    @pytest.mark.asyncio
+    async def test_convert_creates_kb_and_attaches_docs(self, client):
+        # Supply an explicit title so the route skips the SmartDocument lookup
+        # (which would require initializing Beanie's class-level field
+        # descriptors). The default-title fallback is covered in unit tests.
+        user = _make_user()
+        cookies, headers = _auth()
+
+        fake_kb = MagicMock()
+        fake_kb.uuid = "kb-new"
+        fake_kb.title = "PAPPG"
+        fake_kb.description = ""
+        fake_kb.status = "building"
+        fake_kb.shared_with_team = False
+        fake_kb.verified = False
+        fake_kb.organization_ids = []
+        fake_kb.total_sources = 0
+        fake_kb.sources_ready = 0
+        fake_kb.sources_failed = 0
+        fake_kb.total_chunks = 0
+        fake_kb.created_at = datetime.datetime.now(tz=datetime.timezone.utc)
+        fake_kb.updated_at = datetime.datetime.now(tz=datetime.timezone.utc)
+        fake_kb.user_id = "user1"
+        fake_kb.save = AsyncMock()
+
+        with (
+            patch("app.dependencies.decode_token", return_value={"sub": "user1", "type": "access"}),
+            patch("app.dependencies.User") as MockUser,
+            patch("app.routers.knowledge.svc") as mock_svc,
+        ):
+            MockUser.find_one = AsyncMock(return_value=user)
+            mock_svc.create_knowledge_base = AsyncMock(return_value=fake_kb)
+            mock_svc.add_documents = AsyncMock(return_value=1)
+
+            resp = await client.post(
+                "/api/knowledge/convert_documents",
+                cookies=cookies,
+                headers=headers,
+                json={"document_uuids": ["doc-1"], "title": "PAPPG"},
+            )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["uuid"] == "kb-new"
+        assert body["title"] == "PAPPG"
+        # KB was set to "building" before add_documents fires, so retrieval UIs
+        # can show progress.
+        assert fake_kb.status == "building"
+        mock_svc.create_knowledge_base.assert_awaited_once()
+        mock_svc.add_documents.assert_awaited_once()
+        # Both doc UUIDs flow through to the existing attach pipeline.
+        attach_args = mock_svc.add_documents.await_args.args
+        assert attach_args[1] == ["doc-1"]
+
+    @pytest.mark.asyncio
+    async def test_convert_rejects_empty_uuid_list(self, client):
+        user = _make_user()
+        cookies, headers = _auth()
+
+        with (
+            patch("app.dependencies.decode_token", return_value={"sub": "user1", "type": "access"}),
+            patch("app.dependencies.User") as MockUser,
+        ):
+            MockUser.find_one = AsyncMock(return_value=user)
+
+            resp = await client.post(
+                "/api/knowledge/convert_documents",
+                cookies=cookies,
+                headers=headers,
+                json={"document_uuids": []},
+            )
+
+        assert resp.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_convert_uses_supplied_title_when_provided(self, client):
+        user = _make_user()
+        cookies, headers = _auth()
+
+        fake_kb = MagicMock()
+        fake_kb.uuid = "kb-new"
+        fake_kb.title = "Reference materials"
+        fake_kb.description = ""
+        fake_kb.status = "building"
+        fake_kb.shared_with_team = False
+        fake_kb.verified = False
+        fake_kb.organization_ids = []
+        fake_kb.total_sources = 0
+        fake_kb.sources_ready = 0
+        fake_kb.sources_failed = 0
+        fake_kb.total_chunks = 0
+        fake_kb.created_at = datetime.datetime.now(tz=datetime.timezone.utc)
+        fake_kb.updated_at = datetime.datetime.now(tz=datetime.timezone.utc)
+        fake_kb.user_id = "user1"
+        fake_kb.save = AsyncMock()
+
+        with (
+            patch("app.dependencies.decode_token", return_value={"sub": "user1", "type": "access"}),
+            patch("app.dependencies.User") as MockUser,
+            patch("app.routers.knowledge.svc") as mock_svc,
+        ):
+            MockUser.find_one = AsyncMock(return_value=user)
+            mock_svc.create_knowledge_base = AsyncMock(return_value=fake_kb)
+            mock_svc.add_documents = AsyncMock(return_value=2)
+
+            resp = await client.post(
+                "/api/knowledge/convert_documents",
+                cookies=cookies,
+                headers=headers,
+                json={"document_uuids": ["d1", "d2"], "title": "Reference materials"},
+            )
+
+        assert resp.status_code == 200
+        # Title should be the supplied one, NOT the first doc's title.
+        call_kwargs = mock_svc.create_knowledge_base.await_args.kwargs
+        assert call_kwargs["title"] == "Reference materials"

--- a/backend/tests/test_workflow_nodes.py
+++ b/backend/tests/test_workflow_nodes.py
@@ -1107,6 +1107,45 @@ class TestKnowledgeBaseQueryNode:
         result = node.process({"output": "prev"})
         assert result["output"] == ""
 
+    @patch("app.services.document_manager.DocumentManager")
+    def test_emits_retrieved_sources_with_page_and_score(self, mock_dm_cls):
+        """The KB node returns a structured citation list for the workflow
+        result to persist, in addition to the joined prompt text."""
+        mock_dm = MagicMock()
+        mock_dm.query_kb.return_value = [
+            {
+                "content": "Section II.D — cost share",
+                "metadata": {"source_id": "src-1", "source_name": "PAPPG.pdf", "page": 234},
+                "chunk_id": "src-1_chunk_47",
+                "score": 0.12,
+            },
+            {
+                "content": "Q1 budget row",
+                "metadata": {"source_id": "src-2", "source_name": "Budget.xlsx", "sheet": "Year 1"},
+                "chunk_id": "src-2_chunk_3",
+                "score": 0.19,
+            },
+        ]
+        mock_dm_cls.return_value = mock_dm
+
+        node = KnowledgeBaseQueryNode({"kb_uuid": "kb-1", "query": "cost share"})
+        result = node.process({"output": "prev"})
+
+        # Prompt-side: cited label appears in the joined output text.
+        assert "p. 234" in result["output"]
+        assert "Year 1" in result["output"]
+
+        # Citation-side: each result becomes a retrieved_sources entry.
+        sources = result["retrieved_sources"]
+        assert len(sources) == 2
+        assert sources[0]["document_title"] == "PAPPG.pdf"
+        assert sources[0]["page"] == 234
+        assert sources[0]["sheet"] is None
+        assert sources[0]["chunk_id"] == "src-1_chunk_47"
+        assert sources[0]["score"] == 0.12
+        assert sources[1]["sheet"] == "Year 1"
+        assert sources[1]["page"] is None
+
 
 # ---------------------------------------------------------------------------
 # BrowserAutomationNode

--- a/backend/tests/test_workflow_service.py
+++ b/backend/tests/test_workflow_service.py
@@ -114,17 +114,24 @@ class TestCreateWorkflow:
 
 
 class TestGetWorkflowStatus:
+    @patch("app.services.workflow_service.Workflow")
     @patch("app.services.workflow_service.WorkflowResult")
-    async def test_returns_status_dict(self, mock_wr_cls):
+    async def test_returns_status_dict(self, mock_wr_cls, mock_wf_cls):
         from app.services.workflow_service import get_workflow_status
 
         wr = _make_result(session_id="sess1", status="completed")
         mock_wr_cls.find_one = AsyncMock(return_value=wr)
+        # get_workflow_status now resolves a workflow_name via Workflow.get();
+        # without this mock the call would hit uninitialized Beanie.
+        mock_wf = MagicMock()
+        mock_wf.name = "Test workflow"
+        mock_wf_cls.get = AsyncMock(return_value=mock_wf)
 
         result = await get_workflow_status("sess1")
         assert result["status"] == "completed"
         assert result["num_steps_completed"] == 3
         assert result["final_output"] == {"output": "done"}
+        assert result["workflow_name"] == "Test workflow"
 
     @patch("app.services.workflow_service.WorkflowResult")
     async def test_returns_none_for_missing(self, mock_wr_cls):

--- a/frontend/src/api/knowledge.ts
+++ b/frontend/src/api/knowledge.ts
@@ -62,6 +62,13 @@ export function addDocumentsToKB(uuid: string, documentUuids: string[]) {
   })
 }
 
+export function convertDocumentsToKB(documentUuids: string[], title?: string) {
+  return apiFetch<KnowledgeBase>('/api/knowledge/convert_documents', {
+    method: 'POST',
+    body: JSON.stringify({ document_uuids: documentUuids, title }),
+  })
+}
+
 export function addUrlsToKB(
   uuid: string,
   urls: string[],

--- a/frontend/src/components/chat/ChatMessage.tsx
+++ b/frontend/src/components/chat/ChatMessage.tsx
@@ -224,6 +224,34 @@ export function ChatMessage({ message, messageIndex, conversationUuid, streaming
             />
           )}
 
+          {message.citations && message.citations.length > 0 && (
+            <div style={{ marginTop: 8, display: 'flex', flexWrap: 'wrap', gap: 6 }}>
+              <span style={{ fontSize: 11, color: '#6b7280', alignSelf: 'center', marginRight: 2 }}>
+                Sources:
+              </span>
+              {message.citations.map((c, i) => {
+                const locator = typeof c.page === 'number' ? `p. ${c.page}` : (c.sheet || null)
+                const label = locator ? `${c.document_title} · ${locator}` : c.document_title
+                const preview = c.content_preview || ''
+                return (
+                  <span
+                    key={`${c.chunk_id ?? c.document_id ?? i}`}
+                    title={preview}
+                    style={{
+                      display: 'inline-flex', alignItems: 'center', gap: 4,
+                      padding: '2px 8px', fontSize: 11, fontWeight: 500,
+                      backgroundColor: '#f3f4f6', color: '#374151',
+                      border: '1px solid #e5e7eb', borderRadius: 999,
+                      cursor: 'help',
+                    }}
+                  >
+                    {label}
+                  </span>
+                )
+              })}
+            </div>
+          )}
+
           {/* Feedback bar - hidden during streaming */}
           {!isStreamingProp && message.content && <div style={{
             display: 'flex', alignItems: 'center', gap: 4, marginTop: 10,

--- a/frontend/src/components/chat/ChatPanel.tsx
+++ b/frontend/src/components/chat/ChatPanel.tsx
@@ -12,6 +12,7 @@ import { useWorkspace, type PendingChatMessage } from '../../contexts/WorkspaceC
 import { useToast } from '../../contexts/ToastContext'
 import { addLink, removeDocument, removeLink, truncateContext, compactContext, clearContext } from '../../api/chat'
 import { uploadFile } from '../../api/files'
+import { convertDocumentsToKB } from '../../api/knowledge'
 import { getUserConfig, updateUserConfig, markFirstSessionComplete } from '../../api/config'
 import type { FileAttachment, UrlAttachment } from '../../types/chat'
 import type { ModelInfo } from '../../types/workflow'
@@ -65,6 +66,8 @@ export function ChatPanel({ conversationToLoad, pendingMessage, onPendingMessage
     activityId,
     conversationUuid,
     error,
+    errorDetails,
+    clearError,
     contextTokens,
     contextMode,
     contextCutoffIndex,
@@ -77,7 +80,8 @@ export function ChatPanel({ conversationToLoad, pendingMessage, onPendingMessage
     setActivity,
   } = useChat()
 
-  const { bumpActivitySignal, processingDoc, selectedDocUuids, setSelectedDocUuids, selectedDocNames, setSelectedDocNames, selectedFolderUuids, activeKBUuid, activeKBTitle, deactivateKB } = useWorkspace()
+  const { bumpActivitySignal, processingDoc, selectedDocUuids, setSelectedDocUuids, selectedDocNames, setSelectedDocNames, selectedFolderUuids, activeKBUuid, activeKBTitle, activateKB, deactivateKB } = useWorkspace()
+  const [convertingToKB, setConvertingToKB] = useState(false)
   const { toast } = useToast()
   const { pills: onboardingPills, isFirstSession, loading: onboardingLoading } = useOnboarding()
   // Lock the first-session flag once it's set so remounts/refetches can't
@@ -184,6 +188,29 @@ export function ChatPanel({ conversationToLoad, pendingMessage, onPendingMessage
     setContextMode('truncated')
     setContextCutoffIndex(result.context_cutoff_index)
     setContextTokens(0)
+  }
+
+  const handleConvertToKB = async () => {
+    const docs = errorDetails?.oversizeDocuments ?? []
+    if (!docs.length) return
+    setConvertingToKB(true)
+    try {
+      const kb = await convertDocumentsToKB(docs.map(d => d.uuid))
+      // Detach the now-oversized docs from the message so retrying with the KB
+      // doesn't immediately re-trigger the same error.
+      setSelectedDocUuids(prev => prev.filter(u => !docs.some(d => d.uuid === u)))
+      setSelectedDocNames(prev => prev.filter((_, i) => !docs.some(d => d.uuid === selectedDocUuids[i])))
+      activateKB(kb.uuid, kb.title)
+      clearError()
+      toast('Converted to Knowledge Base — ask your question again.', 'success')
+    } catch (e) {
+      toast(
+        e instanceof Error ? e.message : 'Could not convert the documents to a Knowledge Base.',
+        'error',
+      )
+    } finally {
+      setConvertingToKB(false)
+    }
   }
 
   const handleScroll = useCallback(() => {
@@ -770,7 +797,33 @@ export function ChatPanel({ conversationToLoad, pendingMessage, onPendingMessage
         )}
 
         {error && (
-          <div className="mt-2 rounded-md bg-red-50 px-3 py-2 text-sm text-red-600">{error}</div>
+          <div className="mt-2 rounded-md bg-red-50 px-3 py-2 text-sm text-red-700 border border-red-200">
+            <div>{error}</div>
+            {errorDetails?.suggestedAction === 'convert_to_kb' && (errorDetails.oversizeDocuments?.length ?? 0) > 0 && (
+              <div className="mt-2 flex items-center gap-2">
+                <button
+                  onClick={handleConvertToKB}
+                  disabled={convertingToKB}
+                  className="inline-flex items-center gap-1.5 rounded-md bg-red-600 px-2.5 py-1 text-xs font-medium text-white hover:bg-red-700 disabled:opacity-60 disabled:cursor-not-allowed"
+                >
+                  {convertingToKB ? (
+                    <>
+                      <Loader2 size={12} className="animate-spin" />
+                      Converting…
+                    </>
+                  ) : (
+                    <>
+                      <BookOpen size={12} />
+                      Convert to Knowledge Base
+                    </>
+                  )}
+                </button>
+                <span className="text-xs text-red-600/80">
+                  Builds a searchable index so chat can read the document a chunk at a time.
+                </span>
+              </div>
+            )}
+          </div>
         )}
 
         {contextNotices.length > 0 && (

--- a/frontend/src/components/chat/ChatPanel.tsx
+++ b/frontend/src/components/chat/ChatPanel.tsx
@@ -198,8 +198,13 @@ export function ChatPanel({ conversationToLoad, pendingMessage, onPendingMessage
       const kb = await convertDocumentsToKB(docs.map(d => d.uuid))
       // Detach the now-oversized docs from the message so retrying with the KB
       // doesn't immediately re-trigger the same error.
-      setSelectedDocUuids(prev => prev.filter(u => !docs.some(d => d.uuid === u)))
-      setSelectedDocNames(prev => prev.filter((_, i) => !docs.some(d => d.uuid === selectedDocUuids[i])))
+      const oversizeUuids = new Set(docs.map(d => d.uuid))
+      setSelectedDocUuids(selectedDocUuids.filter(u => !oversizeUuids.has(u)))
+      const remainingNames: Record<string, string> = {}
+      for (const [uuid, name] of Object.entries(selectedDocNames)) {
+        if (!oversizeUuids.has(uuid)) remainingNames[uuid] = name
+      }
+      setSelectedDocNames(remainingNames)
       activateKB(kb.uuid, kb.title)
       clearError()
       toast('Converted to Knowledge Base — ask your question again.', 'success')

--- a/frontend/src/components/files/FileRow.tsx
+++ b/frontend/src/components/files/FileRow.tsx
@@ -1,4 +1,4 @@
-import { Loader2, MoreHorizontal, AlertTriangle, Shield } from 'lucide-react'
+import { Loader2, MoreHorizontal, AlertTriangle, Shield, AlertCircle } from 'lucide-react'
 import type { Document } from '../../types/document'
 import { formatFileDate } from '../../utils/time'
 
@@ -85,6 +85,15 @@ export function FileRow({ doc, onClick, onContextMenu, selected, onToggleSelect,
               }
             >
               <AlertTriangle className="h-4 w-4 text-red-500" />
+            </span>
+          ) : doc.ingest_error ? (
+            <span
+              className="shrink-0 mr-2.5 inline-flex items-center"
+              role="img"
+              aria-label={`Could not index this document for search: ${doc.ingest_error}. Chat and Knowledge Base retrieval will not work.`}
+              title={`Could not index this document for search: ${doc.ingest_error}. Chat and Knowledge Base retrieval will not work.`}
+            >
+              <AlertCircle className="h-4 w-4 text-amber-500" />
             </span>
           ) : null}
           <div style={{ minWidth: 0, flex: 1 }}>

--- a/frontend/src/components/workspace/WorkflowEditorPanel.tsx
+++ b/frontend/src/components/workspace/WorkflowEditorPanel.tsx
@@ -28,6 +28,7 @@ import type { ValidationCheck, ValidationCheckDefinition, ValidationInputDefinit
 import { ItemPickerModal } from './ItemPickerModal'
 import { getModels } from '../../api/config'
 import { searchDocuments } from '../../api/documents'
+import { convertDocumentsToKB } from '../../api/knowledge'
 import { listCredentials } from '../../api/credentials'
 import type { Credential } from '../../types/credential'
 import { uploadFile } from '../../api/files'
@@ -36,7 +37,7 @@ import { listAllFolders } from '../../api/folders'
 import type { KnowledgeBase } from '../../types/knowledge'
 import { listItems as listSearchSetItems, suggestFields } from '../../api/extractions'
 import { useWorkflowRunner } from '../../hooks/useWorkflowRunner'
-import type { Workflow, WorkflowStep, WorkflowTask, WorkflowStatus, ModelInfo, SearchSetItem } from '../../types/workflow'
+import type { Workflow, WorkflowStep, WorkflowTask, WorkflowStatus, WorkflowCitation, ModelInfo, SearchSetItem } from '../../types/workflow'
 import { DocumentPickerDialog } from '../shared/DocumentPickerDialog'
 import DOMPurify from 'dompurify'
 import { marked } from 'marked'
@@ -4108,12 +4109,124 @@ function WorkflowOutputCard({ status, sessionId, workflowName, running, runElaps
 
       {/* Error */}
       {isError && (
-        <div style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 13, color: '#dc2626', fontWeight: 500 }}>
-          <XCircle style={{ width: 16, height: 16 }} />
-          Failed
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 8, fontSize: 13, color: '#dc2626', fontWeight: 500 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+            <XCircle style={{ width: 16, height: 16 }} />
+            {status?.error || 'Failed'}
+          </div>
+          {status?.error_payload?.suggested_action === 'convert_to_kb' && (status?.error_payload?.oversize_documents?.length ?? 0) > 0 && (
+            <ConvertWorkflowDocsButton
+              docs={status.error_payload?.oversize_documents ?? []}
+            />
+          )}
+        </div>
+      )}
+
+      {/* Sources from KB query steps */}
+      {(status?.retrieved_sources?.length ?? 0) > 0 && (
+        <WorkflowSourcesPanel sources={status?.retrieved_sources ?? []} />
+      )}
+    </div>
+  )
+}
+
+function WorkflowSourcesPanel({ sources }: { sources: WorkflowCitation[] }) {
+  const [expanded, setExpanded] = useState(false)
+  return (
+    <div style={{ marginTop: 4, borderTop: '1px solid #e5e7eb', paddingTop: 8 }}>
+      <button
+        onClick={() => setExpanded(e => !e)}
+        style={{
+          display: 'flex', alignItems: 'center', gap: 4, padding: 0,
+          background: 'transparent', border: 'none', cursor: 'pointer',
+          fontSize: 12, fontWeight: 600, color: '#374151', fontFamily: 'inherit',
+        }}
+      >
+        <ChevronRight
+          size={14}
+          style={{ transform: expanded ? 'rotate(90deg)' : 'rotate(0deg)', transition: 'transform 0.15s' }}
+        />
+        Sources ({sources.length})
+      </button>
+      {expanded && (
+        <div style={{ marginTop: 8, display: 'flex', flexWrap: 'wrap', gap: 6 }}>
+          {sources.map((c, i) => {
+            const locator = typeof c.page === 'number' ? `p. ${c.page}` : (c.sheet || null)
+            const label = locator ? `${c.document_title} · ${locator}` : c.document_title
+            return (
+              <span
+                key={`${c.chunk_id ?? c.document_id ?? i}`}
+                title={c.content_preview || ''}
+                style={{
+                  display: 'inline-flex', alignItems: 'center', gap: 4,
+                  padding: '2px 8px', fontSize: 11, fontWeight: 500,
+                  backgroundColor: '#f3f4f6', color: '#374151',
+                  border: '1px solid #e5e7eb', borderRadius: 999,
+                  cursor: 'help',
+                }}
+              >
+                {label}
+              </span>
+            )
+          })}
         </div>
       )}
     </div>
+  )
+}
+
+function ConvertWorkflowDocsButton({
+  docs,
+}: { docs: Array<{ uuid: string; title: string; token_count: number }> }) {
+  const [converting, setConverting] = useState(false)
+  const [convertedKB, setConvertedKB] = useState<{ uuid: string; title: string } | null>(null)
+  const { toast } = useToast()
+
+  const handleConvert = async () => {
+    setConverting(true)
+    try {
+      const kb = await convertDocumentsToKB(docs.map(d => d.uuid))
+      setConvertedKB({ uuid: kb.uuid, title: kb.title })
+      toast(
+        `Created Knowledge Base "${kb.title}". Add a Knowledge Base Query step to use it.`,
+        'success',
+      )
+    } catch (e) {
+      toast(
+        e instanceof Error ? e.message : 'Could not convert documents to a Knowledge Base.',
+        'error',
+      )
+    } finally {
+      setConverting(false)
+    }
+  }
+
+  if (convertedKB) {
+    return (
+      <div style={{ fontSize: 12, fontWeight: 400, color: '#374151' }}>
+        Knowledge Base <strong>{convertedKB.title}</strong> is being built. Edit the workflow:
+        replace the oversized document(s) with a <strong>Knowledge Base Query</strong> step
+        targeting it.
+      </div>
+    )
+  }
+
+  return (
+    <button
+      onClick={handleConvert}
+      disabled={converting}
+      style={{
+        alignSelf: 'flex-start',
+        display: 'inline-flex', alignItems: 'center', gap: 6,
+        padding: '6px 10px', fontSize: 12, fontWeight: 600, fontFamily: 'inherit',
+        border: '1px solid #dc2626', borderRadius: 6,
+        backgroundColor: '#dc2626', color: '#fff',
+        cursor: converting ? 'not-allowed' : 'pointer',
+        opacity: converting ? 0.6 : 1,
+      }}
+    >
+      {converting ? 'Converting…' : 'Convert to Knowledge Base'}
+    </button>
   )
 }
 

--- a/frontend/src/hooks/useChat.ts
+++ b/frontend/src/hooks/useChat.ts
@@ -1,11 +1,18 @@
 import { useState, useCallback, useRef } from 'react'
 import { streamChat, getHistory } from '../api/chat'
-import type { ChatMessage, ContextBudgetPlan, StreamChunk } from '../types/chat'
+import type { ChatMessage, Citation, ContextBudgetPlan, OversizeDocument, StreamChunk } from '../types/chat'
 
 export interface ContextNotice {
   action: string
   detail: string
   tokens_dropped: number
+}
+
+export interface ChatError {
+  message: string
+  code?: string
+  suggestedAction?: 'convert_to_kb'
+  oversizeDocuments?: OversizeDocument[]
 }
 
 const THINK_BLOCK_RE = /<think(?:ing)?>[\s\S]*?<\/think(?:ing)?>\n?/g
@@ -20,6 +27,7 @@ export function useChat() {
   const [conversationUuid, setConversationUuid] = useState<string | null>(null)
   const [activityId, setActivityId] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
+  const [errorDetails, setErrorDetails] = useState<ChatError | null>(null)
   const [contextTokens, setContextTokens] = useState(0)
   const [contextMode, setContextMode] = useState<'full' | 'truncated' | 'compacted'>('full')
   const [contextCutoffIndex, setContextCutoffIndex] = useState(0)
@@ -29,10 +37,12 @@ export function useChat() {
   const streamingRef = useRef('')
   const thinkingRef = useRef('')
   const thinkingDurationRef = useRef<number | null>(null)
+  const citationsRef = useRef<Citation[]>([])
 
   const send = useCallback(
     async (message: string, documentUuids: string[] = [], model?: string, knowledgeBaseUuid?: string, includeOnboardingContext?: boolean, folderUuids?: string[], isFirstSession?: boolean) => {
       setError(null)
+      setErrorDetails(null)
       setIsStreaming(true)
       setStreamingContent('')
       setThinkingContent('')
@@ -42,6 +52,7 @@ export function useChat() {
       streamingRef.current = ''
       thinkingRef.current = ''
       thinkingDurationRef.current = null
+      citationsRef.current = []
 
       // Add user message immediately
       setMessages((prev) => [...prev, { role: 'user', content: message }])
@@ -75,6 +86,10 @@ export function useChat() {
                   setContextTokens(chunk.plan.total_input_tokens)
                 }
               }
+            } else if (chunk.kind === 'sources') {
+              if (chunk.sources?.length) {
+                citationsRef.current = [...citationsRef.current, ...chunk.sources]
+              }
             } else if (chunk.kind === 'context_notice') {
               setContextNotices((prev) => [
                 ...prev,
@@ -86,6 +101,12 @@ export function useChat() {
               ])
             } else if (chunk.kind === 'error') {
               setError(chunk.content)
+              setErrorDetails({
+                message: chunk.content,
+                code: chunk.code,
+                suggestedAction: chunk.suggested_action,
+                oversizeDocuments: chunk.oversize_documents,
+              })
             }
           },
           model,
@@ -110,6 +131,9 @@ export function useChat() {
             if (thinkingDurationRef.current != null) {
               assistantMsg.thinking_duration = thinkingDurationRef.current
             }
+          }
+          if (citationsRef.current.length) {
+            assistantMsg.citations = citationsRef.current
           }
           setMessages((prev) => [...prev, assistantMsg])
         }
@@ -146,11 +170,17 @@ export function useChat() {
     setConversationUuid(null)
     setActivityId(null)
     setError(null)
+    setErrorDetails(null)
     setContextTokens(0)
     setContextMode('full')
     setContextCutoffIndex(0)
     setContextPlan(null)
     setContextNotices([])
+  }, [])
+
+  const clearError = useCallback(() => {
+    setError(null)
+    setErrorDetails(null)
   }, [])
 
   const setActivity = useCallback((newActivityId: string, newConversationUuid: string) => {
@@ -168,6 +198,8 @@ export function useChat() {
     conversationUuid,
     activityId,
     error,
+    errorDetails,
+    clearError,
     contextTokens,
     contextMode,
     contextCutoffIndex,

--- a/frontend/src/types/chat.ts
+++ b/frontend/src/types/chat.ts
@@ -3,6 +3,7 @@ export interface ChatMessage {
   content: string
   thinking?: string
   thinking_duration?: number
+  citations?: Citation[]
 }
 
 export interface FileAttachment {
@@ -62,6 +63,22 @@ export interface ContextBudgetPlan {
   headroom_tokens: number
 }
 
+export interface OversizeDocument {
+  uuid: string
+  title: string
+  token_count: number
+}
+
+export interface Citation {
+  document_id?: string | null
+  document_title: string
+  page?: number | null
+  sheet?: string | null
+  chunk_id?: string | null
+  score?: number | null
+  content_preview?: string
+}
+
 export interface StreamChunk {
   kind:
     | 'text'
@@ -71,6 +88,7 @@ export interface StreamChunk {
     | 'usage'
     | 'context_budget'
     | 'context_notice'
+    | 'sources'
   content: string
   duration?: number
   request_tokens?: number
@@ -79,4 +97,10 @@ export interface StreamChunk {
   plan?: ContextBudgetPlan
   action?: string
   tokens_dropped?: number
+  // Error-only: machine-readable failure code + optional suggested recovery.
+  code?: string
+  suggested_action?: 'convert_to_kb'
+  oversize_documents?: OversizeDocument[]
+  // sources kind only: citation list emitted before the LLM streams text.
+  sources?: Citation[]
 }

--- a/frontend/src/types/document.ts
+++ b/frontend/src/types/document.ts
@@ -18,6 +18,9 @@ export interface Document {
   classified_by?: string | null
   retention_hold?: boolean
   soft_deleted?: boolean
+  chromadb_ready?: boolean
+  chunk_count?: number
+  ingest_error?: string | null
 }
 
 export interface Folder {

--- a/frontend/src/types/workflow.ts
+++ b/frontend/src/types/workflow.ts
@@ -79,6 +79,22 @@ export interface Workflow {
   created_by?: AuthorRef | null;
 }
 
+export interface WorkflowErrorPayload {
+  code: string;
+  suggested_action?: 'convert_to_kb';
+  oversize_documents?: Array<{ uuid: string; title: string; token_count: number }>;
+}
+
+export interface WorkflowCitation {
+  document_id?: string | null;
+  document_title: string;
+  page?: number | null;
+  sheet?: string | null;
+  chunk_id?: string | null;
+  score?: number | null;
+  content_preview?: string;
+}
+
 export interface WorkflowStatus {
   status: string;
   num_steps_completed: number;
@@ -90,6 +106,9 @@ export interface WorkflowStatus {
   steps_output: Record<string, unknown> | null;
   output_step_names: string[];
   approval_request_id: string | null;
+  error?: string | null;
+  error_payload?: WorkflowErrorPayload | null;
+  retrieved_sources?: WorkflowCitation[];
 }
 
 export interface ModelInfo {


### PR DESCRIPTION
## Summary
Closes the silent-failure gap when users attach a too-large reference document (the PAPPG case): the system now refuses the LLM call pre-flight, surfaces a structured error with a "Convert to Knowledge Base" action, and — once retrieval is in use — labels every cited chunk with its source page or sheet.

## Why this change
Before this PR, attaching PAPPG (≈77k tokens) to a chat or workflow with a 64k-window model produced a mid-step 400 from the LLM gateway. The Knowledge Base infrastructure already existed but was an undiscovered concept users had to find on their own. Even when they did, retrieved answers had no provenance — chunks came back labeled `chunk 47` instead of `p. 234`, so a research administrator couldn't verify the answer against the source.

This PR closes both gaps. It is Phase 0 of the doc-retrieval unification plan plus the citation slice of Phase 1. Document versioning, admin observability of `chromadb_ready`, and intent-based scan-vs-lookup classification remain deferred pending oversize-frequency telemetry from this release.

## What changed

**Pre-flight oversize + Convert-to-KB**
- `find_oversize_documents()` in `context_budget.py` — single source of truth for "this doc alone won't fit." Used by both chat and workflows.
- `SmartDocument` gains `chromadb_ready`, `chunk_count`, `ingest_error`. `perform_semantic_ingestion` writes those back so the document list can show a distinct amber icon for retrieval-broken docs (different from the existing red `!doc.valid` icon).
- Chat: the existing context-budget fatal branch emits `{kind: "error", code: "context_over_budget_convertible", suggested_action, oversize_documents}` when the over-budget request has at least one individually-oversized attachment. `ChatPanel` renders a Convert-to-KB button on the banner.
- Workflows: pre-flight in `workflow_tasks.py` before `engine.execute()` refuses the run cleanly and writes `error_payload` to `WorkflowResult`. `WorkflowEditorPanel` renders the same button on the failed output card.
- New `POST /api/knowledge/convert_documents` — wraps the existing `create_knowledge_base` + `add_documents` services into a one-call action. Activates the new KB in workspace context on success.

**Page-level citations end-to-end**
- `document_readers.extract_text_with_markers(path, ext) → (text, markers)`. PDFs that go through OCR get markers interpolated against PyMuPDF's page count (the OCR endpoint doesn't preserve page structure). PyMuPDF-direct PDFs get exact page boundaries. XLSX recovers per-sheet markers from the existing extractor.
- `SmartDocument.text_markers` persists those between extraction and ingestion tasks.
- `_split_text_with_offsets` and `_location_for_offset` in `document_manager.py` map each chunk's start position to a marker, so per-chunk ChromaDB metadata now carries `page` (int) or `sheet` (str).
- `query_documents` / `query_kb` return `chunk_id` and `score` alongside content + metadata.
- `KnowledgeBaseQueryNode` returns `retrieved_sources` on its step output. The engine propagates it through `data`; `workflow_tasks` aggregates across steps onto `WorkflowResult.retrieved_sources`. Status response surfaces it for the frontend.
- `chat_service` emits a `kind="sources"` stream chunk when KB context is used.
- `ChatMessage` renders a "Sources:" pill row under the assistant message ("PAPPG · p. 234"). `WorkflowEditorPanel` renders a collapsible "Sources (N)" panel under the workflow output card. Both show the chunk preview on hover.

## Test plan
- [ ] **Backend**: `make backend-ci` (203/203 affected suites pass locally; ruff clean)
- [ ] **Frontend**: `npm run typecheck`, `npm run lint` (clean locally)
- [ ] **Manual — oversize chat**: re-upload PAPPG, attach to a fresh chat with a ~64k-window model, send a message → expect the inline error banner with the Convert-to-KB button instead of a raw 400. Click the button → KB activates → resend the message → expect a normal answer with citation chips.
- [ ] **Manual — oversize workflow**: build a workflow with PAPPG as a fixed input on a Prompt step, run it → expect status `error` with `error_payload.suggested_action="convert_to_kb"` and the Convert-to-KB button on the output card.
- [ ] **Manual — citations**: re-ingest PAPPG (Phase 1 fields require re-extraction), convert to KB, ask a chat question about cost-share → confirm sources chips show `PAPPG · p. N` and the page numbers are in a plausible range (PAPPG cost-share is around §II.D, so chips should land in the 200s).
- [ ] **Manual — XLSX citations**: upload a multi-sheet workbook to a KB, ask a question whose answer is on a specific sheet → confirm the citation shows `Filename · SheetName`.
- [ ] **Manual — ingest-failure icon**: simulate a ChromaDB write failure (kill the chroma container during ingest) → confirm the file browser shows the amber `AlertCircle` icon with `ingest_error` in the tooltip, distinct from the red `AlertTriangle` for `!doc.valid`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)