### PR TITLE
Stop /mgmt/v1/stats from choking on legacy stub SmartDocument records

### DIFF
--- a/backend/app/routers/mgmt.py
+++ b/backend/app/routers/mgmt.py
@@ -231,9 +231,15 @@ async def stats(_: ApiKey = Depends(require_mgmt_scope("metrics:read"))):
     ).count()
 
     # Aggregate token-count bytes proxy: doc reader doesn't store size, so use
-    # a coarse aggregate of token_count (proxy for content volume).
-    docs = await SmartDocument.find_all().to_list()
-    documents_size_bytes_total = sum(d.token_count for d in docs) * 4  # ~4 bytes/token
+    # a coarse aggregate of token_count (proxy for content volume). Run this
+    # in MongoDB rather than materializing every SmartDocument — older stub
+    # records in production are missing required fields and would trip Beanie
+    # validation on the way through `to_list()`.
+    token_agg = await SmartDocument.aggregate(
+        [{"$group": {"_id": None, "total_tokens": {"$sum": "$token_count"}}}],
+    ).to_list()
+    total_tokens = int(token_agg[0].get("total_tokens", 0)) if token_agg else 0
+    documents_size_bytes_total = total_tokens * 4  # ~4 bytes/token
 
     active_user_ids = await ActivityEvent.find(
         {"started_at": {"$gte": cutoff_30d}}

--- a/backend/tests/test_mgmt_api.py
+++ b/backend/tests/test_mgmt_api.py
@@ -165,6 +165,12 @@ class TestRequireMgmtScope:
                     count=AsyncMock(return_value=0),
                     distinct=AsyncMock(return_value=[]),
                 ))
+            # /stats now sums token_count via a Beanie aggregation rather than
+            # materializing every document — older stub records in prod can be
+            # missing required SmartDocument fields and trip Beanie validation.
+            MockDoc.aggregate = MagicMock(return_value=MagicMock(
+                to_list=AsyncMock(return_value=[]),
+            ))
             resp = await client.get(
                 "/api/mgmt/v1/stats",
                 headers={"X-API-Key": "vk_live_wildcard"},
@@ -176,6 +182,51 @@ class TestRequireMgmtScope:
         body = resp.json()
         assert body["users_total"] == 0
         assert "generated_at" in body
+
+    @pytest.mark.asyncio
+    async def test_stats_uses_aggregation_for_token_sum(self, client):
+        """The token-bytes total comes from a MongoDB aggregation, not from
+        materializing every SmartDocument. Regression for Sentry 7479098685:
+        legacy stub records missing required fields would otherwise crash the
+        endpoint with Beanie ValidationError."""
+        wildcard = _make_key(scopes=["*"])
+        with (
+            patch("app.dependencies.ApiKey") as MockKey,
+            patch("app.dependencies.audit_service.log_event", new_callable=AsyncMock),
+            patch("app.routers.mgmt.User") as MockUser,
+            patch("app.routers.mgmt.Team") as MockTeam,
+            patch("app.routers.mgmt.SmartDocument") as MockDoc,
+            patch("app.routers.mgmt.Workflow") as MockWorkflow,
+            patch("app.routers.mgmt.WorkflowResult") as MockWR,
+            patch("app.routers.mgmt.ActivityEvent") as MockAct,
+        ):
+            MockKey.find_one = AsyncMock(return_value=wildcard)
+            for M in (MockUser, MockTeam, MockDoc, MockWorkflow, MockWR, MockAct):
+                M.find_all = MagicMock(return_value=MagicMock(
+                    count=AsyncMock(return_value=0),
+                    to_list=AsyncMock(return_value=[]),
+                ))
+                M.find = MagicMock(return_value=MagicMock(
+                    count=AsyncMock(return_value=0),
+                    distinct=AsyncMock(return_value=[]),
+                ))
+            aggregate_mock = MagicMock(return_value=MagicMock(
+                to_list=AsyncMock(return_value=[{"_id": None, "total_tokens": 1_000_000}]),
+            ))
+            MockDoc.aggregate = aggregate_mock
+
+            resp = await client.get(
+                "/api/mgmt/v1/stats",
+                headers={"X-API-Key": "vk_live_wildcard"},
+            )
+
+        assert resp.status_code == 200
+        # The endpoint asked Mongo to sum token_count, not Python.
+        aggregate_mock.assert_called_once()
+        pipeline = aggregate_mock.call_args.args[0]
+        assert pipeline == [{"$group": {"_id": None, "total_tokens": {"$sum": "$token_count"}}}]
+        # 1M tokens * 4 bytes/token = 4M bytes.
+        assert resp.json()["documents_size_bytes_total"] == 4_000_000
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Production Sentry 7479098685: `GET /api/mgmt/v1/stats` raised `ValidationError` because a few legacy SmartDocument records in production are missing required fields (`path`, `downloadpath`, `title`, `uuid`). The endpoint loaded every document via `SmartDocument.find_all().to_list()`, so Beanie's `model_validate` rejected the first stub it hit and the whole stats response blew up.
- Switch the token-bytes total to a MongoDB aggregation (`$sum: "$token_count"`). The endpoint only ever needed one field — it doesn't need to materialize each doc as a Beanie model. The aggregation skips validation entirely, and it's also cheaper than loading 1500+ documents.
- Added a regression test that asserts the endpoint asks Mongo to compute the sum (not Python), and updated the existing wildcard-scope test to mock the new `aggregate()` call.

Not addressed here: how the stub records got into the database in the first place. Worth investigating separately — likely a partial-write path or a script that touches classification/retention fields without setting the rest. The stats endpoint shouldn't care either way.

## Test plan
- [x] `pytest backend/tests/test_mgmt_api.py` — 17/17 pass locally including the new regression
- [ ] Hit `/api/mgmt/v1/stats` on staging with the same API key that produced the Sentry error → expect a 200 with a non-zero `documents_size_bytes_total`

🤖 Generated with [Claude Code](https://claude.com/claude-code)