### PR TITLE
Stop global drop guard from cancelling in-app reorder drags

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -55,13 +55,18 @@ class ErrorBoundary extends Component<
 function useGlobalDropPrevention() {
   useEffect(() => {
     // Prevent the browser from opening/downloading files when dropped outside a drop zone.
-    // Use bubble phase (not capture) so React drop handlers run first and can
-    // stopPropagation before these fallback handlers fire.
+    // Only intervene for OS file drags — in-app element drags (extraction reorder,
+    // org tree, etc.) have no 'Files' type and rely on the default drop behavior,
+    // so forcing dropEffect to 'none' on them would silently cancel the drop.
+    const isFileDrag = (e: DragEvent) =>
+      !!e.dataTransfer && Array.from(e.dataTransfer.types).includes('Files')
     const preventDragOver = (e: DragEvent) => {
+      if (!isFileDrag(e)) return
       e.preventDefault()
       if (e.dataTransfer) e.dataTransfer.dropEffect = 'none'
     }
     const preventDrop = (e: DragEvent) => {
+      if (!isFileDrag(e)) return
       e.preventDefault()
     }
     document.addEventListener('dragover', preventDragOver as EventListener)


### PR DESCRIPTION
## Problem

Reordering items in an extraction task: the user could pull a row but on release nothing happened. The drag was visibly initiated, then silently cancelled.

## Cause

\`useGlobalDropPrevention\` in \`App.tsx\` (added 2026-03-23, commit 36f539bb) was set up to stop the browser from opening OS files dropped outside a drop zone. But it ran for **every** drag and set \`dataTransfer.dropEffect = 'none'\` on \`dragover\`. The row handlers in \`ExtractionEditorPanel.tsx\` don't call \`stopPropagation\`, so the global listener fired on the bubble pass, the browser saw \`dropEffect = 'none'\`, and cancelled the drop. The \`drop\` event never fired.

The admin org-tree drag in \`Admin.tsx\` had the same latent breakage.

## Fix

Filter the global handler so it only intercepts drags whose \`dataTransfer.types\` includes \`'Files'\` — i.e. real OS file drops. In-app element drags (which have no \`Files\` type) pass through untouched and their row-level handlers work as written.

## Test plan

- Open an extraction, reorder items by dragging the grip handle — order updates and persists.
- In Admin, drag an org node onto another to reparent — still works.
- Drag a file from the OS onto a non-drop-zone area of the app — browser still does **not** open the file.
- Drag a file from the OS onto the file browser panel — upload still triggers.