### PR TITLE
Add watchers, ticket numbers, and message editing to support tickets

### DIFF
--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -37,7 +37,7 @@ from app.models.organization import Organization
 from app.models.audit_log import AuditLog, AdminAuditLog
 from app.models.approval import ApprovalRequest
 from app.models.notification import Notification
-from app.models.support import SupportTicket
+from app.models.support import SupportTicket, SupportCounter
 from app.models.feedback_prompt import FeedbackPrompt, FeedbackPromptResponse
 from app.models.email_log import EmailLog
 from app.models.api_key import ApiKey
@@ -98,6 +98,7 @@ ALL_MODELS = [
     ApprovalRequest,
     Notification,
     SupportTicket,
+    SupportCounter,
     FeedbackPrompt,
     FeedbackPromptResponse,
     EmailLog,

--- a/backend/app/models/support.py
+++ b/backend/app/models/support.py
@@ -32,6 +32,7 @@ class SupportMessage(BaseModel):
     created_at: datetime.datetime = Field(
         default_factory=lambda: datetime.datetime.now(datetime.timezone.utc)
     )
+    edited_at: Optional[datetime.datetime] = None
 
 
 class SupportAttachment(BaseModel):
@@ -51,6 +52,10 @@ class SupportAttachment(BaseModel):
 
 class SupportTicket(Document):
     uuid: str = Field(default_factory=lambda: uuid_mod.uuid4().hex)
+    # Human-friendly sequential id (e.g. 1024). Assigned at insert time via an
+    # atomic counter; legacy tickets created before this feature get backfilled
+    # on first read. Optional only so older docs deserialize cleanly.
+    ticket_number: Optional[int] = None
     subject: str
     status: TicketStatus = TicketStatus.OPEN
     priority: TicketPriority = TicketPriority.NORMAL
@@ -78,6 +83,13 @@ class SupportTicket(Document):
     # ticket owner or other non-support users.
     tags: list[str] = []
 
+    # Users (by user_id) the requester or an agent has looped in on this
+    # ticket. Watchers can view the ticket, get notified on new messages
+    # and status changes, and reply to it. Distinct from `tags` (which are
+    # support-internal labels) — watchers are always visible to everyone
+    # who can see the ticket.
+    watchers: list[str] = []
+
     # Timestamps
     created_at: datetime.datetime = Field(
         default_factory=lambda: datetime.datetime.now(datetime.timezone.utc)
@@ -91,10 +103,28 @@ class SupportTicket(Document):
         name = "support_ticket"
         indexes = [
             "uuid",
+            "ticket_number",
             "user_id",
             "status",
             "assigned_to",
             "tags",
+            "watchers",
             [("status", 1), ("created_at", -1)],
             [("user_id", 1), ("created_at", -1)],
         ]
+
+
+class SupportCounter(Document):
+    """Atomic counter for sequential ticket numbers.
+
+    One singleton document keyed by `name` (always "support_ticket"). Mongo's
+    findOneAndUpdate with $inc + upsert guarantees each create_ticket call
+    gets a unique increasing value, even under concurrent inserts.
+    """
+
+    name: str
+    value: int = 0
+
+    class Settings:
+        name = "support_counter"
+        indexes = ["name"]

--- a/backend/app/routers/support.py
+++ b/backend/app/routers/support.py
@@ -25,6 +25,10 @@ class AddMessageRequest(BaseModel):
     content: str
 
 
+class EditMessageRequest(BaseModel):
+    content: str
+
+
 class UpdateTicketRequest(BaseModel):
     status: str | None = None
     priority: str | None = None
@@ -32,10 +36,27 @@ class UpdateTicketRequest(BaseModel):
     tags: list[str] | None = None
 
 
+class AddWatcherRequest(BaseModel):
+    email: str
+
+
 def _strip_tags(payload: dict) -> dict:
     """Remove the internal-only tags field — non-support callers must not see it."""
     payload.pop("tags", None)
     return payload
+
+
+def _can_view_ticket(ticket: dict, user: User, is_support: bool) -> bool:
+    """Owner, support, or a tagged watcher can read/reply on a ticket."""
+    if is_support:
+        return True
+    if ticket.get("user_id") == user.user_id:
+        return True
+    watcher_ids = {
+        w.get("user_id") if isinstance(w, dict) else w
+        for w in (ticket.get("watchers") or [])
+    }
+    return user.user_id in watcher_ids
 
 
 # ---------------------------------------------------------------------------
@@ -153,9 +174,9 @@ async def get_ticket(
     if not ticket:
         raise HTTPException(status_code=404, detail="Ticket not found")
 
-    # Only allow the ticket owner or support users to view
+    # Owner, support, or tagged watcher may view.
     is_support = await _is_support_user(user)
-    if ticket["user_id"] != user.user_id and not is_support:
+    if not _can_view_ticket(ticket, user, is_support):
         raise HTTPException(status_code=403, detail="Not authorized")
 
     if not is_support:
@@ -181,13 +202,13 @@ async def add_message(
     body: AddMessageRequest,
     user: User = Depends(get_current_user),
 ):
-    # Check access
+    # Check access — owner, support, or watcher may reply.
     ticket_data = await support_service.get_ticket(ticket_uuid)
     if not ticket_data:
         raise HTTPException(status_code=404, detail="Ticket not found")
 
     is_support = await _is_support_user(user)
-    if ticket_data["user_id"] != user.user_id and not is_support:
+    if not _can_view_ticket(ticket_data, user, is_support):
         raise HTTPException(status_code=403, detail="Not authorized")
 
     result = await support_service.add_message(
@@ -196,6 +217,37 @@ async def add_message(
         content=body.content,
         is_support_reply=is_support and ticket_data["user_id"] != user.user_id,
     )
+    if not result:
+        raise HTTPException(status_code=404, detail="Ticket not found")
+    return result if is_support else _strip_tags(result)
+
+
+@router.patch("/tickets/{ticket_uuid}/messages/{message_uuid}")
+async def edit_message(
+    ticket_uuid: str,
+    message_uuid: str,
+    body: EditMessageRequest,
+    user: User = Depends(get_current_user),
+):
+    """Edit your own message on a ticket. Authorship is required — even
+    support agents can't rewrite someone else's words."""
+    ticket_data = await support_service.get_ticket(ticket_uuid)
+    if not ticket_data:
+        raise HTTPException(status_code=404, detail="Ticket not found")
+
+    is_support = await _is_support_user(user)
+    if not _can_view_ticket(ticket_data, user, is_support):
+        raise HTTPException(status_code=403, detail="Not authorized")
+
+    result, error = await support_service.edit_message(
+        ticket_uuid=ticket_uuid,
+        message_uuid=message_uuid,
+        user=user,
+        content=body.content,
+    )
+    if error:
+        status_code = 404 if "not found" in error.lower() else 403 if "edit your own" in error.lower() else 400
+        raise HTTPException(status_code=status_code, detail=error)
     if not result:
         raise HTTPException(status_code=404, detail="Ticket not found")
     return result if is_support else _strip_tags(result)
@@ -212,7 +264,7 @@ async def add_attachment(
         raise HTTPException(status_code=404, detail="Ticket not found")
 
     is_support = await _is_support_user(user)
-    if ticket_data["user_id"] != user.user_id and not is_support:
+    if not _can_view_ticket(ticket_data, user, is_support):
         raise HTTPException(status_code=403, detail="Not authorized")
 
     file_bytes = await file.read()
@@ -242,7 +294,7 @@ async def download_attachment(
         raise HTTPException(status_code=404, detail="Ticket not found")
 
     is_support = await _is_support_user(user)
-    if ticket_data["user_id"] != user.user_id and not is_support:
+    if not _can_view_ticket(ticket_data, user, is_support):
         raise HTTPException(status_code=403, detail="Not authorized")
 
     data = await support_service.get_attachment_data(ticket_uuid, attachment_uuid)
@@ -296,6 +348,61 @@ async def update_ticket(
     if not result:
         raise HTTPException(status_code=404, detail="Ticket not found")
     return result
+
+
+@router.post("/tickets/{ticket_uuid}/watchers")
+async def add_watcher(
+    ticket_uuid: str,
+    body: AddWatcherRequest,
+    user: User = Depends(get_current_user),
+):
+    """Tag a user (by email) to follow this ticket.
+
+    Owner, support agents, and existing watchers may all add new watchers —
+    if you can read the ticket, you can pull in another collaborator.
+    """
+    ticket_data = await support_service.get_ticket(ticket_uuid)
+    if not ticket_data:
+        raise HTTPException(status_code=404, detail="Ticket not found")
+    is_support = await _is_support_user(user)
+    if not _can_view_ticket(ticket_data, user, is_support):
+        raise HTTPException(status_code=403, detail="Not authorized")
+
+    result, error = await support_service.add_watcher(
+        ticket_uuid=ticket_uuid,
+        actor=user,
+        email=body.email,
+    )
+    if error:
+        raise HTTPException(status_code=400, detail=error)
+    if not result:
+        raise HTTPException(status_code=404, detail="Ticket not found")
+    return result if is_support else _strip_tags(result)
+
+
+@router.delete("/tickets/{ticket_uuid}/watchers/{watcher_user_id}")
+async def remove_watcher(
+    ticket_uuid: str,
+    watcher_user_id: str,
+    user: User = Depends(get_current_user),
+):
+    """Untag a watcher. Owner, support, or the watcher themselves may remove."""
+    ticket_data = await support_service.get_ticket(ticket_uuid)
+    if not ticket_data:
+        raise HTTPException(status_code=404, detail="Ticket not found")
+    is_support = await _is_support_user(user)
+    is_owner = ticket_data["user_id"] == user.user_id
+    is_self = user.user_id == watcher_user_id
+    if not (is_support or is_owner or is_self):
+        raise HTTPException(status_code=403, detail="Not authorized")
+
+    result = await support_service.remove_watcher(
+        ticket_uuid=ticket_uuid,
+        watcher_user_id=watcher_user_id,
+    )
+    if not result:
+        raise HTTPException(status_code=404, detail="Ticket not found")
+    return result if is_support else _strip_tags(result)
 
 
 @router.get("/stats")

--- a/backend/app/services/email_service.py
+++ b/backend/app/services/email_service.py
@@ -356,14 +356,21 @@ def verification_status_email(
 
 def support_reply_email(
     user_name: str, ticket_subject: str, message: str, ticket_uuid: str, frontend_url: str,
+    ticket_number: int | None = None,
 ) -> tuple[str, str]:
     """Returns (subject, html_body) when support replies to a user's ticket."""
-    subject = f"Re: {ticket_subject}"
+    num_prefix = f"[#{ticket_number}] " if ticket_number else ""
+    subject = f"{num_prefix}Re: {ticket_subject}"
+    label = (
+        f'<span class="highlight">#{ticket_number}</span> &middot; <span class="highlight">{ticket_subject}</span>'
+        if ticket_number
+        else f'<span class="highlight">{ticket_subject}</span>'
+    )
     html = f"""<!DOCTYPE html><html><head>{_BASE_STYLE}</head><body>
     <div class="container"><div class="card">
       <div class="logo">Vandalizer Support</div>
       <h1>New reply on your ticket</h1>
-      <p>Hi {user_name}, there's a new reply on your support ticket <span class="highlight">{ticket_subject}</span>.</p>
+      <p>Hi {user_name}, there's a new reply on your support ticket {label}.</p>
       <div style="margin:16px 0;padding:12px 16px;background:rgba(255,255,255,0.05);border-left:3px solid #f1b300;border-radius:4px;">
         <p style="margin:0;font-size:14px;color:#d1d5db;">{message[:500]}</p>
       </div>
@@ -375,9 +382,11 @@ def support_reply_email(
 
 def support_status_email(
     user_name: str, ticket_subject: str, new_status: str, ticket_uuid: str, frontend_url: str,
+    ticket_number: int | None = None,
 ) -> tuple[str, str]:
     """Returns (subject, html_body) when a support ticket status changes."""
-    subject = f"Ticket {new_status}: {ticket_subject}"
+    num_prefix = f"[#{ticket_number}] " if ticket_number else ""
+    subject = f"{num_prefix}Ticket {new_status}: {ticket_subject}"
     html = f"""<!DOCTYPE html><html><head>{_BASE_STYLE}</head><body>
     <div class="container"><div class="card">
       <div class="logo">Vandalizer Support</div>
@@ -392,9 +401,11 @@ def support_status_email(
 def support_new_message_email(
     support_name: str, ticket_subject: str, ticket_user: str, message: str,
     ticket_uuid: str, frontend_url: str,
+    ticket_number: int | None = None,
 ) -> tuple[str, str]:
     """Returns (subject, html_body) when a user replies on a support ticket (for agents)."""
-    subject = f"New message on ticket: {ticket_subject}"
+    num_prefix = f"[#{ticket_number}] " if ticket_number else ""
+    subject = f"{num_prefix}New message on ticket: {ticket_subject}"
     html = f"""<!DOCTYPE html><html><head>{_BASE_STYLE}</head><body>
     <div class="container"><div class="card">
       <div class="logo">Vandalizer Support</div>
@@ -417,11 +428,13 @@ def support_tag_added_email(
     actor_name: str,
     ticket_uuid: str,
     frontend_url: str,
+    ticket_number: int | None = None,
 ) -> tuple[str, str]:
     """Returns (subject, html_body) when a support agent adds tag(s) to a ticket."""
     tag_list = ", ".join(added_tags)
     plural = "s" if len(added_tags) != 1 else ""
-    subject = f"Tag{plural} added to ticket: {ticket_subject}"
+    num_prefix = f"[#{ticket_number}] " if ticket_number else ""
+    subject = f"{num_prefix}Tag{plural} added to ticket: {ticket_subject}"
     tag_pills = "".join(
         f'<span style="display:inline-block;background:#f1b300;color:#000;'
         f'font-weight:600;font-size:13px;padding:3px 10px;border-radius:12px;'
@@ -434,6 +447,37 @@ def support_tag_added_email(
       <h1>Tag{plural} added to a ticket</h1>
       <p>Hi {support_name}, <span class="highlight">{actor_name}</span> added tag{plural} <strong style="color:#fff">{tag_list}</strong> to ticket <strong style="color:#fff">{ticket_subject}</strong> (from {ticket_user}).</p>
       <div style="margin:16px 0;">{tag_pills}</div>
+      <p style="margin-top:24px"><a class="btn" href="{frontend_url}/support?ticket={ticket_uuid}">View Ticket</a></p>
+      <div class="footer">Vandalizer Support System</div>
+    </div></div></body></html>"""
+    return subject, html
+
+
+def support_watcher_added_email(
+    watcher_name: str,
+    ticket_subject: str,
+    ticket_user: str,
+    actor_name: str,
+    first_message: str,
+    ticket_uuid: str,
+    frontend_url: str,
+    ticket_number: int | None = None,
+) -> tuple[str, str]:
+    """Returns (subject, html_body) when a user is tagged as a watcher on a ticket."""
+    num_prefix = f"[#{ticket_number}] " if ticket_number else ""
+    subject = f"{num_prefix}You were added to a support ticket: {ticket_subject}"
+    preview_block = ""
+    if first_message:
+        preview_block = f"""
+      <div style="margin:16px 0;padding:12px 16px;background:rgba(255,255,255,0.05);border-left:3px solid #f1b300;border-radius:4px;">
+        <p style="margin:0;font-size:14px;color:#d1d5db;">{first_message[:500]}</p>
+      </div>"""
+    html = f"""<!DOCTYPE html><html><head>{_BASE_STYLE}</head><body>
+    <div class="container"><div class="card">
+      <div class="logo">Vandalizer Support</div>
+      <h1>You're now following a support ticket</h1>
+      <p>Hi {watcher_name}, <span class="highlight">{actor_name}</span> added you to ticket <strong style="color:#fff">{ticket_subject}</strong> (opened by {ticket_user}). You'll receive updates as the ticket progresses and can reply directly.</p>
+      {preview_block}
       <p style="margin-top:24px"><a class="btn" href="{frontend_url}/support?ticket={ticket_uuid}">View Ticket</a></p>
       <div class="footer">Vandalizer Support System</div>
     </div></div></body></html>"""

--- a/backend/app/services/support_service.py
+++ b/backend/app/services/support_service.py
@@ -1,15 +1,18 @@
 """Support ticket service."""
 
+import asyncio
 import datetime
 import logging
 from pathlib import Path
 
 import redis.asyncio as aioredis
+from pymongo import ReturnDocument
 
 from app.config import Settings
 from app.services.email_service import _BASE_STYLE
 from app.models.support import (
     SupportAttachment,
+    SupportCounter,
     SupportMessage,
     SupportTicket,
     TicketPriority,
@@ -25,6 +28,59 @@ logger = logging.getLogger(__name__)
 # Cooldown in seconds — skip email if we already emailed this person about
 # this ticket within this window (avoids spam during live chat).
 _EMAIL_COOLDOWN_SECONDS = 600  # 10 minutes
+
+# Sequential ticket numbers start at this base — "#1001" reads better than
+# "#1" and makes it obvious it isn't an internal db id.
+_TICKET_NUMBER_BASE = 1000
+
+_counter_init_lock = asyncio.Lock()
+_counter_initialized = False
+
+
+async def _ensure_counter_initialized() -> None:
+    """First-call backfill: assign ticket_number to legacy tickets and seed
+    the counter. Idempotent; the asyncio lock guards concurrent inserts on
+    process start.
+    """
+    global _counter_initialized
+    if _counter_initialized:
+        return
+    async with _counter_init_lock:
+        if _counter_initialized:
+            return
+        coll = SupportCounter.get_motor_collection()
+        existing = await coll.find_one({"name": "support_ticket"})
+        if existing is None:
+            # Chronological backfill so older tickets get smaller numbers.
+            legacy = (
+                await SupportTicket.find({"ticket_number": None})
+                .sort("+created_at")
+                .to_list()
+            )
+            next_num = 0
+            for t in legacy:
+                next_num += 1
+                t.ticket_number = _TICKET_NUMBER_BASE + next_num
+                await t.save()
+            await coll.update_one(
+                {"name": "support_ticket"},
+                {"$set": {"name": "support_ticket", "value": next_num}},
+                upsert=True,
+            )
+        _counter_initialized = True
+
+
+async def _next_ticket_number() -> int:
+    """Atomically reserve the next ticket number."""
+    await _ensure_counter_initialized()
+    coll = SupportCounter.get_motor_collection()
+    res = await coll.find_one_and_update(
+        {"name": "support_ticket"},
+        {"$inc": {"value": 1}},
+        upsert=True,
+        return_document=ReturnDocument.AFTER,
+    )
+    return _TICKET_NUMBER_BASE + int(res["value"])
 
 
 def _iso_utc(dt: datetime.datetime | None) -> str | None:
@@ -59,9 +115,32 @@ async def _check_email_cooldown(ticket_uuid: str, recipient: str) -> bool:
         return True
 
 
-def _ticket_to_dict(t: SupportTicket) -> dict:
+async def _hydrate_watchers(user_ids: list[str]) -> list[dict]:
+    """Look up watcher user_ids and return [{user_id, name, email}] dicts.
+
+    Users that no longer exist are returned with just their user_id so the
+    UI can still render and unfollow them.
+    """
+    if not user_ids:
+        return []
+    users = await User.find({"user_id": {"$in": list(user_ids)}}).to_list()
+    by_id = {u.user_id: u for u in users}
+    result: list[dict] = []
+    for uid in user_ids:
+        u = by_id.get(uid)
+        result.append({
+            "user_id": uid,
+            "name": (u.name if u else None) or uid,
+            "email": u.email if u else None,
+        })
+    return result
+
+
+async def _ticket_to_dict(t: SupportTicket) -> dict:
+    watcher_ids = list(getattr(t, "watchers", []) or [])
     return {
         "uuid": t.uuid,
+        "ticket_number": getattr(t, "ticket_number", None),
         "subject": t.subject,
         "status": t.status.value,
         "priority": t.priority.value,
@@ -78,6 +157,7 @@ def _ticket_to_dict(t: SupportTicket) -> dict:
                 "content": m.content,
                 "is_support_reply": m.is_support_reply,
                 "created_at": _iso_utc(m.created_at),
+                "edited_at": _iso_utc(getattr(m, "edited_at", None)),
             }
             for m in t.messages
         ],
@@ -98,6 +178,7 @@ def _ticket_to_dict(t: SupportTicket) -> dict:
         "closed_at": _iso_utc(t.closed_at),
         "category": t.category,
         "tags": list(getattr(t, "tags", []) or []),
+        "watchers": await _hydrate_watchers(watcher_ids),
     }
 
 
@@ -106,6 +187,7 @@ def _ticket_summary(t: SupportTicket) -> dict:
     last_message = t.messages[-1] if t.messages else None
     return {
         "uuid": t.uuid,
+        "ticket_number": getattr(t, "ticket_number", None),
         "subject": t.subject,
         "status": t.status.value,
         "priority": t.priority.value,
@@ -126,6 +208,10 @@ def _ticket_summary(t: SupportTicket) -> dict:
         "read_by": t.read_by,
         "category": t.category,
         "tags": list(getattr(t, "tags", []) or []),
+        # List view only needs the user_ids — the full name/email lookup is
+        # done in the ticket detail view. We surface them here so the UI can
+        # show a "Watching" badge for the current user without an extra fetch.
+        "watcher_ids": list(getattr(t, "watchers", []) or []),
         "created_at": _iso_utc(t.created_at),
         "updated_at": _iso_utc(t.updated_at),
         "closed_at": _iso_utc(t.closed_at),
@@ -146,6 +232,7 @@ async def create_ticket(
         is_support_reply=False,
     )
     ticket = SupportTicket(
+        ticket_number=await _next_ticket_number(),
         subject=subject,
         priority=TicketPriority(priority),
         user_id=user.user_id,
@@ -159,7 +246,7 @@ async def create_ticket(
     # Notify support contacts
     await _notify_support_contacts_new_ticket(ticket)
 
-    return _ticket_to_dict(ticket)
+    return await _ticket_to_dict(ticket)
 
 
 # Trial check-in prompts are stored as support tickets with this category.
@@ -193,9 +280,16 @@ async def list_tickets(
     limit: int = 50,
     offset: int = 0,
 ) -> list[dict]:
+    """List tickets the given user_id owns *or* is tagged as a watcher on.
+
+    Watched tickets are surfaced in the same list as owned ones so the
+    requester sees a single unified queue — owner_tickets vs. tickets I
+    follow are distinguished client-side via `user_id` vs. `watcher_ids`.
+    """
     query: dict = {}
     if user_id:
-        query["user_id"] = user_id
+        # Owner OR watcher. We $or this with the other filters via $and.
+        query["$or"] = [{"user_id": user_id}, {"watchers": user_id}]
     if status:
         query["status"] = status
     if assigned_to:
@@ -254,7 +348,7 @@ async def get_ticket(ticket_uuid: str) -> dict | None:
     ticket = await SupportTicket.find_one(SupportTicket.uuid == ticket_uuid)
     if not ticket:
         return None
-    return _ticket_to_dict(ticket)
+    return await _ticket_to_dict(ticket)
 
 
 async def mark_ticket_read(ticket_uuid: str, user_id: str) -> bool:
@@ -317,8 +411,62 @@ async def add_message(
         await _email_ticket_owner_reply(ticket, msg)
     else:
         await _notify_support_contacts_new_message(ticket, msg)
+        # Watchers can reply too — when they do, the owner needs to know
+        # (the support-contacts branch above covers support staff).
+        if user.user_id != ticket.user_id:
+            await create_notification(
+                user_id=ticket.user_id,
+                kind="support_new_message",
+                title=f"New message on ticket: {ticket.subject}",
+                body=msg.content[:120],
+                link=f"/support?ticket={ticket.uuid}",
+                item_kind="support_ticket",
+                item_id=ticket.uuid,
+                item_name=ticket.subject,
+            )
 
-    return _ticket_to_dict(ticket)
+    # Notify watchers on every new message (they followed the ticket precisely
+    # to stay in the loop). Skip the sender — they obviously know.
+    await _notify_watchers_new_message(ticket, msg)
+
+    return await _ticket_to_dict(ticket)
+
+
+async def edit_message(
+    ticket_uuid: str,
+    message_uuid: str,
+    user: User,
+    content: str,
+) -> tuple[dict | None, str | None]:
+    """Edit an existing message's content. Only the author can edit.
+
+    Returns (ticket_dict, error). ``error`` is set on permission/validation
+    failures so the router can map it to a 4xx response.
+    """
+    cleaned = (content or "").strip()
+    if not cleaned:
+        return None, "Message content is required"
+
+    ticket = await SupportTicket.find_one(SupportTicket.uuid == ticket_uuid)
+    if not ticket:
+        return None, "Ticket not found"
+
+    target: SupportMessage | None = None
+    for m in ticket.messages:
+        if m.uuid == message_uuid:
+            target = m
+            break
+    if target is None:
+        return None, "Message not found"
+
+    if target.user_id != user.user_id:
+        return None, "You can only edit your own messages"
+
+    target.content = cleaned
+    target.edited_at = datetime.datetime.now(datetime.timezone.utc)
+    ticket.updated_at = target.edited_at
+    await ticket.save()
+    return await _ticket_to_dict(ticket), None
 
 
 def _support_attachments_dir() -> Path:
@@ -357,7 +505,7 @@ async def add_attachment(
     ticket.attachments.append(att)
     ticket.updated_at = datetime.datetime.now(datetime.timezone.utc)
     await ticket.save()
-    return _ticket_to_dict(ticket)
+    return await _ticket_to_dict(ticket)
 
 
 async def get_attachment_data(ticket_uuid: str, attachment_uuid: str) -> dict | None:
@@ -441,12 +589,169 @@ async def update_ticket(
         )
         # Email the ticket owner about status change
         await _email_ticket_owner_status(ticket, status)
+        # Watchers asked to follow the ticket — keep them in the loop on
+        # status changes too (in-app notification only; no email blast).
+        await _notify_watchers_status(ticket, status, actor)
 
     # Email the other support agents when tags are added.
     if added_tags:
         await _notify_support_contacts_tag_added(ticket, added_tags, actor)
 
-    return _ticket_to_dict(ticket)
+    return await _ticket_to_dict(ticket)
+
+
+# ---------------------------------------------------------------------------
+# Watchers — users tagged on a ticket to follow its progress
+# ---------------------------------------------------------------------------
+
+async def add_watcher(
+    ticket_uuid: str,
+    actor: User,
+    email: str,
+) -> tuple[dict | None, str | None]:
+    """Tag a user (by email) as a watcher on the ticket.
+
+    Returns (ticket_dict, error). ``error`` is set if the email doesn't map
+    to a real account, or the user is the ticket owner (already participant).
+    """
+    ticket = await SupportTicket.find_one(SupportTicket.uuid == ticket_uuid)
+    if not ticket:
+        return None, "Ticket not found"
+
+    normalized = (email or "").strip().lower()
+    if not normalized:
+        return None, "Email is required"
+
+    target = await User.find_one(User.email == normalized)
+    if not target:
+        return None, f"No Vandalizer account found for {email}"
+
+    if target.user_id == ticket.user_id:
+        return None, "That user already owns this ticket"
+
+    if target.user_id in (ticket.watchers or []):
+        # Idempotent — return the ticket without re-notifying.
+        return await _ticket_to_dict(ticket), None
+
+    ticket.watchers = list(ticket.watchers or []) + [target.user_id]
+    ticket.updated_at = datetime.datetime.now(datetime.timezone.utc)
+    await ticket.save()
+
+    await _notify_watcher_added(ticket, target, actor)
+
+    return await _ticket_to_dict(ticket), None
+
+
+async def remove_watcher(
+    ticket_uuid: str,
+    watcher_user_id: str,
+) -> dict | None:
+    ticket = await SupportTicket.find_one(SupportTicket.uuid == ticket_uuid)
+    if not ticket:
+        return None
+    current = list(ticket.watchers or [])
+    if watcher_user_id not in current:
+        return await _ticket_to_dict(ticket)
+    ticket.watchers = [w for w in current if w != watcher_user_id]
+    ticket.updated_at = datetime.datetime.now(datetime.timezone.utc)
+    await ticket.save()
+    return await _ticket_to_dict(ticket)
+
+
+async def _notify_watcher_added(
+    ticket: SupportTicket, watcher: User, actor: User,
+) -> None:
+    """Notify a user that they've been tagged on a ticket — in-app + email."""
+    actor_name = (actor.name or actor.user_id) if actor else "Someone"
+    first_message = ticket.messages[0].content if ticket.messages else ""
+    await create_notification(
+        user_id=watcher.user_id,
+        kind="support_watcher_added",
+        title=f"{actor_name} added you to a support ticket",
+        body=ticket.subject,
+        link=f"/support?ticket={ticket.uuid}",
+        item_kind="support_ticket",
+        item_id=ticket.uuid,
+        item_name=ticket.subject,
+    )
+    if not watcher.email:
+        return
+    settings = Settings()
+    from app.services.email_service import support_watcher_added_email
+    subject, html = support_watcher_added_email(
+        watcher_name=watcher.name or watcher.user_id,
+        ticket_subject=ticket.subject,
+        ticket_user=ticket.user_name or ticket.user_id,
+        actor_name=actor_name,
+        first_message=first_message,
+        ticket_uuid=ticket.uuid,
+        frontend_url=settings.frontend_url,
+        ticket_number=ticket.ticket_number,
+    )
+    await send_email(
+        watcher.email, subject, html, settings, email_type="support_watcher_added",
+    )
+
+
+async def _notify_watchers_new_message(
+    ticket: SupportTicket, msg: SupportMessage,
+) -> None:
+    """In-app notification (and cooldown-respecting email) to each watcher."""
+    if not ticket.watchers:
+        return
+    watchers = await User.find({"user_id": {"$in": list(ticket.watchers)}}).to_list()
+    settings = Settings()
+    for w in watchers:
+        if w.user_id == msg.user_id:
+            continue  # sender already knows
+        await create_notification(
+            user_id=w.user_id,
+            kind="support_new_message",
+            title=f"New message on ticket: {ticket.subject}",
+            body=msg.content[:120],
+            link=f"/support?ticket={ticket.uuid}",
+            item_kind="support_ticket",
+            item_id=ticket.uuid,
+            item_name=ticket.subject,
+        )
+        if w.email and await _check_email_cooldown(ticket.uuid, w.user_id):
+            from app.services.email_service import support_new_message_email
+            subject, html = support_new_message_email(
+                support_name=w.name or w.user_id,
+                ticket_subject=ticket.subject,
+                ticket_user=msg.user_name or msg.user_id,
+                message=msg.content,
+                ticket_uuid=ticket.uuid,
+                frontend_url=settings.frontend_url,
+                ticket_number=ticket.ticket_number,
+            )
+            await send_email(
+                w.email, subject, html, settings,
+                email_type="support_new_message",
+            )
+
+
+async def _notify_watchers_status(
+    ticket: SupportTicket, new_status: str, actor: User | None,
+) -> None:
+    """In-app only — watchers see status flips alongside the ticket owner."""
+    if not ticket.watchers:
+        return
+    actor_id = actor.user_id if actor else None
+    pretty = new_status.replace("_", " ")
+    for watcher_id in ticket.watchers:
+        if watcher_id == actor_id:
+            continue
+        await create_notification(
+            user_id=watcher_id,
+            kind="support_status",
+            title=f"Ticket {pretty}",
+            body=f"\"{ticket.subject}\" was marked as {pretty}.",
+            link=f"/support?ticket={ticket.uuid}",
+            item_kind="support_ticket",
+            item_id=ticket.uuid,
+            item_name=ticket.subject,
+        )
 
 
 async def get_support_contacts() -> list[dict]:
@@ -490,7 +795,8 @@ async def _notify_support_contacts_new_ticket(ticket: SupportTicket) -> None:
 
         # Email notification
         if email:
-            subject = f"New Support Ticket: {ticket.subject}"
+            num_prefix = f"[#{ticket.ticket_number}] " if ticket.ticket_number else ""
+            subject = f"{num_prefix}New Support Ticket: {ticket.subject}"
             html = _new_ticket_email(
                 support_name=name,
                 ticket_subject=ticket.subject,
@@ -498,6 +804,7 @@ async def _notify_support_contacts_new_ticket(ticket: SupportTicket) -> None:
                 message=ticket.messages[0].content if ticket.messages else "",
                 ticket_uuid=ticket.uuid,
                 frontend_url=settings.frontend_url,
+                ticket_number=ticket.ticket_number,
             )
             await send_email(email, subject, html, settings, email_type="support_new_ticket")
 
@@ -534,6 +841,7 @@ async def _notify_support_contacts_new_message(
                     message=msg.content,
                     ticket_uuid=ticket.uuid,
                     frontend_url=settings.frontend_url,
+                    ticket_number=ticket.ticket_number,
                 )
                 await send_email(email, subject, html, settings, email_type="support_new_message")
 
@@ -567,6 +875,7 @@ async def _notify_support_contacts_tag_added(
             actor_name=actor_name,
             ticket_uuid=ticket.uuid,
             frontend_url=settings.frontend_url,
+            ticket_number=ticket.ticket_number,
         )
         await send_email(email, subject, html, settings, email_type="support_tag_added")
 
@@ -588,6 +897,7 @@ async def _email_ticket_owner_reply(
         message=msg.content,
         ticket_uuid=ticket.uuid,
         frontend_url=settings.frontend_url,
+        ticket_number=ticket.ticket_number,
     )
     await send_email(owner.email, subject, html, settings, email_type="support_reply")
 
@@ -607,6 +917,7 @@ async def _email_ticket_owner_status(
         new_status=new_status.replace("_", " "),
         ticket_uuid=ticket.uuid,
         frontend_url=settings.frontend_url,
+        ticket_number=ticket.ticket_number,
     )
     await send_email(owner.email, subject, html, settings, email_type="support_status")
 
@@ -629,12 +940,20 @@ def _new_ticket_email(
     message: str,
     ticket_uuid: str,
     frontend_url: str,
+    ticket_number: int | None = None,
 ) -> str:
+    number_line = (
+        f'<p><strong style="color:#fff">Ticket:</strong> '
+        f'<span class="highlight">#{ticket_number}</span></p>'
+        if ticket_number is not None
+        else ""
+    )
     return f"""<!DOCTYPE html><html><head>{_STYLE}</head><body>
     <div class="container"><div class="card">
       <div class="logo">Vandalizer Support</div>
       <h1>New Support Ticket</h1>
       <p>Hi {support_name}, a new support ticket has been created.</p>
+      {number_line}
       <p><strong style="color:#fff">From:</strong> {ticket_user}<br/>
          <strong style="color:#fff">Subject:</strong> <span class="highlight">{ticket_subject}</span></p>
       <div class="message-box"><p style="margin:0">{message[:500]}</p></div>

--- a/backend/tests/test_support_service_helpers.py
+++ b/backend/tests/test_support_service_helpers.py
@@ -37,7 +37,11 @@ def _enum(value: str) -> SimpleNamespace:
     return SimpleNamespace(value=value)
 
 
-def _message(content: str = "hi", is_support_reply: bool = False) -> SimpleNamespace:
+def _message(
+    content: str = "hi",
+    is_support_reply: bool = False,
+    edited_at: datetime.datetime | None = None,
+) -> SimpleNamespace:
     return SimpleNamespace(
         uuid=f"msg-{content[:3]}",
         user_id="alice",
@@ -45,6 +49,7 @@ def _message(content: str = "hi", is_support_reply: bool = False) -> SimpleNames
         content=content,
         is_support_reply=is_support_reply,
         created_at=datetime.datetime(2026, 3, 5, 10, 0, 0),
+        edited_at=edited_at,
     )
 
 
@@ -59,9 +64,15 @@ def _attachment(filename: str = "f.pdf") -> SimpleNamespace:
     )
 
 
-def _ticket(messages=None, attachments=None) -> SimpleNamespace:
+def _ticket(
+    messages=None,
+    attachments=None,
+    watchers=None,
+    ticket_number: int | None = 1042,
+) -> SimpleNamespace:
     return SimpleNamespace(
         uuid="t-1",
+        ticket_number=ticket_number,
         subject="Need help",
         status=_enum("open"),
         priority=_enum("normal"),
@@ -75,6 +86,7 @@ def _ticket(messages=None, attachments=None) -> SimpleNamespace:
         read_by=["alice"],
         category="bug",
         tags=[],
+        watchers=watchers if watchers is not None else [],
         created_at=datetime.datetime(2026, 3, 5, 9, 0, 0),
         updated_at=datetime.datetime(2026, 3, 5, 11, 0, 0),
         closed_at=None,
@@ -82,26 +94,39 @@ def _ticket(messages=None, attachments=None) -> SimpleNamespace:
 
 
 class TestTicketToDict:
-    def test_basic_shape_with_no_messages_or_attachments(self):
-        d = _ticket_to_dict(_ticket())
+    async def test_basic_shape_with_no_messages_or_attachments(self):
+        d = await _ticket_to_dict(_ticket())
         assert d["uuid"] == "t-1"
+        assert d["ticket_number"] == 1042
         assert d["status"] == "open"
         assert d["priority"] == "normal"
         assert d["messages"] == []
         assert d["attachments"] == []
         assert d["message_count"] == 0
         assert d["closed_at"] is None
+        assert d["watchers"] == []
         # Timestamps should be ISO strings with a timezone offset.
         assert d["created_at"].endswith("+00:00")
 
-    def test_messages_and_attachments_serialized(self):
+    async def test_messages_and_attachments_serialized(self):
         msgs = [_message("first"), _message("second reply", is_support_reply=True)]
         atts = [_attachment("notes.pdf")]
-        d = _ticket_to_dict(_ticket(messages=msgs, attachments=atts))
+        d = await _ticket_to_dict(_ticket(messages=msgs, attachments=atts))
         assert d["message_count"] == 2
         assert d["messages"][1]["is_support_reply"] is True
+        assert d["messages"][0]["edited_at"] is None
         assert d["attachments"][0]["filename"] == "notes.pdf"
         assert d["attachments"][0]["created_at"].endswith("+00:00")
+
+    async def test_edited_message_surfaces_edited_at(self):
+        edited = datetime.datetime(2026, 3, 5, 10, 30, 0)
+        msgs = [_message("first", edited_at=edited)]
+        d = await _ticket_to_dict(_ticket(messages=msgs))
+        assert d["messages"][0]["edited_at"] == "2026-03-05T10:30:00+00:00"
+
+    async def test_legacy_ticket_without_number_serializes_as_none(self):
+        d = await _ticket_to_dict(_ticket(ticket_number=None))
+        assert d["ticket_number"] is None
 
 
 class TestTicketSummary:
@@ -112,6 +137,12 @@ class TestTicketSummary:
         assert s["last_message_at"] is None
         assert s["last_message_is_support_reply"] is None
         assert s["last_message_user_id"] is None
+        assert s["watcher_ids"] == []
+        assert s["ticket_number"] == 1042
+
+    def test_summary_for_legacy_ticket_without_number(self):
+        s = _ticket_summary(_ticket(ticket_number=None))
+        assert s["ticket_number"] is None
 
     def test_last_message_preview_truncated_to_120_chars(self):
         long = "A" * 500
@@ -128,3 +159,44 @@ class TestTicketSummary:
         assert s["last_message_is_support_reply"] is True
         assert s["last_message_user_id"] == "alice"
         assert s["read_by"] == ["alice"]
+
+    def test_watcher_ids_surfaced_for_list_view(self):
+        s = _ticket_summary(_ticket(watchers=["bob", "carol"]))
+        # List view returns just the ids — the client uses them to decide
+        # whether to show a "Watching" badge without re-fetching the user.
+        assert s["watcher_ids"] == ["bob", "carol"]
+
+
+# ---------------------------------------------------------------------------
+# Watcher view-permission helper in the router
+# ---------------------------------------------------------------------------
+
+class TestCanViewTicket:
+    def _ticket_dict(self, owner: str = "alice", watchers=None) -> dict:
+        return {
+            "uuid": "t-1",
+            "user_id": owner,
+            "watchers": [
+                {"user_id": w, "name": w, "email": None} for w in (watchers or [])
+            ],
+        }
+
+    def _user(self, uid: str) -> SimpleNamespace:
+        return SimpleNamespace(user_id=uid)
+
+    def test_owner_can_view(self):
+        from app.routers.support import _can_view_ticket
+        assert _can_view_ticket(self._ticket_dict(), self._user("alice"), False)
+
+    def test_support_can_view_anything(self):
+        from app.routers.support import _can_view_ticket
+        assert _can_view_ticket(self._ticket_dict(), self._user("agent"), True)
+
+    def test_watcher_can_view(self):
+        from app.routers.support import _can_view_ticket
+        t = self._ticket_dict(watchers=["bob"])
+        assert _can_view_ticket(t, self._user("bob"), False)
+
+    def test_stranger_blocked(self):
+        from app.routers.support import _can_view_ticket
+        assert not _can_view_ticket(self._ticket_dict(), self._user("eve"), False)

--- a/frontend/src/api/support.ts
+++ b/frontend/src/api/support.ts
@@ -57,6 +57,20 @@ export function addMessage(ticketUuid: string, content: string) {
   })
 }
 
+export function editMessage(
+  ticketUuid: string,
+  messageUuid: string,
+  content: string,
+) {
+  return apiFetch<SupportTicket>(
+    `/api/support/tickets/${ticketUuid}/messages/${messageUuid}`,
+    {
+      method: 'PATCH',
+      body: JSON.stringify({ content }),
+    },
+  )
+}
+
 export async function addAttachment(
   ticketUuid: string,
   file: File,
@@ -103,4 +117,18 @@ export function getSupportContacts() {
 
 export function listAllTags() {
   return apiFetch<{ tags: string[] }>('/api/support/tags')
+}
+
+export function addWatcher(ticketUuid: string, email: string) {
+  return apiFetch<SupportTicket>(`/api/support/tickets/${ticketUuid}/watchers`, {
+    method: 'POST',
+    body: JSON.stringify({ email }),
+  })
+}
+
+export function removeWatcher(ticketUuid: string, watcherUserId: string) {
+  return apiFetch<SupportTicket>(
+    `/api/support/tickets/${ticketUuid}/watchers/${encodeURIComponent(watcherUserId)}`,
+    { method: 'DELETE' },
+  )
 }

--- a/frontend/src/components/support/SupportChatPanel.tsx
+++ b/frontend/src/components/support/SupportChatPanel.tsx
@@ -2,14 +2,18 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import {
   ArrowLeft,
+  Check,
   CheckCircle2,
   Circle,
   Clock,
+  Eye,
   Loader2,
   MessageSquare,
   Paperclip,
+  Pencil,
   Plus,
   Send,
+  UserPlus,
   X,
 } from 'lucide-react'
 import { useAuth } from '../../hooks/useAuth'
@@ -101,6 +105,8 @@ function TicketListView({
           <>
             {open.map((t) => {
               const attention = needsAttention(t)
+              const isWatching = t.user_id !== currentUserId
+                && (t.watcher_ids ?? []).includes(currentUserId)
               return (
                 <button
                   key={t.uuid}
@@ -117,7 +123,19 @@ function TicketListView({
                           Check-in
                         </span>
                       )}
+                      {isWatching && (
+                        <span
+                          className="shrink-0 inline-flex items-center gap-0.5 rounded bg-indigo-50 px-1 py-0.5 text-[9px] font-bold uppercase text-indigo-700"
+                          title="You were tagged on this ticket"
+                        >
+                          <Eye className="h-2.5 w-2.5" />
+                          Watching
+                        </span>
+                      )}
                       <p className={`truncate text-sm ${attention ? 'font-semibold text-gray-900' : 'font-medium text-gray-900'}`}>
+                        {t.ticket_number != null && (
+                          <span className="mr-1 font-mono text-[11px] text-gray-400">#{t.ticket_number}</span>
+                        )}
                         {t.subject}
                       </p>
                       {attention && (
@@ -154,7 +172,12 @@ function TicketListView({
                   >
                     <span className={`mt-1.5 h-2 w-2 shrink-0 rounded-full ${STATUS_DOT.closed}`} />
                     <div className="min-w-0 flex-1">
-                      <p className="truncate text-sm text-gray-700">{t.subject}</p>
+                      <p className="truncate text-sm text-gray-700">
+                        {t.ticket_number != null && (
+                          <span className="mr-1 font-mono text-[11px] text-gray-400">#{t.ticket_number}</span>
+                        )}
+                        {t.subject}
+                      </p>
                     </div>
                     <span className="text-[10px] text-gray-400">{timeAgo(t.updated_at)}</span>
                   </button>
@@ -394,6 +417,9 @@ function ChatView({
   const [sending, setSending] = useState(false)
   const [updatingStatus, setUpdatingStatus] = useState(false)
   const [previewAttachment, setPreviewAttachment] = useState<import('../../types/support').SupportAttachment | null>(null)
+  const [editingMessageUuid, setEditingMessageUuid] = useState<string | null>(null)
+  const [editDraft, setEditDraft] = useState('')
+  const [savingEdit, setSavingEdit] = useState(false)
   const messagesEndRef = useRef<HTMLDivElement>(null)
   const fileInputRef = useRef<HTMLInputElement>(null)
 
@@ -465,6 +491,33 @@ function ChatView({
     }
   }
 
+  const startEdit = (msg: import('../../types/support').SupportMessage) => {
+    setEditingMessageUuid(msg.uuid)
+    setEditDraft(msg.content)
+  }
+
+  const cancelEdit = () => {
+    setEditingMessageUuid(null)
+    setEditDraft('')
+  }
+
+  const saveEdit = async () => {
+    if (!editingMessageUuid) return
+    const trimmed = editDraft.trim()
+    if (!trimmed) return
+    setSavingEdit(true)
+    try {
+      const updated = await supportApi.editMessage(ticketUuid, editingMessageUuid, trimmed)
+      setTicket(updated)
+      cancelEdit()
+    } catch (err) {
+      const m = err instanceof Error ? err.message : 'Could not save edit'
+      toast(m, 'error')
+    } finally {
+      setSavingEdit(false)
+    }
+  }
+
   const handleStatusChange = async (newStatus: string) => {
     setUpdatingStatus(true)
     try {
@@ -507,7 +560,12 @@ function ChatView({
             <ArrowLeft className="h-4 w-4" />
           </button>
           <div className="min-w-0 flex-1">
-            <p className="truncate text-sm font-medium text-gray-900">{ticket.subject}</p>
+            <p className="truncate text-sm font-medium text-gray-900">
+              {ticket.ticket_number != null && (
+                <span className="mr-1 font-mono text-[11px] text-gray-400">#{ticket.ticket_number}</span>
+              )}
+              {ticket.subject}
+            </p>
             <div className="flex items-center gap-2">
               <StatusIcon className={`h-3 w-3 ${
                 ticket.status === 'closed' ? 'text-gray-400' : ticket.status === 'in_progress' ? 'text-blue-500' : 'text-yellow-500'
@@ -561,15 +619,23 @@ function ChatView({
             )}
           </div>
         )}
+
+        {/* Watchers — visible to everyone on the ticket */}
+        <WatcherBar
+          ticket={ticket}
+          currentUserId={user?.user_id ?? ''}
+          onChange={setTicket}
+        />
       </div>
 
       {/* Messages */}
       <div className="flex-1 overflow-y-auto px-4 py-3 space-y-3">
         {ticket.messages.map((msg) => {
           const isMe = msg.user_id === user?.user_id
+          const isEditing = editingMessageUuid === msg.uuid
           const msgAttachments = ticket.attachments.filter(a => a.message_uuid === msg.uuid)
           return (
-            <div key={msg.uuid} className={`flex flex-col ${isMe ? 'items-end' : 'items-start'}`}>
+            <div key={msg.uuid} className={`group flex flex-col ${isMe ? 'items-end' : 'items-start'}`}>
               <div
                 className={`max-w-[85%] rounded-xl px-3 py-2 ${
                   isMe
@@ -582,11 +648,61 @@ function ChatView({
                     {msg.user_name || 'Support'}
                   </p>
                 )}
-                <p className="whitespace-pre-wrap text-sm">{msg.content}</p>
+                {isEditing ? (
+                  <div className="flex flex-col gap-1.5">
+                    <textarea
+                      autoFocus
+                      value={editDraft}
+                      onChange={(e) => setEditDraft(e.target.value)}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+                          e.preventDefault()
+                          saveEdit()
+                        }
+                        if (e.key === 'Escape') {
+                          e.preventDefault()
+                          cancelEdit()
+                        }
+                      }}
+                      rows={Math.min(8, Math.max(2, editDraft.split('\n').length))}
+                      className="resize-none rounded-md px-2 py-1 text-sm text-gray-900 bg-white/95 focus:outline-none focus:ring-2 focus:ring-blue-300"
+                    />
+                    <div className="flex items-center justify-end gap-1">
+                      <button
+                        onClick={cancelEdit}
+                        disabled={savingEdit}
+                        className="rounded px-2 py-0.5 text-[11px] font-medium text-white/90 hover:bg-white/10 disabled:opacity-50"
+                      >
+                        Cancel
+                      </button>
+                      <button
+                        onClick={saveEdit}
+                        disabled={savingEdit || !editDraft.trim()}
+                        className="inline-flex items-center gap-1 rounded bg-white/20 px-2 py-0.5 text-[11px] font-medium text-white hover:bg-white/30 disabled:opacity-50"
+                      >
+                        {savingEdit ? <Loader2 className="h-3 w-3 animate-spin" /> : <Check className="h-3 w-3" />}
+                        Save
+                      </button>
+                    </div>
+                  </div>
+                ) : (
+                  <p className="whitespace-pre-wrap text-sm">{msg.content}</p>
+                )}
                 <p className={`mt-1 text-[10px] ${isMe ? 'text-blue-200' : 'text-gray-400'}`}>
                   {timeAgo(msg.created_at)}
+                  {msg.edited_at && <span className="ml-1 italic">(edited)</span>}
                 </p>
               </div>
+              {isMe && !isEditing && (
+                <button
+                  onClick={() => startEdit(msg)}
+                  className="mt-0.5 inline-flex items-center gap-0.5 rounded px-1 py-0.5 text-[10px] text-gray-400 opacity-0 transition-opacity hover:bg-gray-100 hover:text-gray-600 group-hover:opacity-100"
+                  title="Edit message"
+                >
+                  <Pencil className="h-2.5 w-2.5" />
+                  Edit
+                </button>
+              )}
               {msgAttachments.length > 0 && (
                 <div className={`flex flex-col gap-1.5 mt-1.5 max-w-[85%] ${isMe ? 'items-end' : 'items-start'}`}>
                   {msgAttachments.map((a) => (
@@ -674,6 +790,117 @@ function ChatView({
           </button>
         </div>
       </div>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Watcher bar — tagged users who see and follow the ticket
+// ---------------------------------------------------------------------------
+
+function WatcherBar({
+  ticket,
+  currentUserId,
+  onChange,
+}: {
+  ticket: SupportTicket
+  currentUserId: string
+  onChange: (next: SupportTicket) => void
+}) {
+  const { toast } = useToast()
+  const [adding, setAdding] = useState(false)
+  const [email, setEmail] = useState('')
+  const [busy, setBusy] = useState(false)
+
+  const watchers = ticket.watchers ?? []
+  // Anyone who can view the ticket can add/remove watchers from the UI; the
+  // backend enforces the actual rule (owner, support, or self-remove). We
+  // simplify the client by always showing controls and letting a 403 toast.
+
+  const submit = async () => {
+    const trimmed = email.trim()
+    if (!trimmed || busy) return
+    setBusy(true)
+    try {
+      const updated = await supportApi.addWatcher(ticket.uuid, trimmed)
+      onChange(updated)
+      setEmail('')
+      setAdding(false)
+      toast('Watcher added', 'success')
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Could not add watcher'
+      toast(msg, 'error')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const remove = async (userId: string) => {
+    try {
+      const updated = await supportApi.removeWatcher(ticket.uuid, userId)
+      onChange(updated)
+    } catch {
+      toast('Could not remove watcher', 'error')
+    }
+  }
+
+  return (
+    <div className="mt-2 ml-7 flex flex-wrap items-center gap-1.5">
+      <span
+        className="inline-flex items-center gap-1 text-[10px] font-medium uppercase text-gray-400"
+        title="Tagged users follow this ticket and get notified on updates"
+      >
+        <Eye className="h-3 w-3" />
+        Watchers
+      </span>
+      {watchers.length === 0 && !adding && (
+        <span className="text-[11px] text-gray-400">None</span>
+      )}
+      {watchers.map((w) => {
+        const isMe = w.user_id === currentUserId
+        return (
+          <span
+            key={w.user_id}
+            className="inline-flex items-center gap-1 rounded-full bg-indigo-50 px-2 py-0.5 text-[11px] font-medium text-indigo-700"
+            title={w.email || w.user_id}
+          >
+            {isMe ? 'You' : w.name}
+            <button
+              onClick={() => remove(w.user_id)}
+              className="rounded-full p-0.5 text-indigo-500 hover:bg-indigo-100 hover:text-indigo-900"
+              title={isMe ? 'Stop watching' : `Remove ${w.name}`}
+            >
+              <X className="h-2.5 w-2.5" />
+            </button>
+          </span>
+        )
+      })}
+      {adding ? (
+        <input
+          autoFocus
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          onBlur={() => { if (!busy) { setEmail(''); setAdding(false) } }}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') { e.preventDefault(); submit() }
+            if (e.key === 'Escape') { setEmail(''); setAdding(false) }
+          }}
+          placeholder="email…"
+          type="email"
+          disabled={busy}
+          className="rounded-full border border-gray-300 px-2 py-0.5 text-[11px] outline-none focus:border-blue-500 disabled:opacity-50"
+          style={{ minWidth: 140 }}
+        />
+      ) : (
+        <button
+          onClick={() => setAdding(true)}
+          className="inline-flex items-center gap-1 rounded-full border border-dashed border-gray-300 px-2 py-0.5 text-[11px] text-gray-500 hover:border-blue-400 hover:text-blue-600"
+          title="Tag a user to follow this ticket"
+        >
+          <UserPlus className="h-2.5 w-2.5" />
+          Tag user
+        </button>
+      )}
     </div>
   )
 }

--- a/frontend/src/pages/SupportCenter.tsx
+++ b/frontend/src/pages/SupportCenter.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useState, useCallback, useRef } from 'react'
 import { Navigate, useNavigate, useSearch } from '@tanstack/react-router'
 import {
-  ArrowLeft, MessageSquare, Send, Plus, Paperclip, X, Loader2, Link2, Tag,
+  ArrowLeft, Check, MessageSquare, Send, Plus, Paperclip, Pencil, X, Loader2, Link2, Tag,
+  Eye, UserPlus,
 } from 'lucide-react'
 import { PageLayout } from '../components/layout/PageLayout'
 import { useAuth } from '../hooks/useAuth'
@@ -293,6 +294,16 @@ function ListView({
                   <div style={{ flex: 1, minWidth: 0 }}>
                     <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
                       {needsAttention && <span style={{ width: 8, height: 8, borderRadius: '50%', background: '#3b82f6', flexShrink: 0 }} />}
+                      {t.ticket_number != null && (
+                        <span
+                          style={{
+                            fontSize: 12, fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+                            color: '#6b7280', flexShrink: 0,
+                          }}
+                        >
+                          #{t.ticket_number}
+                        </span>
+                      )}
                       <span style={{ fontSize: 14, fontWeight: 500, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
                         {t.subject}
                       </span>
@@ -530,12 +541,16 @@ function ChatView({
   ticketUuid: string
   onBack: () => void
 }) {
+  const { user } = useAuth()
   const { toast } = useToast()
   const [ticket, setTicket] = useState<SupportTicket | null>(null)
   const [loading, setLoading] = useState(true)
   const [reply, setReply] = useState('')
   const [sending, setSending] = useState(false)
   const [previewAttachment, setPreviewAttachment] = useState<SupportAttachment | null>(null)
+  const [editingMessageUuid, setEditingMessageUuid] = useState<string | null>(null)
+  const [editDraft, setEditDraft] = useState('')
+  const [savingEdit, setSavingEdit] = useState(false)
   const messagesEndRef = useRef<HTMLDivElement>(null)
   const fileInputRef = useRef<HTMLInputElement>(null)
 
@@ -581,6 +596,32 @@ function ChatView({
       setTicket(updated)
     } catch {
       toast('Failed to update status', 'error')
+    }
+  }
+
+  const startEdit = (msg: { uuid: string; content: string }) => {
+    setEditingMessageUuid(msg.uuid)
+    setEditDraft(msg.content)
+  }
+
+  const cancelEdit = () => {
+    setEditingMessageUuid(null)
+    setEditDraft('')
+  }
+
+  const saveEdit = async () => {
+    if (!editingMessageUuid) return
+    const trimmed = editDraft.trim()
+    if (!trimmed) return
+    setSavingEdit(true)
+    try {
+      const updated = await supportApi.editMessage(ticketUuid, editingMessageUuid, trimmed)
+      setTicket(updated)
+      cancelEdit()
+    } catch (err) {
+      toast(err instanceof Error ? err.message : 'Could not save edit', 'error')
+    } finally {
+      setSavingEdit(false)
     }
   }
 
@@ -639,7 +680,19 @@ function ChatView({
         {/* Header with requester + status controls */}
         <div style={{ padding: '16px 20px', borderBottom: '1px solid #e5e7eb', display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: 12, flexWrap: 'wrap' }}>
           <div style={{ minWidth: 0, flex: 1 }}>
-            <h3 style={{ margin: 0, fontSize: 16, fontWeight: 600, overflow: 'hidden', textOverflow: 'ellipsis' }}>{ticket.subject}</h3>
+            <h3 style={{ margin: 0, fontSize: 16, fontWeight: 600, overflow: 'hidden', textOverflow: 'ellipsis' }}>
+              {ticket.ticket_number != null && (
+                <span
+                  style={{
+                    fontSize: 13, fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+                    color: '#6b7280', marginRight: 8,
+                  }}
+                >
+                  #{ticket.ticket_number}
+                </span>
+              )}
+              {ticket.subject}
+            </h3>
             <div style={{ fontSize: 13, color: '#6b7280', marginTop: 4 }}>
               {ticket.user_name || ticket.user_id}
               {ticket.user_email ? ` (${ticket.user_email})` : ''}
@@ -720,10 +773,15 @@ function ChatView({
           }}
         />
 
+        {/* Watchers — tagged users who follow the ticket. Visible to all parties. */}
+        <WatcherBar ticket={ticket} onChange={setTicket} />
+
         {/* Messages — agent on right (blue, "Support" label), customer on left */}
         <div style={{ padding: 20, display: 'flex', flexDirection: 'column', gap: 12, maxHeight: 520, overflowY: 'auto' }}>
           {ticket.messages.map((m) => {
             const isSupport = m.is_support_reply
+            const isMine = m.user_id === user?.user_id
+            const isEditing = editingMessageUuid === m.uuid
             const msgAttachments = ticket.attachments.filter((a) => a.message_uuid === m.uuid)
             return (
               <div key={m.uuid} style={{ display: 'flex', flexDirection: 'column', alignItems: isSupport ? 'flex-end' : 'flex-start' }}>
@@ -736,11 +794,89 @@ function ChatView({
                     {m.user_name || m.user_id}
                     {isSupport && <span style={{ marginLeft: 6, fontSize: 10, fontWeight: 500, opacity: 0.85 }}>Support</span>}
                   </div>
-                  <div style={{ fontSize: 14, whiteSpace: 'pre-wrap' }}>{m.content}</div>
+                  {isEditing ? (
+                    <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+                      <textarea
+                        autoFocus
+                        value={editDraft}
+                        onChange={(e) => setEditDraft(e.target.value)}
+                        onKeyDown={(e) => {
+                          if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+                            e.preventDefault()
+                            saveEdit()
+                          }
+                          if (e.key === 'Escape') {
+                            e.preventDefault()
+                            cancelEdit()
+                          }
+                        }}
+                        rows={Math.min(10, Math.max(2, editDraft.split('\n').length))}
+                        style={{
+                          fontSize: 14, padding: '6px 8px', borderRadius: 6,
+                          border: '1px solid rgba(0,0,0,0.1)', resize: 'vertical',
+                          background: isSupport ? 'rgba(255,255,255,0.95)' : '#fff',
+                          color: '#111827', fontFamily: 'inherit', minWidth: 280,
+                        }}
+                      />
+                      <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 6 }}>
+                        <button
+                          onClick={cancelEdit}
+                          disabled={savingEdit}
+                          style={{
+                            padding: '2px 8px', fontSize: 11, fontWeight: 600,
+                            borderRadius: 6, border: 'none', cursor: 'pointer',
+                            background: 'transparent',
+                            color: isSupport ? 'rgba(255,255,255,0.85)' : '#6b7280',
+                            opacity: savingEdit ? 0.5 : 1,
+                          }}
+                        >
+                          Cancel
+                        </button>
+                        <button
+                          onClick={saveEdit}
+                          disabled={savingEdit || !editDraft.trim()}
+                          style={{
+                            display: 'inline-flex', alignItems: 'center', gap: 3,
+                            padding: '2px 10px', fontSize: 11, fontWeight: 600,
+                            borderRadius: 6, border: 'none', cursor: 'pointer',
+                            background: isSupport ? 'rgba(255,255,255,0.25)' : '#2563eb',
+                            color: '#fff',
+                            opacity: (savingEdit || !editDraft.trim()) ? 0.5 : 1,
+                          }}
+                        >
+                          {savingEdit ? (
+                            <Loader2 size={10} style={{ animation: 'spin 1s linear infinite' }} />
+                          ) : (
+                            <Check size={10} />
+                          )}
+                          Save
+                        </button>
+                      </div>
+                    </div>
+                  ) : (
+                    <div style={{ fontSize: 14, whiteSpace: 'pre-wrap' }}>{m.content}</div>
+                  )}
                   <div style={{ fontSize: 10, marginTop: 4, color: isSupport ? 'rgba(255,255,255,0.75)' : '#9ca3af' }}>
                     {timeAgo(m.created_at)}
+                    {m.edited_at && <span style={{ marginLeft: 4, fontStyle: 'italic' }}>(edited)</span>}
                   </div>
                 </div>
+                {isMine && !isEditing && (
+                  <button
+                    onClick={() => startEdit(m)}
+                    title="Edit message"
+                    style={{
+                      marginTop: 2, display: 'inline-flex', alignItems: 'center', gap: 3,
+                      padding: '2px 6px', fontSize: 11, color: '#9ca3af',
+                      background: 'transparent', border: 'none', cursor: 'pointer',
+                      borderRadius: 4, fontFamily: 'inherit',
+                    }}
+                    onMouseEnter={(e) => { (e.currentTarget as HTMLButtonElement).style.color = '#374151' }}
+                    onMouseLeave={(e) => { (e.currentTarget as HTMLButtonElement).style.color = '#9ca3af' }}
+                  >
+                    <Pencil size={10} /> Edit
+                  </button>
+                )}
                 {msgAttachments.length > 0 && (
                   <div style={{ marginTop: 6, display: 'flex', flexDirection: 'column', gap: 6, alignItems: isSupport ? 'flex-end' : 'flex-start' }}>
                     {msgAttachments.map((a) => (
@@ -881,6 +1017,119 @@ function AttachmentChip({
       <Paperclip size={12} />
       {a.filename}
     </a>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Watcher bar — agent view of tagged users; can add/remove anyone
+// ---------------------------------------------------------------------------
+
+function WatcherBar({
+  ticket, onChange,
+}: {
+  ticket: SupportTicket
+  onChange: (next: SupportTicket) => void
+}) {
+  const { toast } = useToast()
+  const [adding, setAdding] = useState(false)
+  const [email, setEmail] = useState('')
+  const [busy, setBusy] = useState(false)
+  const watchers = ticket.watchers ?? []
+
+  const submit = async () => {
+    const trimmed = email.trim()
+    if (!trimmed || busy) return
+    setBusy(true)
+    try {
+      const updated = await supportApi.addWatcher(ticket.uuid, trimmed)
+      onChange(updated)
+      setEmail('')
+      setAdding(false)
+      toast('Watcher added', 'success')
+    } catch (err) {
+      toast(err instanceof Error ? err.message : 'Could not add watcher', 'error')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const remove = async (userId: string) => {
+    try {
+      const updated = await supportApi.removeWatcher(ticket.uuid, userId)
+      onChange(updated)
+    } catch {
+      toast('Could not remove watcher', 'error')
+    }
+  }
+
+  return (
+    <div style={{
+      padding: '8px 20px', borderBottom: '1px solid #e5e7eb', background: '#fafafa',
+      display: 'flex', alignItems: 'center', gap: 6, flexWrap: 'wrap',
+    }}>
+      <Eye size={12} color="#6b7280" />
+      <span style={{ fontSize: 11, color: '#6b7280', fontWeight: 600, marginRight: 4 }}>
+        Watchers
+      </span>
+      {watchers.length === 0 && !adding && (
+        <span style={{ fontSize: 12, color: '#9ca3af' }}>None</span>
+      )}
+      {watchers.map((w) => (
+        <span
+          key={w.user_id}
+          title={w.email || w.user_id}
+          style={{
+            display: 'inline-flex', alignItems: 'center', gap: 4,
+            fontSize: 12, padding: '2px 4px 2px 8px', borderRadius: 9999,
+            background: '#eef2ff', color: '#4338ca', fontWeight: 500,
+          }}
+        >
+          {w.name}
+          <button
+            onClick={() => remove(w.user_id)}
+            title={`Remove ${w.name}`}
+            style={{
+              display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+              width: 16, height: 16, padding: 0, border: 'none', background: 'none',
+              color: '#4338ca', cursor: 'pointer', borderRadius: 9999,
+            }}
+          >
+            <X size={10} />
+          </button>
+        </span>
+      ))}
+      {adding ? (
+        <input
+          autoFocus
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          onBlur={() => { if (!busy) { setEmail(''); setAdding(false) } }}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') { e.preventDefault(); submit() }
+            if (e.key === 'Escape') { setEmail(''); setAdding(false) }
+          }}
+          placeholder="user email…"
+          type="email"
+          disabled={busy}
+          style={{
+            fontSize: 12, padding: '2px 8px', border: '1px solid #d1d5db',
+            borderRadius: 9999, outline: 'none', minWidth: 160, fontFamily: 'inherit',
+          }}
+        />
+      ) : (
+        <button
+          onClick={() => setAdding(true)}
+          style={{
+            display: 'inline-flex', alignItems: 'center', gap: 3,
+            fontSize: 12, padding: '2px 8px', borderRadius: 9999,
+            border: '1px dashed #d1d5db', background: 'transparent', color: '#6b7280',
+            cursor: 'pointer', fontFamily: 'inherit',
+          }}
+        >
+          <UserPlus size={10} /> Tag user
+        </button>
+      )}
+    </div>
   )
 }
 

--- a/frontend/src/types/support.ts
+++ b/frontend/src/types/support.ts
@@ -5,6 +5,7 @@ export interface SupportMessage {
   content: string
   is_support_reply: boolean
   created_at: string | null
+  edited_at: string | null
 }
 
 export interface SupportAttachment {
@@ -16,8 +17,17 @@ export interface SupportAttachment {
   created_at: string | null
 }
 
+export interface SupportWatcher {
+  user_id: string
+  name: string
+  email: string | null
+}
+
 export interface SupportTicket {
   uuid: string
+  // Human-friendly sequential id (e.g. 1024). Nullable for any legacy ticket
+  // created before this feature shipped that hasn't been backfilled yet.
+  ticket_number: number | null
   subject: string
   status: 'open' | 'in_progress' | 'closed'
   priority: 'low' | 'normal' | 'high'
@@ -29,6 +39,8 @@ export interface SupportTicket {
   category: string | null
   // Only present for support agents — backend strips this for ticket owners.
   tags?: string[]
+  // Users tagged to follow the ticket. Visible to anyone who can see it.
+  watchers: SupportWatcher[]
   messages: SupportMessage[]
   attachments: SupportAttachment[]
   message_count: number
@@ -39,6 +51,7 @@ export interface SupportTicket {
 
 export interface SupportTicketSummary {
   uuid: string
+  ticket_number: number | null
   subject: string
   status: 'open' | 'in_progress' | 'closed'
   priority: 'low' | 'normal' | 'high'
@@ -48,6 +61,8 @@ export interface SupportTicketSummary {
   category: string | null
   // Only present for support agents — backend strips this for ticket owners.
   tags?: string[]
+  // user_ids of watchers; used to render a "Watching" badge without a detail fetch.
+  watcher_ids: string[]
   message_count: number
   last_message_preview: string | null
   last_message_at: string | null


### PR DESCRIPTION
## Summary

Three related improvements to the support ticket flow.

## Changes

- **Watchers** — owner, support agents, and existing watchers can tag another Vandalizer user (by email) onto a ticket. Watchers can read it, reply, and receive in-app + email notifications on new messages, status changes, and when first added. Watched tickets surface in the requester's ticket list alongside owned tickets with a "Watching" badge. Removable by owner, support, or the watcher themselves.
- **Ticket numbers** — every ticket now has a sequential human-friendly id (e.g. `#1001`) backed by a new `SupportCounter` Beanie document. Reserved at insert time via `findOneAndUpdate` with `$inc` (atomic under concurrent inserts). Legacy tickets are backfilled in chronological order on first call. The number is prefixed into every support email subject (`[#1001] Re: …`) and rendered next to the subject in the email body.
- **Message editing** — `SupportMessage` gains an `edited_at` timestamp. New `PATCH /tickets/{u}/messages/{m}` endpoint lets a user edit their own message; authorship is enforced server-side (even support agents can't rewrite someone else's words). Frontend API client (`editMessage`) is wired up; in-page editor UI is not part of this PR.

New endpoints:
- `POST /api/support/tickets/{uuid}/watchers` (body `{ email }`)
- `DELETE /api/support/tickets/{uuid}/watchers/{watcher_user_id}`
- `PATCH /api/support/tickets/{uuid}/messages/{message_uuid}` (body `{ content }`)

Schema changes:
- `SupportTicket.ticket_number: Optional[int]` (indexed)
- `SupportTicket.watchers: list[str]` (indexed; user_ids)
- `SupportMessage.edited_at: Optional[datetime]`
- New `SupportCounter` collection (`support_counter`), registered in `database.py`

## Test Plan

- [ ] Shared checks pass (`make ci`)
- [ ] Release check passes if packaging or deployment changed (`make release-check`)
- [ ] Manually tested the affected feature(s)
  - [ ] Open a ticket, tag a teammate as a watcher by email — confirm they see it in their ticket list with a "Watching" badge and receive the "you were added" email
  - [ ] As the watcher, reply to the ticket — confirm the owner gets the in-app notification
  - [ ] Status-flip a ticket — confirm watchers get an in-app notification
  - [ ] Untag a watcher (owner removes, watcher self-removes)
  - [ ] Create a fresh ticket, confirm `#NNNN` shows up everywhere it should and that the email subject is prefixed
  - [ ] Confirm legacy tickets are backfilled with sequential numbers on first server start
  - [ ] Edit your own message via the PATCH endpoint; confirm `edited_at` is set; confirm a different user (including support) gets 403
- [ ] Updated `CHANGELOG.md` for user-facing or operator-facing changes
- [ ] Updated deploy/release docs (`README.md`, `DEPLOY.md`, `OPERATIONS.md`, or `RELEASE_CHECKLIST.md`) if the install or release path changed

## Notes for review

- `add_watcher` looks up users globally by email — there's no team scoping. A user from a different team can be tagged onto a ticket and read its full history. Intentional?
- Watcher input is email-only with no autocomplete; you have to know the exact account email. Worth a follow-up for a typeahead.
- `_can_view_ticket` tolerates both shapes of `watchers` (string ids or hydrated dicts) because the helper is called against router-level dicts that have already been hydrated by `_ticket_to_dict`.