### PR TITLE
Show submitter name across verification management

### DIFF
--- a/backend/app/services/verification_service.py
+++ b/backend/app/services/verification_service.py
@@ -16,6 +16,8 @@ from app.models.knowledge import KnowledgeBase
 from app.models.system_config import SystemConfig
 from app.models.workflow import Workflow
 from app.models.search_set import SearchSet
+from app.schemas.user import AuthorRef
+from app.services.user_lookup import resolve_author, resolve_authors
 
 
 async def submit_for_verification(
@@ -139,7 +141,8 @@ async def submit_for_verification(
         validation_tier=validation_tier,
     )
     await req.insert()
-    return await _request_to_dict(req)
+    submitter_ref = await resolve_author(user_id)
+    return await _request_to_dict(req, submitter_ref=submitter_ref)
 
 
 async def list_queue(
@@ -147,6 +150,7 @@ async def list_queue(
     limit: int = 50,
 ) -> list[dict]:
     """List verification requests (for reviewers)."""
+
     query: dict = {}
     if status_filter:
         query["status"] = status_filter
@@ -157,9 +161,10 @@ async def list_queue(
         ]}
 
     requests = await VerificationRequest.find(query).sort("-submitted_at").limit(limit).to_list()
+    author_map = await resolve_authors(r.submitter_user_id for r in requests)
     results = []
     for req in requests:
-        d = await _request_to_dict(req)
+        d = await _request_to_dict(req, submitter_ref=author_map.get(req.submitter_user_id))
         # Attach item name
         d["item_name"] = await _get_item_name(req.item_kind, req.item_id)
         results.append(d)
@@ -168,10 +173,12 @@ async def list_queue(
 
 async def get_request(request_uuid: str) -> dict | None:
     """Get a single verification request by UUID."""
+
     req = await VerificationRequest.find_one(VerificationRequest.uuid == request_uuid)
     if not req:
         return None
-    d = await _request_to_dict(req)
+    submitter_ref = await resolve_author(req.submitter_user_id)
+    d = await _request_to_dict(req, submitter_ref=submitter_ref)
     d["item_name"] = await _get_item_name(req.item_kind, req.item_id)
     return d
 
@@ -225,20 +232,23 @@ async def update_status(
             for cid in collection_ids:
                 await add_to_collection(cid, str(req.item_id))
 
-    return await _request_to_dict(req)
+    submitter_ref = await resolve_author(req.submitter_user_id)
+    return await _request_to_dict(req, submitter_ref=submitter_ref)
 
 
 async def my_requests(user_id: str, limit: int = 50) -> list[dict]:
     """List a user's own verification requests."""
+
     requests = (
         await VerificationRequest.find(VerificationRequest.submitter_user_id == user_id)
         .sort("-submitted_at")
         .limit(limit)
         .to_list()
     )
+    submitter_ref = await resolve_author(user_id)
     results = []
     for req in requests:
-        d = await _request_to_dict(req)
+        d = await _request_to_dict(req, submitter_ref=submitter_ref)
         d["item_name"] = await _get_item_name(req.item_kind, req.item_id)
         results.append(d)
     return results
@@ -480,9 +490,28 @@ async def list_verified_items(
     for m in all_meta:
         meta_map[(m.item_kind, m.item_id)] = m
 
-    # --- Batch-resolve workflow authors ---
-    from app.services.user_lookup import resolve_authors
-    author_map = await resolve_authors(wf_creator_map.values())
+    # --- Batch-resolve submitters from latest approved VerificationRequest per item ---
+    all_object_ids = [i.item_id for i in items]
+    submitter_user_map: dict[tuple[str, str], str] = {}
+    if all_object_ids:
+        approved_reqs = (
+            await VerificationRequest.find(
+                {
+                    "item_id": {"$in": all_object_ids},
+                    "status": VerificationStatus.APPROVED.value,
+                }
+            )
+            .sort("-reviewed_at")
+            .to_list()
+        )
+        for req in approved_reqs:
+            key = (req.item_kind, str(req.item_id))
+            # First occurrence is the latest (sorted desc)
+            submitter_user_map.setdefault(key, req.submitter_user_id)
+
+    # --- Batch-resolve workflow authors + submitters in one shot ---
+    all_user_ids = list(wf_creator_map.values()) + list(submitter_user_map.values())
+    author_map = await resolve_authors(all_user_ids)
 
     # --- Batch-fetch KB metrics ---
     kb_map: dict[str, KnowledgeBase] = {}
@@ -521,6 +550,9 @@ async def list_verified_items(
         if quality_tier and item_tier != quality_tier:
             continue
 
+        submitter_id = submitter_user_map.get((item.kind.value, item_id_str))
+        submitter_ref = author_map.get(submitter_id) if submitter_id else None
+
         entry = {
             "id": str(item.id),
             "item_id": item_id_str,
@@ -538,6 +570,7 @@ async def list_verified_items(
             "quality_grade": meta.quality_grade if meta else None,
             "last_validated_at": meta.last_validated_at.isoformat() if meta and meta.last_validated_at else None,
             "validation_run_count": meta.validation_run_count if meta else 0,
+            "submitted_by": submitter_ref.model_dump() if submitter_ref else None,
         }
 
         # KB-specific metrics (from batch)
@@ -946,7 +979,10 @@ async def _get_item_name(item_kind: str, item_id: PydanticObjectId) -> str:
         return ss.title if ss else "Unknown extraction"
 
 
-async def _request_to_dict(req: VerificationRequest) -> dict:
+async def _request_to_dict(
+    req: VerificationRequest,
+    submitter_ref: AuthorRef | None = None,
+) -> dict:
     # Resolve item_uuid for search_set and knowledge_base items
     item_uuid = None
     if req.item_kind == "search_set":
@@ -969,6 +1005,7 @@ async def _request_to_dict(req: VerificationRequest) -> dict:
         "submitter_name": req.submitter_name,
         "submitter_org": req.submitter_org,
         "submitter_role": req.submitter_role,
+        "submitter": submitter_ref.model_dump() if submitter_ref else None,
         "summary": req.summary,
         "description": req.description,
         "category": req.category,

--- a/backend/tests/test_verification_service.py
+++ b/backend/tests/test_verification_service.py
@@ -181,6 +181,17 @@ def _chain_query(*items):
     return chain
 
 
+@pytest.fixture(autouse=True)
+def _stub_author_resolvers():
+    """The service module pulls in resolve_author/resolve_authors at import time
+    to attach submitter AuthorRefs to verification dicts. These require a live
+    Beanie-initialized User collection, which the unit tests don't provide. Stub
+    them out so the existing serialization tests stay focused on their subject."""
+    with patch(f"{MODULE}.resolve_author", new_callable=AsyncMock, return_value=None), \
+         patch(f"{MODULE}.resolve_authors", new_callable=AsyncMock, return_value={}):
+        yield
+
+
 # ---------------------------------------------------------------------------
 # _request_to_dict
 # ---------------------------------------------------------------------------

--- a/frontend/src/components/library/CollectionsManager.tsx
+++ b/frontend/src/components/library/CollectionsManager.tsx
@@ -5,6 +5,7 @@ import {
   addToCollection, removeFromCollection, listVerifiedItems,
 } from '../../api/library'
 import type { VerifiedCollection, VerifiedCatalogItem } from '../../types/library'
+import { AuthorChip } from '../shared/AuthorChip'
 import { useOptionalWorkspace } from '../../contexts/WorkspaceContext'
 import { useConfirm } from '../shared/useConfirm'
 
@@ -334,6 +335,9 @@ export function CollectionsManager() {
                                   }`}>
                                     {item.quality_tier}
                                   </span>
+                                )}
+                                {item?.submitted_by && (
+                                  <AuthorChip author={item.submitted_by} label="by" />
                                 )}
                               </div>
                               <div className="flex items-center gap-1 shrink-0">

--- a/frontend/src/components/library/VerificationQueue.tsx
+++ b/frontend/src/components/library/VerificationQueue.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from '@tanstack/react-router'
 import { ShieldCheck, Clock, Search, ChevronDown, ChevronRight, Tag, FileText, ExternalLink } from 'lucide-react'
 import { listVerificationQueue, myVerificationRequests, updateVerificationStatus, listCollections } from '../../api/library'
 import type { VerificationRequest, VerificationStatus, VerifiedCollection } from '../../types/library'
+import { AuthorChip } from '../shared/AuthorChip'
 import { listOrganizationsFlat } from '../../api/organizations'
 import type { Organization } from '../../api/organizations'
 
@@ -146,6 +147,8 @@ export function VerificationQueue() {
         (r.item_name || '').toLowerCase().includes(q) ||
         (r.summary || '').toLowerCase().includes(q) ||
         (r.submitter_name || '').toLowerCase().includes(q) ||
+        (r.submitter?.name || '').toLowerCase().includes(q) ||
+        (r.submitter?.email || '').toLowerCase().includes(q) ||
         (r.description || '').toLowerCase().includes(q)
       )
     }
@@ -259,9 +262,13 @@ export function VerificationQueue() {
                           </span>
                         )}
                       </div>
-                      <div className="text-xs text-gray-500 space-x-3 ml-9">
+                      <div className="text-xs text-gray-500 ml-9 flex items-center gap-3 flex-wrap">
                         <span>{req.item_kind === 'workflow' ? 'Workflow' : req.item_kind === 'knowledge_base' ? 'Knowledge Base' : 'Extraction'}</span>
-                        {req.submitter_name && <span>by {req.submitter_name}</span>}
+                        {req.submitter ? (
+                          <AuthorChip author={req.submitter} label="by" />
+                        ) : req.submitter_name ? (
+                          <span>by {req.submitter_name}</span>
+                        ) : null}
                         {req.submitter_org && <span>({req.submitter_org})</span>}
                         {req.submitted_at && (
                           <span>

--- a/frontend/src/components/library/VerifiedCatalog.tsx
+++ b/frontend/src/components/library/VerifiedCatalog.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { Search, ShieldCheck, X, Pencil, ShieldOff, Tag, FolderPlus, Download, Upload } from 'lucide-react'
 import { QualityContractBadge } from './QualityContractBadge'
 import { CatalogImportDialog } from './CatalogImportDialog'
+import { AuthorChip } from '../shared/AuthorChip'
 import { listVerifiedItems, updateItemMetadata, unverifyItem, listCollections, addToCollection, exportCatalogUrl, previewCatalogImport } from '../../api/library'
 import type { CatalogPreviewItem } from '../../api/library'
 import type { VerifiedCatalogItem, VerifiedCollection } from '../../types/library'
@@ -426,6 +427,9 @@ export function VerifiedCatalog() {
                       <span className="text-xs text-gray-500">
                         {new Date(item.created_at).toLocaleDateString()}
                       </span>
+                    )}
+                    {item.submitted_by && (
+                      <AuthorChip author={item.submitted_by} label="by" />
                     )}
                   </div>
                   {item.description && (

--- a/frontend/src/types/library.ts
+++ b/frontend/src/types/library.ts
@@ -62,6 +62,7 @@ export interface VerificationRequest {
   status: VerificationStatus
   submitter_user_id: string
   submitter_name: string | null
+  submitter: AuthorRef | null
   submitter_org?: string | null
   submitter_role?: string | null
   summary: string | null
@@ -126,6 +127,7 @@ export interface VerifiedCatalogItem {
   kb_status?: string
   source_uuid?: string
   created_by?: AuthorRef | null
+  submitted_by?: AuthorRef | null
 }
 
 export interface VerifiedCollection {


### PR DESCRIPTION
## Summary
- Resolve the verification submitter from the User record on the backend and emit it as an `AuthorRef`, so the queue, verified catalog, and collections views can attribute every item to a real person — and link to their email — instead of relying on the optional `submitter_name` form field.
- `list_verified_items` now batch-fetches the latest approved `VerificationRequest` per catalog item and attaches a `submitted_by` author chip to workflows, extractions, and knowledge bases alike (previously only workflows showed creator info).
- The Verification Queue now prefers the resolved submitter (falling back to the legacy `submitter_name` string), and the search box matches the resolved name/email too.

## Test plan
- [x] `pytest tests/test_verification_service.py tests/test_verification_routes.py` — 66 passed
- [x] `npx tsc --noEmit` in `frontend/` — clean
- [ ] Manual: open `/verification` as an examiner, confirm the Queue, Catalog, and Collections tabs each show a "by <Name>" chip on submissions (with a mail link when the user has an email)
- [ ] Manual: submit a verification request leaving the form's "submitter name" field blank, confirm the queue still shows the submitter's name from their user account