### PR TITLE
Share-link deep links for workflows, extractions, and KBs

### DIFF
--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -169,6 +169,15 @@ async def register(
             detail="Registration failed. Please check your details and try again.",
         )
 
+    if settings.enable_trial_system:
+        from app.services.demo_service import TRIAL_DAYS
+
+        now = datetime.datetime.now(datetime.timezone.utc)
+        user.is_demo_user = True
+        user.demo_expires_at = now + datetime.timedelta(days=TRIAL_DAYS)
+        user.demo_status = "active"
+        await user.save()
+
     # If the user was signing up to accept a team invite, auto-accept it.
     # Only accepts when the registered email matches the invite's recipient
     # email — otherwise silently ignore and let them accept manually later.

--- a/frontend/src/components/auth/ProtectedRoute.tsx
+++ b/frontend/src/components/auth/ProtectedRoute.tsx
@@ -16,7 +16,16 @@ export function ProtectedRoute({ children }: { children: React.ReactNode }) {
     )
   }
 
-  if (!user) return <Navigate to="/landing" search={{ error: undefined, invite_token: undefined, admin: undefined }} />
+  if (!user) {
+    const here = window.location.pathname + window.location.search
+    const next = here && here !== '/' && !here.startsWith('/landing') ? here : undefined
+    return (
+      <Navigate
+        to="/landing"
+        search={{ error: undefined, invite_token: undefined, admin: undefined, next }}
+      />
+    )
+  }
 
   if (demoExpired && demoFeedbackToken) {
     return <Navigate to="/demo/feedback" search={{ token: demoFeedbackToken }} />

--- a/frontend/src/components/chat/ChatPanel.tsx
+++ b/frontend/src/components/chat/ChatPanel.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState, useCallback, type DragEvent } from 'react'
-import { Loader2, BookOpen, X, ArrowDown, ChevronRight, Shield, CheckCircle2, Upload } from 'lucide-react'
+import { Loader2, BookOpen, X, ArrowDown, ChevronRight, Shield, CheckCircle2, Upload, Link2 } from 'lucide-react'
 import { useQueryClient } from '@tanstack/react-query'
 import { ChatMessage } from './ChatMessage'
 import { ChatInput } from './ChatInput'
@@ -10,6 +10,7 @@ import { useChat } from '../../hooks/useChat'
 import { useOnboarding } from '../../hooks/useOnboarding'
 import { useWorkspace, type PendingChatMessage } from '../../contexts/WorkspaceContext'
 import { useToast } from '../../contexts/ToastContext'
+import { useShareLink } from '../../lib/shareLink'
 import { addLink, removeDocument, removeLink, truncateContext, compactContext, clearContext } from '../../api/chat'
 import { uploadFile } from '../../api/files'
 import { convertDocumentsToKB } from '../../api/knowledge'
@@ -84,6 +85,7 @@ export function ChatPanel({ conversationToLoad, pendingMessage, onPendingMessage
   const { bumpActivitySignal, processingDoc, selectedDocsProcessing, selectedDocUuids, setSelectedDocUuids, selectedDocNames, setSelectedDocNames, selectedFolderUuids, activeKBUuid, activeKBTitle, activateKB, deactivateKB, setCurrentConversationUuid } = useWorkspace()
   const [convertingToKB, setConvertingToKB] = useState(false)
   const { toast } = useToast()
+  const shareLink = useShareLink()
   const { pills: onboardingPills, isFirstSession, loading: onboardingLoading } = useOnboarding()
   // Lock the first-session flag once it's set so remounts/refetches can't
   // flip it mid-conversation (markFirstSessionComplete fires early).
@@ -909,6 +911,21 @@ export function ChatPanel({ conversationToLoad, pendingMessage, onPendingMessage
         >
           <BookOpen size={14} />
           <span style={{ flex: 1 }}>Knowledge Base: {activeKBTitle}</span>
+          <button
+            onClick={() => shareLink('kb', activeKBUuid, activeKBTitle || undefined)}
+            title="Copy share link"
+            style={{
+              background: 'transparent',
+              border: 'none',
+              cursor: 'pointer',
+              padding: 2,
+              display: 'flex',
+              color: 'inherit',
+              opacity: 0.7,
+            }}
+          >
+            <Link2 size={14} />
+          </button>
           <button
             onClick={deactivateKB}
             style={{

--- a/frontend/src/components/knowledge/KBCard.tsx
+++ b/frontend/src/components/knowledge/KBCard.tsx
@@ -10,12 +10,14 @@ import {
   MessageSquare,
   MoreHorizontal,
   Share2,
+  Link2,
   Send,
   Bookmark,
   Users,
 } from 'lucide-react'
 import type { KnowledgeBase } from '../../types/knowledge'
 import type { Organization } from '../../api/organizations'
+import { useShareLink } from '../../lib/shareLink'
 
 const STATUS_BADGE: Record<string, { label: string; color: string; bg: string }> = {
   empty: { label: 'Empty', color: '#6b7280', bg: '#f3f4f6' },
@@ -46,6 +48,7 @@ export function KBCard({
   const badge = STATUS_BADGE[kb.status] || STATUS_BADGE.empty
   const isReady = kb.status === 'ready'
   const isReference = kb.is_reference
+  const shareLink = useShareLink()
 
   const [menuOpen, setMenuOpen] = useState(false)
   const menuRef = useRef<HTMLDivElement>(null)
@@ -239,6 +242,16 @@ export function KBCard({
               label={kb.shared_with_team ? 'Unshare from team' : 'Share with team'}
               onClick={() => {
                 onShare(kb)
+                setMenuOpen(false)
+              }}
+            />
+          )}
+          {isReady && (
+            <MenuItem
+              icon={<Link2 size={14} />}
+              label="Copy share link"
+              onClick={() => {
+                shareLink('kb', kb.uuid, kb.title)
                 setMenuOpen(false)
               }}
             />

--- a/frontend/src/components/layout/AuthLayout.tsx
+++ b/frontend/src/components/layout/AuthLayout.tsx
@@ -16,7 +16,7 @@ export function AuthLayout({ children, title }: { children: ReactNode; title: st
       {/* Top nav */}
       <nav className="relative z-10 border-b border-white/10 bg-[#0a0a0a]/80 backdrop-blur-md">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex items-center justify-between h-16">
-          <Link to="/landing" search={{ error: undefined, invite_token: undefined, admin: undefined }}>
+          <Link to="/landing" search={{ error: undefined, invite_token: undefined, admin: undefined, next: undefined }}>
             <img src="/images/Vandalizer_Wordmark_Color_RGB+W.png" alt="Vandalizer" className="h-10" />
           </Link>
         </div>
@@ -28,7 +28,7 @@ export function AuthLayout({ children, title }: { children: ReactNode; title: st
           <h1 className="mb-8 text-center text-2xl font-bold text-white">{title}</h1>
           {children}
           <p className="mt-6 text-center text-sm text-gray-500">
-            <Link to="/landing" search={{ error: undefined, invite_token: undefined, admin: undefined }} className="text-gray-400 hover:text-[#f1b300] transition-colors">
+            <Link to="/landing" search={{ error: undefined, invite_token: undefined, admin: undefined, next: undefined }} className="text-gray-400 hover:text-[#f1b300] transition-colors">
               &larr; Back to home
             </Link>
           </p>

--- a/frontend/src/components/library/ExploreTab.tsx
+++ b/frontend/src/components/library/ExploreTab.tsx
@@ -5,7 +5,7 @@ import { marked } from 'marked'
 import {
   Search, ShieldCheck, BookOpen, Workflow, FileSearch,
   FolderOpen, Star, X, Plus, ArrowUpDown,
-  Bookmark, ArrowLeft, Loader2, Tag, Sparkles, ExternalLink,
+  Bookmark, ArrowLeft, Loader2, Tag, Sparkles, ExternalLink, Link2,
 } from 'lucide-react'
 import { useNavigate } from '@tanstack/react-router'
 import { QualityBadge } from './QualityBadge'
@@ -19,6 +19,7 @@ import { adoptKnowledgeBase } from '../../api/knowledge'
 import type { VerifiedCatalogItem, VerifiedCollection, Library, LibraryItemKind } from '../../types/library'
 import { useAuth } from '../../hooks/useAuth'
 import { useToast } from '../../contexts/ToastContext'
+import { useShareLink } from '../../lib/shareLink'
 
 marked.setOptions({ breaks: true, gfm: true })
 
@@ -111,6 +112,12 @@ export function ItemDetailModal({
 }) {
   const tierStyle = TIER_STYLES[(item.quality_tier || '') as keyof typeof TIER_STYLES]
   const kindConf = KIND_CONFIG[item.kind as keyof typeof KIND_CONFIG]
+  const shareLink = useShareLink()
+  const shareKind: 'workflow' | 'extraction' | 'kb' | null =
+    item.kind === 'workflow' ? 'workflow'
+    : item.kind === 'search_set' ? 'extraction'
+    : item.kind === 'knowledge_base' ? 'kb'
+    : null
 
   return createPortal(
     <div className="fixed inset-0 z-[9990] flex items-start justify-center pt-[5vh] bg-black/40" onClick={onClose}>
@@ -213,6 +220,16 @@ export function ItemDetailModal({
               >
                 <ExternalLink className="h-4 w-4" />
                 Open
+              </button>
+            )}
+            {shareKind && item.source_uuid && (
+              <button
+                onClick={() => shareLink(shareKind, item.source_uuid!, item.display_name || item.name)}
+                className="ml-auto inline-flex items-center gap-1.5 px-4 py-2 rounded-lg text-sm font-medium text-gray-700 bg-gray-100 hover:bg-gray-200 transition-colors"
+                title="Copy share link"
+              >
+                <Link2 className="h-4 w-4" />
+                Share
               </button>
             )}
           </div>

--- a/frontend/src/components/library/LibraryItemRow.test.tsx
+++ b/frontend/src/components/library/LibraryItemRow.test.tsx
@@ -16,6 +16,11 @@ vi.mock('../../hooks/useAuth', () => ({
   }),
 }))
 
+vi.mock('../../lib/shareLink', () => ({
+  useShareLink: () => vi.fn(),
+  buildShareUrl: vi.fn(),
+}))
+
 function makeItem(overrides: Partial<LibraryItem> = {}): LibraryItem {
   return {
     id: 'item-1',

--- a/frontend/src/components/library/LibraryItemRow.tsx
+++ b/frontend/src/components/library/LibraryItemRow.tsx
@@ -6,6 +6,7 @@ import {
   Star,
   Copy,
   Share2,
+  Link2,
   Trash2,
   Pencil,
   ShieldCheck,
@@ -16,6 +17,7 @@ import { QualityBadge } from './QualityBadge'
 import { VerificationSubmitModal } from './VerificationSubmitModal'
 import { AuthorChip } from '../shared/AuthorChip'
 import { useAuth } from '../../hooks/useAuth'
+import { useShareLink } from '../../lib/shareLink'
 import { relativeTime } from '../../utils/time'
 import type { LibraryItem, LibraryFolder } from '../../types/library'
 
@@ -37,6 +39,7 @@ interface Props {
 
 export function LibraryItemRow({ item, scope, onPin, onFavorite, onClone, onShare, onRemove, onOpen, onEdit, onMoveToFolder, folders, qualityTier, qualityScore }: Props) {
   const { user } = useAuth()
+  const shareLink = useShareLink()
   const [hovered, setHovered] = useState(false)
   const [menuOpen, setMenuOpen] = useState(false)
   const [folderSubmenuOpen, setFolderSubmenuOpen] = useState(false)
@@ -307,6 +310,17 @@ export function LibraryItemRow({ item, scope, onPin, onFavorite, onClone, onShar
                     />
                   )}
                   <div style={{ borderTop: '1px solid #e0e0e0', margin: '4px 0' }} />
+                  {(item.kind === 'workflow' || item.kind === 'search_set') && (item.item_uuid || item.item_id) && (
+                    <MenuItem
+                      icon={<Link2 size={14} />}
+                      label="Copy share link"
+                      onClick={() => {
+                        const kind = item.kind === 'workflow' ? 'workflow' : 'extraction'
+                        shareLink(kind, (item.item_uuid || item.item_id) as string, item.name)
+                        setMenuOpen(false)
+                      }}
+                    />
+                  )}
                   {scope === 'mine' ? (
                     <>
                       <MenuItem

--- a/frontend/src/components/workspace/ExtractionEditorPanel.tsx
+++ b/frontend/src/components/workspace/ExtractionEditorPanel.tsx
@@ -1,10 +1,11 @@
 import React, { Fragment, useCallback, useEffect, useRef, useState } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
 import { ExtractionTutorial } from './ExtractionTutorial'
-import { X, Pencil, Loader2, Copy, Trash2, GripVertical, Plus, ChevronDown, ChevronRight, Play, TrendingUp, Sparkles, FileText, AlertTriangle, Eye, Shield, ShieldCheck, Download, Check, PenTool, Wrench, ClipboardCheck, SlidersHorizontal, Clock } from 'lucide-react'
+import { X, Pencil, Loader2, Copy, Trash2, GripVertical, Plus, ChevronDown, ChevronRight, Play, TrendingUp, Sparkles, FileText, AlertTriangle, Eye, Shield, ShieldCheck, Download, Check, PenTool, Wrench, ClipboardCheck, SlidersHorizontal, Clock, Link2 } from 'lucide-react'
 import { useWorkspace } from '../../contexts/WorkspaceContext'
 import { useToast } from '../../contexts/ToastContext'
 import { useAuth } from '../../hooks/useAuth'
+import { useShareLink } from '../../lib/shareLink'
 import { useConfirm } from '../shared/useConfirm'
 import { useSearchSetItems } from '../../hooks/useExtractions'
 import {
@@ -76,6 +77,7 @@ export function ExtractionEditorPanel() {
   const { openExtractionId, openExtraction, closeExtraction, selectedDocUuids, selectedDocNames, setHighlightTerms, bumpActivitySignal, consumeExtractionResults } = useWorkspace()
   const { toast } = useToast()
   const { user } = useAuth()
+  const shareLink = useShareLink()
   const confirm = useConfirm()
   const [searchSet, setSearchSet] = useState<SearchSet | null>(null)
   const [loading, setLoading] = useState(true)
@@ -489,6 +491,22 @@ export function ExtractionEditorPanel() {
             {selectedDocUuids.length} document{selectedDocUuids.length !== 1 ? 's' : ''} selected
           </div>
         </div>
+        <button
+          onClick={() => shareLink('extraction', searchSet.uuid, searchSet.title)}
+          title="Copy share link"
+          style={{
+            background: 'none',
+            border: 'none',
+            cursor: 'pointer',
+            padding: 4,
+            borderRadius: 4,
+            color: '#5f6368',
+            display: 'flex',
+            flexShrink: 0,
+          }}
+        >
+          <Link2 style={{ width: 18, height: 18 }} />
+        </button>
         <button
           onClick={closeExtraction}
           style={{

--- a/frontend/src/components/workspace/WorkflowEditorPanel.tsx
+++ b/frontend/src/components/workspace/WorkflowEditorPanel.tsx
@@ -8,11 +8,12 @@ import {
   ChevronDown, ChevronRight, ArrowUp, ArrowDown,
   Circle, Hand, Keyboard, Sparkles, ShieldCheck, Type,
   ArrowRight, Pause, TrendingUp, RefreshCw,
-  Upload, Clock, Copy, Check, FolderInput,
+  Upload, Clock, Copy, Check, FolderInput, Link2,
 } from 'lucide-react'
 import { useWorkspace } from '../../contexts/WorkspaceContext'
 import { useToast } from '../../contexts/ToastContext'
 import { useAuth } from '../../hooks/useAuth'
+import { useShareLink } from '../../lib/shareLink'
 import {
   getWorkflow, addStep, deleteStep, addTask, deleteTask, updateTask,
   updateWorkflow, updateStep, downloadResults, testStep, getTestStepStatus,
@@ -194,6 +195,7 @@ export function WorkflowEditorPanel() {
   const queryClient = useQueryClient()
   const { toast } = useToast()
   const { user } = useAuth()
+  const shareLink = useShareLink()
   const { openWorkflowId, openWorkflow, closeWorkflow, consumeWorkflowSession, selectedDocUuids, bumpActivitySignal } = useWorkspace()
   const [workflow, setWorkflow] = useState<Workflow | null>(null)
   const [loading, setLoading] = useState(true)
@@ -569,6 +571,13 @@ export function WorkflowEditorPanel() {
               }
             }}
           />
+          <button
+            onClick={() => shareLink('workflow', workflow.id, workflow.name)}
+            title="Copy share link"
+            style={{ background: 'none', border: 'none', cursor: 'pointer', padding: 4, borderRadius: 4, color: '#5f6368', display: 'flex', flexShrink: 0 }}
+          >
+            <Link2 style={{ width: 18, height: 18 }} />
+          </button>
           <button
             onClick={closeWorkflow}
             style={{ background: 'none', border: 'none', cursor: 'pointer', padding: 4, borderRadius: 4, color: '#5f6368', display: 'flex', flexShrink: 0 }}

--- a/frontend/src/lib/shareLink.ts
+++ b/frontend/src/lib/shareLink.ts
@@ -1,0 +1,26 @@
+import { useCallback } from 'react'
+import { useToast } from '../contexts/ToastContext'
+
+export type ShareableKind = 'workflow' | 'extraction' | 'kb'
+
+export function buildShareUrl(kind: ShareableKind, uuid: string): string {
+  const params = new URLSearchParams({ [kind]: uuid })
+  return `${window.location.origin}/?${params.toString()}`
+}
+
+export function useShareLink() {
+  const { toast } = useToast()
+  return useCallback(
+    async (kind: ShareableKind, uuid: string, label?: string) => {
+      const url = buildShareUrl(kind, uuid)
+      try {
+        await navigator.clipboard.writeText(url)
+        const what = label ? `“${label}”` : 'Link'
+        toast(`${what} copied — share it with anyone.`, 'success')
+      } catch {
+        toast('Could not copy link to clipboard.', 'error')
+      }
+    },
+    [toast],
+  )
+}

--- a/frontend/src/pages/Demo.tsx
+++ b/frontend/src/pages/Demo.tsx
@@ -473,7 +473,7 @@ export default function Demo() {
       {/* Nav */}
       <nav className="fixed top-0 inset-x-0 z-50 bg-[#0a0a0a]/80 backdrop-blur-md border-b border-white/10">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex items-center justify-between h-16">
-          <Link to="/landing" search={{ error: undefined, invite_token: undefined, admin: undefined }} className="flex items-center gap-2 text-gray-400 hover:text-white transition-colors">
+          <Link to="/landing" search={{ error: undefined, invite_token: undefined, admin: undefined, next: undefined }} className="flex items-center gap-2 text-gray-400 hover:text-white transition-colors">
             <ArrowLeft className="w-4 h-4" />
             <span className="text-xl font-bold text-white">Vandalizer</span>
           </Link>

--- a/frontend/src/pages/DemoFeedback.tsx
+++ b/frontend/src/pages/DemoFeedback.tsx
@@ -95,7 +95,7 @@ export default function DemoFeedback() {
       {/* Nav */}
       <nav className="fixed top-0 inset-x-0 z-50 bg-[#0a0a0a]/80 backdrop-blur-md border-b border-white/10">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex items-center justify-between h-16">
-          <Link to="/landing" search={{ error: undefined, invite_token: undefined, admin: undefined }} className="flex items-center gap-2 text-gray-400 hover:text-white transition-colors">
+          <Link to="/landing" search={{ error: undefined, invite_token: undefined, admin: undefined, next: undefined }} className="flex items-center gap-2 text-gray-400 hover:text-white transition-colors">
             <ArrowLeft className="w-4 h-4" />
             <span className="text-xl font-bold text-white">Vandalizer</span>
           </Link>
@@ -124,7 +124,7 @@ export default function DemoFeedback() {
               <p className="text-gray-400">{error}</p>
                 <Link
                   to="/landing"
-                  search={{ error: undefined, invite_token: undefined, admin: undefined }}
+                  search={{ error: undefined, invite_token: undefined, admin: undefined, next: undefined }}
                   className="inline-block mt-6 rounded-lg bg-white/10 px-6 py-3 font-bold text-white hover:bg-white/20 transition-colors"
                 >
                 Go to Homepage
@@ -141,7 +141,7 @@ export default function DemoFeedback() {
                 </p>
                 <Link
                   to="/landing"
-                  search={{ error: undefined, invite_token: undefined, admin: undefined }}
+                  search={{ error: undefined, invite_token: undefined, admin: undefined, next: undefined }}
                   className="inline-block rounded-lg bg-[#f1b300] px-6 py-3 font-bold text-black hover:bg-[#d49e00] transition-colors"
                 >
                   Back to Homepage

--- a/frontend/src/pages/Docs.tsx
+++ b/frontend/src/pages/Docs.tsx
@@ -624,7 +624,7 @@ export default function Docs() {
       <nav className="fixed top-0 inset-x-0 z-50 bg-[#0a0a0a]/80 backdrop-blur-md border-b border-white/10">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex items-center justify-between h-16">
           <div className="flex items-center gap-6">
-            <Link to="/landing" search={{ error: undefined, invite_token: undefined, admin: undefined }} className="text-xl font-bold text-white hover:text-[#f1b300] transition-colors">
+            <Link to="/landing" search={{ error: undefined, invite_token: undefined, admin: undefined, next: undefined }} className="text-xl font-bold text-white hover:text-[#f1b300] transition-colors">
               Vandalizer
             </Link>
             <span className="text-sm text-[#f1b300] font-medium">Docs</span>

--- a/frontend/src/pages/Landing.tsx
+++ b/frontend/src/pages/Landing.tsx
@@ -265,15 +265,30 @@ function AuthBlock({ config }: { config: AuthConfig | null }) {
 // Landing page
 // ---------------------------------------------------------------------------
 
+function safeNextPath(raw: string | undefined): string | null {
+  if (!raw) return null
+  // Must be a same-origin relative path. Reject protocol-relative (//host)
+  // and absolute URLs to prevent open-redirect.
+  if (!raw.startsWith('/') || raw.startsWith('//')) return null
+  return raw
+}
+
 export default function Landing() {
   const { user, loading, demoExpired, demoFeedbackToken } = useAuth()
   const [authConfig, setAuthConfig] = useState<AuthConfig | null>(null)
   const search = useSearch({ strict: false }) as Record<string, string | undefined>
   const inviteToken = search?.invite_token
+  const nextPath = safeNextPath(search?.next)
 
   useEffect(() => {
     getAuthConfig().then(setAuthConfig)
   }, [])
+
+  useEffect(() => {
+    if (user && !demoExpired && !inviteToken && nextPath) {
+      window.location.replace(nextPath)
+    }
+  }, [user, demoExpired, inviteToken, nextPath])
 
   if (loading) return null
   if (user && demoExpired && demoFeedbackToken) {
@@ -283,6 +298,10 @@ export default function Landing() {
     // If user arrived here with an invite token, redirect to accept it
     if (inviteToken) {
       return <Navigate to="/invite" search={{ token: inviteToken }} />
+    }
+    if (nextPath) {
+      // Effect above is handling the redirect via location.replace — render nothing meanwhile.
+      return null
     }
     return (
       <Navigate

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -72,6 +72,7 @@ const landingRoute = createRoute({
     error: (search.error as string) || undefined,
     invite_token: (search.invite_token as string) || undefined,
     admin: (search.admin as string) || undefined,
+    next: (search.next as string) || undefined,
   }),
   component: Landing,
 })

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -90,7 +90,7 @@ const loginRoute = createRoute({
 const registerRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/register',
-  component: () => <Navigate to="/landing" search={{ error: undefined, invite_token: undefined, admin: undefined }} />,
+  component: () => <Navigate to="/landing" search={{ error: undefined, invite_token: undefined, admin: undefined, next: undefined }} />,
 })
 
 const resetPasswordRoute = createRoute({


### PR DESCRIPTION
## Summary

- Adds **Copy share link** entry points on workflows, extractions, and knowledge bases via a single `useShareLink` hook. Surfaces: LibraryItemRow + KBCard kebab menus, WorkflowEditor + ExtractionEditor headers, ChatPanel KB banner, and the Explore detail modal.
- Wires up `?next=<path>` deep-link redirect: `ProtectedRoute` preserves the intended URL when bouncing logged-out visitors to `/landing`, and `Landing` honors it after login/register (validated to a same-origin relative path to block open-redirect).
- Self-serve registration now creates a 14-day trial user when `enable_trial_system` is on, so a recipient with no account can sign up via a shared link and land directly on the item. Non-trial deployments are unchanged — new users come straight in as full users.

URL format: `${origin}/?<workflow|extraction|kb>=<uuid>`.

## Test plan
- [ ] **Logged-in workflow share:** open a workflow in the editor, click the new link icon in the header, paste the URL in a private window with the same account — opens the workflow.
- [ ] **Logged-out workflow share:** paste the same URL in a private window with no session — lands on `/landing?next=…`, sign in, land back on the workflow.
- [ ] **Extraction kebab share** from the library list — same flows.
- [ ] **KB kebab share** + **KB chat banner share** — pasted URL opens the KB in chat.
- [ ] **Explore tab Share button** on a verified workflow / extraction / KB.
- [ ] **Trial signup via share link:** with `ENABLE_TRIAL_SYSTEM=1`, register from `/landing?next=/?workflow=…`, verify the new account is `is_demo_user=True` with `demo_expires_at` ~14 days out, and post-register lands on the shared workflow.
- [ ] **No-trial deployment:** with `ENABLE_TRIAL_SYSTEM=0` (default), register from the same link — account is a normal full user, post-register still lands on the shared item.
- [ ] **Open-redirect safety:** `/landing?next=https://evil.example.com` after login still lands on `/`, not on the external URL.
- [ ] Verified the Explore tab modal **Share** button does not depend on `onTryIt` being defined.

## Known follow-ups (intentionally out of scope)
- Trial signups via this path get the minimal trial record (no `DemoApplication`, no activation email, no recapture drip). If those mechanics are load-bearing for trial conversion, extend the register handler to seed them.
- Recipients without access to the underlying item still see the existing "not found" panel. A friendlier "ask for access" state would be a separate task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
