### PR TITLE
Inject Sentry config into the frontend Docker build

### DIFF
--- a/.github/workflows/build-container.yaml
+++ b/.github/workflows/build-container.yaml
@@ -55,7 +55,13 @@ jobs:
         with:
           context: ${{ matrix.context }}
           push: true
+          # The Sentry args are only consumed by the frontend Dockerfile;
+          # the backend image declares no matching ARG and ignores them.
+          # Empty secrets pass through as empty strings, which makes
+          # initSentry() a no-op rather than failing the build.
           build-args: |
             VERSION=sha-${{ steps.vars.outputs.sha_short }}
+            VITE_SENTRY_DSN=${{ secrets.VITE_SENTRY_DSN }}
+            VITE_SENTRY_ENVIRONMENT=${{ vars.VITE_SENTRY_ENVIRONMENT || 'staging' }}
           tags: ghcr.io/${{ github.repository }}-${{ matrix.image_name }}:sha-${{ steps.vars.outputs.sha_short }},ghcr.io/${{ github.repository }}-${{ matrix.image_name }}:${{ steps.vars.outputs.ref_name }}
           file: ${{ matrix.dockerfile }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -63,8 +63,14 @@ jobs:
           context: ${{ matrix.context }}
           file: ${{ matrix.dockerfile }}
           push: true
+          # The Sentry args are only consumed by the frontend Dockerfile;
+          # the backend image declares no matching ARG and ignores them.
+          # Empty secrets pass through as empty strings, which makes
+          # initSentry() a no-op rather than failing the build.
           build-args: |
             VERSION=${{ github.ref_name }}
+            VITE_SENTRY_DSN=${{ secrets.VITE_SENTRY_DSN }}
+            VITE_SENTRY_ENVIRONMENT=production
           tags: ghcr.io/${{ github.repository }}-${{ matrix.image_name }}:${{ github.ref_name }}
           labels: |
             org.opencontainers.image.source=https://github.com/${{ github.repository }}

--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,12 @@ ci: backend-ci frontend-ci
 
 docker-build:
 	docker build -t vandalizer-backend ./backend
-	docker build -t vandalizer-frontend ./frontend
+	# Forward Sentry build-args from the shell. Unset vars expand to empty,
+	# which makes initSentry() a no-op (matches the no-DSN dev case).
+	docker build \
+		--build-arg VITE_SENTRY_DSN="$$VITE_SENTRY_DSN" \
+		--build-arg VITE_SENTRY_ENVIRONMENT="$$VITE_SENTRY_ENVIRONMENT" \
+		--build-arg VITE_SENTRY_RELEASE="$$VITE_SENTRY_RELEASE" \
+		-t vandalizer-frontend ./frontend
 
 release-check: backend-static ci docker-build

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -3,6 +3,21 @@ FROM node:22-alpine AS builder
 
 WORKDIR /app
 
+# Build-time configuration. Vite reads VITE_-prefixed env vars at compile
+# time, so we accept these as build args and re-export them as ENV before
+# `npm run build`. `.env` files are excluded from the build context via
+# `.dockerignore`, so this is the only way the bundle picks them up.
+ARG VITE_SENTRY_DSN
+ARG VITE_SENTRY_ENVIRONMENT
+ARG VITE_SENTRY_RELEASE
+# `VERSION` is already passed by the release / build-container workflows;
+# reuse it as the Sentry release identifier when one isn't supplied so
+# errors group correctly per deploy.
+ARG VERSION
+ENV VITE_SENTRY_DSN=${VITE_SENTRY_DSN} \
+    VITE_SENTRY_ENVIRONMENT=${VITE_SENTRY_ENVIRONMENT} \
+    VITE_SENTRY_RELEASE=${VITE_SENTRY_RELEASE:-${VERSION}}
+
 COPY package.json package-lock.json ./
 RUN npm ci
 


### PR DESCRIPTION
## Summary
Frontend Sentry has been silent since it shipped. Root cause: Vite reads `VITE_*` env vars at compile time, and the Docker build never had them.

- `frontend/.dockerignore` blocks `.env` and `.env.*` from the build context — correct, secrets don't belong in image layers.
- `frontend/Dockerfile` didn't declare any matching `ARG`s, so even passed build-args wouldn't reach the bundle.
- The `Makefile` `docker-build` target didn't pass `--build-arg`.
- Both `release.yaml` and `build-container.yaml` only forwarded `VERSION`, not the Sentry secrets.

End result: `import.meta.env.VITE_SENTRY_DSN` evaluated to `undefined` in every built bundle, `initSentry()` short-circuited at `frontend/src/lib/sentry.ts:5`, and `Sentry.init` never ran. The `<ErrorBoundary>` in `App.tsx` calls `Sentry.captureException` but with the SDK uninitialized that's a no-op.

## What changed
- **`frontend/Dockerfile`**: declare `ARG VITE_SENTRY_DSN`, `VITE_SENTRY_ENVIRONMENT`, `VITE_SENTRY_RELEASE`, and re-export them as `ENV` before `npm run build` so Vite picks them up. Default `VITE_SENTRY_RELEASE` to the existing `VERSION` build-arg so each deploy groups its errors under a meaningful release tag.
- **`Makefile`**: forward `$VITE_SENTRY_DSN` / `$VITE_SENTRY_ENVIRONMENT` / `$VITE_SENTRY_RELEASE` from the caller's shell into `docker build --build-arg`. Unset vars expand to empty, which makes the build a no-op for local devs who don't have Sentry configured.
- **`.github/workflows/release.yaml`** and **`build-container.yaml`**: extend the existing `build-args` block with `VITE_SENTRY_DSN=${{ secrets.VITE_SENTRY_DSN }}` and an environment label. The backend image declares no matching `ARG` and silently ignores the extra args from the shared matrix step. `build-container.yaml` also reads an optional `vars.VITE_SENTRY_ENVIRONMENT` so non-tag builds can label themselves `staging` instead of `production`.

## Setup required after merge
- [ ] Add `VITE_SENTRY_DSN` under repo Settings → Secrets and variables → Actions (your DSN value, the one currently in your local `.env`).
- [ ] *(Optional)* Add `VITE_SENTRY_ENVIRONMENT` under repo *Variables* (not Secrets) if you want non-tag builds labeled `staging` rather than the hardcoded fallback.

## Test plan
- [x] Local Vite build with `VITE_SENTRY_DSN=...` in the environment → grep'd the resulting `dist/assets/*.js` for the DSN token → present
- [x] `docker build --build-arg VITE_SENTRY_DSN=... --build-arg VERSION=test-sha ./frontend` → `docker run` + `grep` inside `/usr/share/nginx/html/assets/*.js` → both the DSN and the release identifier are baked into the served bundle
- [ ] After merge: confirm the next deploy's bundle ships with the DSN (DevTools → Sources → look for the DSN string in the main chunk), then throw a deliberate error in the browser and watch Sentry receive it

🤖 Generated with [Claude Code](https://claude.com/claude-code)