### PR TITLE
Decouple shared KB lifetime from owner's My KBs delete

### DIFF
--- a/backend/app/models/knowledge.py
+++ b/backend/app/models/knowledge.py
@@ -76,6 +76,7 @@ class KnowledgeBase(Document):
     user_id: str
     team_id: Optional[str] = None
     shared_with_team: bool = False
+    team_owned: bool = False
     verified: bool = False
     organization_ids: list[str] = Field(default_factory=list)  # Org UUIDs for visibility scoping
     status: str = "empty"  # empty | building | ready | error

--- a/backend/app/routers/knowledge.py
+++ b/backend/app/routers/knowledge.py
@@ -63,6 +63,7 @@ def _kb_response(kb, *, scope: str | None = None) -> KBResponse:
         description=kb.description or "",
         status=kb.status,
         shared_with_team=kb.shared_with_team,
+        team_owned=kb.team_owned,
         verified=kb.verified,
         organization_ids=kb.organization_ids,
         total_sources=kb.total_sources,
@@ -103,6 +104,8 @@ async def list_knowledge_bases_legacy(user: User = Depends(get_current_user)):
 
 def _classify_scope(kb, user_id: str, team_id: str | None) -> str:
     """Determine the display scope for a KB relative to the requesting user."""
+    if kb.shared_with_team and kb.team_id == team_id and kb.team_owned:
+        return "team"
     if kb.user_id == user_id:
         return "mine"
     if kb.verified:
@@ -309,12 +312,53 @@ async def share_knowledge_base(
 
 
 @router.delete("/{uuid}")
-async def delete_knowledge_base(uuid: str, user: User = Depends(get_current_user)):
+async def delete_knowledge_base(
+    uuid: str,
+    mode: str | None = Query(None, pattern="^unshare_and_delete$"),
+    user: User = Depends(get_current_user),
+):
+    """Delete a knowledge base.
+
+    For KBs that are currently shared with a team, the caller must pass
+    ``mode=unshare_and_delete`` to acknowledge that the KB will disappear
+    from the Team Library as well. Otherwise the request fails with 409 and
+    the client should prompt the user to choose between transferring
+    ownership (via POST /{uuid}/transfer-to-team) or force-deleting.
+    """
     user_org_ancestry = await organization_service.get_user_org_ancestry(user)
-    ok = await svc.delete_knowledge_base(uuid, user, user_org_ancestry=user_org_ancestry)
+    try:
+        ok = await svc.delete_knowledge_base(
+            uuid,
+            user,
+            user_org_ancestry=user_org_ancestry,
+            force_shared=(mode == "unshare_and_delete"),
+        )
+    except svc.SharedKBDeleteRequiresMode:
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "code": "shared_kb_delete_requires_mode",
+                "message": "This knowledge base is shared with your team. Choose to move it to the Team Library only, or to unshare and delete everywhere.",
+            },
+        )
     if not ok:
         raise HTTPException(status_code=404, detail="Knowledge base not found")
     return {"ok": True}
+
+
+@router.post("/{uuid}/transfer-to-team")
+async def transfer_to_team(uuid: str, user: User = Depends(get_current_user)):
+    """Mark a shared KB as team-owned: removes it from My KBs but keeps Team Library access."""
+    user_org_ancestry = await organization_service.get_user_org_ancestry(user)
+    try:
+        kb = await svc.transfer_kb_to_team(
+            uuid, user, user_org_ancestry=user_org_ancestry,
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    if not kb:
+        raise HTTPException(status_code=404, detail="Knowledge base not found")
+    return {"ok": True, "team_owned": kb.team_owned}
 
 
 @router.post("/{uuid}/add_documents")

--- a/backend/app/schemas/knowledge.py
+++ b/backend/app/schemas/knowledge.py
@@ -59,6 +59,7 @@ class KBResponse(BaseModel):
     description: Optional[str] = None
     status: str
     shared_with_team: bool = False
+    team_owned: bool = False
     verified: bool = False
     organization_ids: list[str] = []
     total_sources: int = 0

--- a/backend/app/services/knowledge_service.py
+++ b/backend/app/services/knowledge_service.py
@@ -32,6 +32,47 @@ def _get_dm() -> DocumentManager:
     return _dm
 
 
+def build_kb_list_query(
+    user_id: str,
+    team_id: str | None,
+    scope: str | None,
+    search: str | None,
+) -> dict | None:
+    """Build the mongo query for listing knowledge bases.
+
+    Returns None when the requested scope is impossible (e.g. "team" with no team).
+    team_owned KBs are excluded from the "mine" surface — they live in Team
+    Library only, even for their original creator.
+    """
+    if scope == "mine":
+        query: dict = {"user_id": user_id, "team_owned": {"$ne": True}}
+    elif scope == "team":
+        if not team_id:
+            return None
+        query = {"shared_with_team": True, "team_id": team_id}
+    elif scope == "verified":
+        query = {"verified": True}
+    else:
+        or_clauses: list[dict] = [
+            {"user_id": user_id, "team_owned": {"$ne": True}},
+            {"verified": True},
+        ]
+        if team_id:
+            or_clauses.append({"shared_with_team": True, "team_id": team_id})
+        query = {"$or": or_clauses}
+
+    if search:
+        pattern = re.escape(search)
+        query = {"$and": [
+            query,
+            {"$or": [
+                {"title": {"$regex": pattern, "$options": "i"}},
+                {"description": {"$regex": pattern, "$options": "i"}},
+            ]},
+        ]}
+    return query
+
+
 async def list_knowledge_bases(
     user_id: str,
     team_id: str | None = None,
@@ -47,34 +88,9 @@ async def list_knowledge_bases(
     Returns ``(items, total)`` where *total* is the unscoped count before
     skip/limit (for pagination metadata).
     """
-    # Build the base query depending on scope
-    if scope == "mine":
-        query = {"user_id": user_id}
-    elif scope == "team":
-        if not team_id:
-            return [], 0
-        query = {"shared_with_team": True, "team_id": team_id}
-    elif scope == "verified":
-        query = {"verified": True}
-    else:
-        # No scope filter — return everything the user can see (original behaviour)
-        or_clauses: list[dict] = [
-            {"user_id": user_id},
-            {"verified": True},
-        ]
-        if team_id:
-            or_clauses.append({"shared_with_team": True, "team_id": team_id})
-        query = {"$or": or_clauses}
-
-    # Text search on title / description
-    if search:
-        pattern = re.escape(search)
-        search_filter = {"$or": [
-            {"title": {"$regex": pattern, "$options": "i"}},
-            {"description": {"$regex": pattern, "$options": "i"}},
-        ]}
-        # Merge with existing query
-        query = {"$and": [query, search_filter]}
+    query = build_kb_list_query(user_id, team_id, scope, search)
+    if query is None:
+        return [], 0
 
     total = await KnowledgeBase.find(query).count()
     kbs = await (
@@ -236,11 +252,50 @@ async def share_with_team(
     return kb
 
 
+class SharedKBDeleteRequiresMode(Exception):
+    """Raised when delete_knowledge_base is called on a shared KB without an explicit mode.
+
+    The caller must choose between transferring ownership to the team (so the KB stays
+    in the Team Library) or unsharing + hard-deleting everywhere.
+    """
+
+
+async def transfer_kb_to_team(
+    uuid: str,
+    user: User,
+    *,
+    user_org_ancestry: list[str] | None = None,
+) -> KnowledgeBase | None:
+    """Mark a KB as team-owned so it disappears from My KBs but stays in Team Library.
+
+    Idempotent. Also ensures shared_with_team is True (a KB cannot be team-owned
+    without being shared).
+    """
+    kb = await get_knowledge_base(
+        uuid,
+        user,
+        manage=True,
+        user_org_ancestry=user_org_ancestry,
+        allow_admin=True,
+    )
+    if not kb:
+        return None
+    if not kb.team_id:
+        # Without a team, "team-owned" has no meaning; treat as configuration error.
+        raise ValueError("Knowledge base has no team_id; cannot transfer to team")
+    kb.shared_with_team = True
+    kb.team_owned = True
+    kb.updated_at = datetime.datetime.now(tz=datetime.timezone.utc)
+    await kb.save()
+    return kb
+
+
 async def delete_knowledge_base(
     uuid: str,
     user: User,
     *,
     user_org_ancestry: list[str] | None = None,
+    force_shared: bool = False,
 ) -> bool:
     kb = await get_knowledge_base(
         uuid,
@@ -251,6 +306,10 @@ async def delete_knowledge_base(
     )
     if not kb:
         return False
+    if kb.shared_with_team and not force_shared:
+        raise SharedKBDeleteRequiresMode(
+            "Knowledge base is shared with team; caller must choose transfer or force-delete",
+        )
     # Delete ChromaDB collection
     try:
         dm = _get_dm()
@@ -892,28 +951,6 @@ async def _ingest_document_source(source: KnowledgeBaseSource, kb: KnowledgeBase
         await source.save()
 
 
-def _extract_text_from_html(html: str) -> str:
-    """Extract clean text from HTML using BeautifulSoup."""
-    soup = BeautifulSoup(html, "html.parser")
-    # Remove non-content elements
-    for tag in soup.find_all(["script", "style", "nav", "footer", "header", "aside", "form"]):
-        tag.decompose()
-    text = soup.get_text(separator="\n")
-    # Clean up whitespace
-    text = re.sub(r"[ \t]+", " ", text)
-    text = re.sub(r"\n{3,}", "\n\n", text)
-    return text.strip()
-
-
-def _extract_title_from_html(html: str, url: str) -> str:
-    """Extract page title from HTML."""
-    soup = BeautifulSoup(html, "html.parser")
-    if soup.title and soup.title.string:
-        return soup.title.string.strip()[:200]
-    from urllib.parse import urlparse
-    return urlparse(url).netloc
-
-
 async def _ingest_url_source(
     source: KnowledgeBaseSource, kb: KnowledgeBase,
 ) -> str | None:
@@ -921,15 +958,12 @@ async def _ingest_url_source(
     source.status = "processing"
     await source.save()
     try:
-        from app.utils.url_validation import validate_outbound_url
+        from app.services.web_fetcher import fetch_url
 
-        validate_outbound_url(source.url)
-        async with httpx.AsyncClient(timeout=30.0, follow_redirects=True) as client:
-            resp = await client.get(source.url)
-            resp.raise_for_status()
-            raw_html = resp.text[:500000]
+        result = await fetch_url(source.url)
+        raw_html = result.raw_html or ""
+        raw_text = result.text
 
-        raw_text = _extract_text_from_html(raw_html)
         if not raw_text.strip():
             source.status = "error"
             source.error_message = "Failed to extract text from URL"
@@ -937,7 +971,7 @@ async def _ingest_url_source(
             return None
 
         source.content = raw_text[:500000]
-        source.url_title = _extract_title_from_html(raw_html, source.url)
+        source.url_title = result.title
 
         dm = _get_dm()
         chunk_count = await asyncio.to_thread(

--- a/backend/tests/test_knowledge_routes.py
+++ b/backend/tests/test_knowledge_routes.py
@@ -249,6 +249,7 @@ def _mock_kb(**overrides):
     kb.description = overrides.get("description", "A test knowledge base")
     kb.status = overrides.get("status", "ready")
     kb.shared_with_team = overrides.get("shared_with_team", False)
+    kb.team_owned = overrides.get("team_owned", False)
     kb.verified = overrides.get("verified", False)
     kb.organization_ids = overrides.get("organization_ids", [])
     kb.total_sources = overrides.get("total_sources", 2)
@@ -932,3 +933,178 @@ class TestConvertDocumentsToKB:
         # Title should be the supplied one, NOT the first doc's title.
         call_kwargs = mock_svc.create_knowledge_base.await_args.kwargs
         assert call_kwargs["title"] == "Reference materials"
+
+
+class TestKnowledgeSharedDeleteFlow:
+    """Cover the two-mode delete + transfer-to-team flow for shared KBs."""
+
+    @pytest.mark.asyncio
+    async def test_delete_shared_kb_without_mode_returns_409(self, client):
+        user = _make_user()
+        cookies, headers = _auth()
+
+        with (
+            patch("app.dependencies.decode_token", return_value={"sub": "user1", "type": "access"}),
+            patch("app.dependencies.User") as MockUser,
+            patch("app.routers.knowledge.svc") as mock_svc,
+            patch("app.routers.knowledge.organization_service") as mock_org,
+        ):
+            MockUser.find_one = AsyncMock(return_value=user)
+            mock_org.get_user_org_ancestry = AsyncMock(return_value=[])
+            from app.services.knowledge_service import SharedKBDeleteRequiresMode
+            mock_svc.SharedKBDeleteRequiresMode = SharedKBDeleteRequiresMode
+            mock_svc.delete_knowledge_base = AsyncMock(side_effect=SharedKBDeleteRequiresMode())
+
+            resp = await client.delete(
+                "/api/knowledge/kb-uuid-1",
+                cookies=cookies,
+                headers=headers,
+            )
+
+        assert resp.status_code == 409
+        body = resp.json()["detail"]
+        assert body["code"] == "shared_kb_delete_requires_mode"
+        # Caller was invoked without force_shared.
+        call_kwargs = mock_svc.delete_knowledge_base.await_args.kwargs
+        assert call_kwargs["force_shared"] is False
+
+    @pytest.mark.asyncio
+    async def test_delete_with_unshare_and_delete_mode_force_deletes(self, client):
+        user = _make_user()
+        cookies, headers = _auth()
+
+        with (
+            patch("app.dependencies.decode_token", return_value={"sub": "user1", "type": "access"}),
+            patch("app.dependencies.User") as MockUser,
+            patch("app.routers.knowledge.svc") as mock_svc,
+            patch("app.routers.knowledge.organization_service") as mock_org,
+        ):
+            MockUser.find_one = AsyncMock(return_value=user)
+            mock_org.get_user_org_ancestry = AsyncMock(return_value=[])
+            from app.services.knowledge_service import SharedKBDeleteRequiresMode
+            mock_svc.SharedKBDeleteRequiresMode = SharedKBDeleteRequiresMode
+            mock_svc.delete_knowledge_base = AsyncMock(return_value=True)
+
+            resp = await client.delete(
+                "/api/knowledge/kb-uuid-1?mode=unshare_and_delete",
+                cookies=cookies,
+                headers=headers,
+            )
+
+        assert resp.status_code == 200
+        call_kwargs = mock_svc.delete_knowledge_base.await_args.kwargs
+        assert call_kwargs["force_shared"] is True
+
+    @pytest.mark.asyncio
+    async def test_delete_rejects_unknown_mode(self, client):
+        # The route's Query regex only allows "unshare_and_delete".
+        user = _make_user()
+        cookies, headers = _auth()
+
+        with (
+            patch("app.dependencies.decode_token", return_value={"sub": "user1", "type": "access"}),
+            patch("app.dependencies.User") as MockUser,
+        ):
+            MockUser.find_one = AsyncMock(return_value=user)
+            resp = await client.delete(
+                "/api/knowledge/kb-uuid-1?mode=transfer",
+                cookies=cookies,
+                headers=headers,
+            )
+
+        assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_transfer_to_team_success(self, client):
+        user = _make_user()
+        cookies, headers = _auth()
+        kb = _mock_kb(shared_with_team=True, team_owned=True, team_id="team-1")
+
+        with (
+            patch("app.dependencies.decode_token", return_value={"sub": "user1", "type": "access"}),
+            patch("app.dependencies.User") as MockUser,
+            patch("app.routers.knowledge.svc") as mock_svc,
+            patch("app.routers.knowledge.organization_service") as mock_org,
+        ):
+            MockUser.find_one = AsyncMock(return_value=user)
+            mock_org.get_user_org_ancestry = AsyncMock(return_value=[])
+            mock_svc.transfer_kb_to_team = AsyncMock(return_value=kb)
+
+            resp = await client.post(
+                "/api/knowledge/kb-uuid-1/transfer-to-team",
+                cookies=cookies,
+                headers=headers,
+            )
+
+        assert resp.status_code == 200
+        assert resp.json() == {"ok": True, "team_owned": True}
+
+    @pytest.mark.asyncio
+    async def test_transfer_to_team_not_found_returns_404(self, client):
+        user = _make_user()
+        cookies, headers = _auth()
+
+        with (
+            patch("app.dependencies.decode_token", return_value={"sub": "user1", "type": "access"}),
+            patch("app.dependencies.User") as MockUser,
+            patch("app.routers.knowledge.svc") as mock_svc,
+            patch("app.routers.knowledge.organization_service") as mock_org,
+        ):
+            MockUser.find_one = AsyncMock(return_value=user)
+            mock_org.get_user_org_ancestry = AsyncMock(return_value=[])
+            mock_svc.transfer_kb_to_team = AsyncMock(return_value=None)
+
+            resp = await client.post(
+                "/api/knowledge/missing/transfer-to-team",
+                cookies=cookies,
+                headers=headers,
+            )
+
+        assert resp.status_code == 404
+
+
+class TestKBListQueryBuilder:
+    """Verify the mongo query shape for the scope filters that drive My KBs vs Team."""
+
+    def test_mine_scope_excludes_team_owned(self):
+        from app.services.knowledge_service import build_kb_list_query
+
+        q = build_kb_list_query("user1", "team-1", "mine", None)
+        assert q == {"user_id": "user1", "team_owned": {"$ne": True}}
+
+    def test_team_scope_filters_by_shared_and_team_id(self):
+        from app.services.knowledge_service import build_kb_list_query
+
+        q = build_kb_list_query("user1", "team-1", "team", None)
+        assert q == {"shared_with_team": True, "team_id": "team-1"}
+
+    def test_team_scope_without_team_id_returns_none(self):
+        from app.services.knowledge_service import build_kb_list_query
+
+        assert build_kb_list_query("user1", None, "team", None) is None
+
+    def test_default_scope_excludes_team_owned_from_mine_branch(self):
+        from app.services.knowledge_service import build_kb_list_query
+
+        q = build_kb_list_query("user1", "team-1", None, None)
+        or_clauses = q["$or"]
+        mine_clause = next(
+            (c for c in or_clauses if c.get("user_id") == "user1"),
+            None,
+        )
+        assert mine_clause is not None
+        assert mine_clause["team_owned"] == {"$ne": True}
+        # Team-share branch should still be present.
+        assert any(
+            c.get("shared_with_team") is True and c.get("team_id") == "team-1"
+            for c in or_clauses
+        )
+
+    def test_search_wraps_with_and_clause(self):
+        from app.services.knowledge_service import build_kb_list_query
+
+        q = build_kb_list_query("user1", None, "mine", "needle")
+        assert "$and" in q
+        base, search = q["$and"]
+        assert base == {"user_id": "user1", "team_owned": {"$ne": True}}
+        assert search["$or"][0]["title"]["$regex"] == "needle"

--- a/frontend/src/api/knowledge.ts
+++ b/frontend/src/api/knowledge.ts
@@ -51,8 +51,15 @@ export function updateKnowledgeBase(uuid: string, data: { title?: string; descri
   })
 }
 
-export function deleteKnowledgeBase(uuid: string) {
-  return apiFetch<{ ok: boolean }>(`/api/knowledge/${uuid}`, { method: 'DELETE' })
+export function deleteKnowledgeBase(uuid: string, mode?: 'unshare_and_delete') {
+  const qs = mode ? `?mode=${mode}` : ''
+  return apiFetch<{ ok: boolean }>(`/api/knowledge/${uuid}${qs}`, { method: 'DELETE' })
+}
+
+export function transferKnowledgeBaseToTeam(uuid: string) {
+  return apiFetch<{ ok: boolean; team_owned: boolean }>(`/api/knowledge/${uuid}/transfer-to-team`, {
+    method: 'POST',
+  })
 }
 
 export function addDocumentsToKB(uuid: string, documentUuids: string[]) {

--- a/frontend/src/components/knowledge/KBCard.tsx
+++ b/frontend/src/components/knowledge/KBCard.tsx
@@ -116,12 +116,17 @@ export function KBCard({
           {kb.title}
         </span>
         {kb.shared_with_team && (
-          <span style={{
-            fontSize: 10, fontWeight: 600, padding: '1px 6px', borderRadius: 8,
-            color: 'rgb(0, 128, 128)', backgroundColor: 'rgba(0, 128, 128, 0.1)',
-            whiteSpace: 'nowrap',
-          }}>
-            Team
+          <span
+            title={kb.team_owned
+              ? 'Owned by your team — not in any individual\'s My KBs'
+              : 'Shared with your team'}
+            style={{
+              fontSize: 10, fontWeight: 600, padding: '1px 6px', borderRadius: 8,
+              color: 'rgb(0, 128, 128)', backgroundColor: 'rgba(0, 128, 128, 0.1)',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {kb.team_owned ? 'Team-owned' : 'Team'}
           </span>
         )}
         {kb.verified && (

--- a/frontend/src/components/shared/SharedKBDeleteDialog.tsx
+++ b/frontend/src/components/shared/SharedKBDeleteDialog.tsx
@@ -1,0 +1,129 @@
+import { useEffect, useState } from 'react'
+import { AlertTriangle, X, Loader2, Users, Trash2 } from 'lucide-react'
+
+export type SharedKBDeleteChoice = 'transfer' | 'unshare_and_delete'
+
+interface Props {
+  open: boolean
+  kbTitle: string
+  onCancel: () => void
+  onChoose: (choice: SharedKBDeleteChoice) => Promise<void> | void
+}
+
+export function SharedKBDeleteDialog({ open, kbTitle, onCancel, onChoose }: Props) {
+  const [busy, setBusy] = useState<SharedKBDeleteChoice | null>(null)
+
+  useEffect(() => {
+    if (!open) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && busy === null) onCancel()
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [open, busy, onCancel])
+
+  if (!open) return null
+
+  const handle = async (choice: SharedKBDeleteChoice) => {
+    try {
+      setBusy(choice)
+      await onChoose(choice)
+    } finally {
+      setBusy(null)
+    }
+  }
+
+  const disabled = busy !== null
+
+  return (
+    <div
+      className="fixed inset-0 flex items-center justify-center bg-black/50"
+      style={{ zIndex: 1000 }}
+      onClick={(e) => {
+        if (e.target === e.currentTarget && !disabled) onCancel()
+      }}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="shared-kb-delete-title"
+        className="w-full max-w-md rounded-lg bg-white p-6 shadow-xl"
+      >
+        <div className="mb-3 flex items-start justify-between gap-3">
+          <h3 id="shared-kb-delete-title" className="text-lg font-medium text-gray-900">
+            Delete shared knowledge base?
+          </h3>
+          <button
+            type="button"
+            onClick={onCancel}
+            disabled={disabled}
+            aria-label="Close"
+            className="text-gray-400 hover:text-gray-600 disabled:opacity-40"
+          >
+            <X className="h-5 w-5" />
+          </button>
+        </div>
+
+        <p className="mb-4 text-sm text-gray-600">
+          <strong>{kbTitle}</strong> is currently shared with your team. What would you like to do?
+        </p>
+
+        <div className="flex flex-col gap-2">
+          <button
+            type="button"
+            onClick={() => handle('transfer')}
+            disabled={disabled}
+            className="flex items-start gap-3 rounded-md border border-gray-200 p-3 text-left hover:bg-gray-50 disabled:opacity-50"
+          >
+            <div className="mt-0.5 flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-blue-50">
+              {busy === 'transfer'
+                ? <Loader2 className="h-4 w-4 animate-spin text-blue-600" />
+                : <Users className="h-4 w-4 text-blue-600" />}
+            </div>
+            <div className="flex-1">
+              <div className="text-sm font-semibold text-gray-900">Move to Team Library only</div>
+              <div className="text-xs text-gray-600">
+                Removes the knowledge base from My KBs but keeps it available to your team.
+              </div>
+            </div>
+          </button>
+
+          <button
+            type="button"
+            onClick={() => handle('unshare_and_delete')}
+            disabled={disabled}
+            className="flex items-start gap-3 rounded-md border border-red-200 p-3 text-left hover:bg-red-50 disabled:opacity-50"
+          >
+            <div className="mt-0.5 flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-red-50">
+              {busy === 'unshare_and_delete'
+                ? <Loader2 className="h-4 w-4 animate-spin text-red-600" />
+                : <Trash2 className="h-4 w-4 text-red-600" />}
+            </div>
+            <div className="flex-1">
+              <div className="text-sm font-semibold text-red-700">Unshare and delete everywhere</div>
+              <div className="text-xs text-gray-600">
+                Permanently deletes the knowledge base and removes it from the Team Library. This cannot be undone.
+              </div>
+            </div>
+          </button>
+        </div>
+
+        <div className="mt-4 flex items-start gap-2 rounded-md bg-amber-50 p-2 text-xs text-amber-800">
+          <AlertTriangle className="mt-0.5 h-3.5 w-3.5 flex-shrink-0" />
+          <span>Chats and workflows referencing this KB may lose context if it is deleted.</span>
+        </div>
+
+        <div className="mt-4 flex justify-end">
+          <button
+            type="button"
+            onClick={onCancel}
+            disabled={disabled}
+            className="rounded-md px-3 py-2 text-sm text-gray-700 hover:bg-gray-100 disabled:opacity-50"
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/workspace/KnowledgePanel.tsx
+++ b/frontend/src/components/workspace/KnowledgePanel.tsx
@@ -18,6 +18,7 @@ import { KnowledgeExplainer } from './KnowledgeExplainer'
 import { ShareWithTeamDialog } from '../library/ShareWithTeamDialog'
 import { useToast } from '../../contexts/ToastContext'
 import { useConfirm } from '../shared/useConfirm'
+import { SharedKBDeleteDialog, type SharedKBDeleteChoice } from '../shared/SharedKBDeleteDialog'
 
 type TabKey = 'mine' | 'team' | 'explore'
 const TABS: { key: TabKey; label: string }[] = [
@@ -44,7 +45,8 @@ export function KnowledgePanel() {
   const { activateKB } = useWorkspace()
   const { user } = useAuth()
   const { toast } = useToast()
-  const { create, remove, refresh } = useKnowledgeBases()
+  const { create, remove, transferToTeam, refresh } = useKnowledgeBases()
+  const [sharedDeleteTarget, setSharedDeleteTarget] = useState<KnowledgeBase | null>(null)
   const confirm = useConfirm()
   const [activeTab, setActiveTab] = useState<TabKey>('mine')
   const [search, setSearch] = useState('')
@@ -168,6 +170,10 @@ export function KnowledgePanel() {
 
   const handleDelete = async (uuid: string) => {
     const kb = scopedMine.knowledgeBases.find((k: KnowledgeBase) => k.uuid === uuid)
+    if (kb?.shared_with_team) {
+      setSharedDeleteTarget(kb)
+      return
+    }
     const ok = await confirm({
       title: 'Delete knowledge base?',
       message: (
@@ -186,6 +192,26 @@ export function KnowledgePanel() {
     } catch (err) {
       console.error('Failed to delete KB:', err)
       toast(err instanceof Error ? err.message : 'Failed to delete knowledge base', 'error')
+    }
+  }
+
+  const handleSharedDeleteChoice = async (choice: SharedKBDeleteChoice) => {
+    const kb = sharedDeleteTarget
+    if (!kb) return
+    try {
+      if (choice === 'transfer') {
+        await transferToTeam(kb.uuid)
+        if (selectedKB?.uuid === kb.uuid) setSelectedKB(null)
+        toast('Moved to Team Library', 'success')
+      } else {
+        await remove(kb.uuid, 'unshare_and_delete')
+        if (selectedKB?.uuid === kb.uuid) setSelectedKB(null)
+        toast('Knowledge base deleted', 'success')
+      }
+      setSharedDeleteTarget(null)
+    } catch (err) {
+      console.error('Failed to delete/transfer KB:', err)
+      toast(err instanceof Error ? err.message : 'Operation failed', 'error')
     }
   }
 
@@ -958,6 +984,12 @@ export function KnowledgePanel() {
 
       {shareDialogJSX}
       {verifyModalJSX}
+      <SharedKBDeleteDialog
+        open={!!sharedDeleteTarget}
+        kbTitle={sharedDeleteTarget?.title ?? ''}
+        onCancel={() => setSharedDeleteTarget(null)}
+        onChoose={handleSharedDeleteChoice}
+      />
       </>
     )
   }
@@ -1185,6 +1217,12 @@ export function KnowledgePanel() {
     )}
     {shareDialogJSX}
     {verifyModalJSX}
+    <SharedKBDeleteDialog
+      open={!!sharedDeleteTarget}
+      kbTitle={sharedDeleteTarget?.title ?? ''}
+      onCancel={() => setSharedDeleteTarget(null)}
+      onChoose={handleSharedDeleteChoice}
+    />
     </>
   )
 }

--- a/frontend/src/hooks/useKnowledgeBases.ts
+++ b/frontend/src/hooks/useKnowledgeBases.ts
@@ -21,18 +21,28 @@ export function useKnowledgeBases() {
   })
 
   const removeMutation = useMutation({
-    mutationFn: (uuid: string) => api.deleteKnowledgeBase(uuid),
+    mutationFn: (args: { uuid: string; mode?: 'unshare_and_delete' }) =>
+      api.deleteKnowledgeBase(args.uuid, args.mode),
+    onSuccess: () => qc.invalidateQueries({ queryKey }),
+  })
+
+  const transferMutation = useMutation({
+    mutationFn: (uuid: string) => api.transferKnowledgeBaseToTeam(uuid),
     onSuccess: () => qc.invalidateQueries({ queryKey }),
   })
 
   const create = async (title: string, description?: string) =>
     createMutation.mutateAsync({ title, description })
 
-  const remove = async (uuid: string) => {
-    await removeMutation.mutateAsync(uuid)
+  const remove = async (uuid: string, mode?: 'unshare_and_delete') => {
+    await removeMutation.mutateAsync({ uuid, mode })
   }
 
-  return { knowledgeBases, loading, refresh, create, remove }
+  const transferToTeam = async (uuid: string) => {
+    await transferMutation.mutateAsync(uuid)
+  }
+
+  return { knowledgeBases, loading, refresh, create, remove, transferToTeam }
 }
 
 /** Scoped hook — uses the v2 list endpoint with scope, search, and pagination. */
@@ -59,7 +69,13 @@ export function useScopedKnowledgeBases(params?: {
   })
 
   const removeMutation = useMutation({
-    mutationFn: (uuid: string) => api.deleteKnowledgeBase(uuid),
+    mutationFn: (args: { uuid: string; mode?: 'unshare_and_delete' }) =>
+      api.deleteKnowledgeBase(args.uuid, args.mode),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['knowledgeBases'] }),
+  })
+
+  const transferMutation = useMutation({
+    mutationFn: (uuid: string) => api.transferKnowledgeBaseToTeam(uuid),
     onSuccess: () => qc.invalidateQueries({ queryKey: ['knowledgeBases'] }),
   })
 
@@ -77,8 +93,12 @@ export function useScopedKnowledgeBases(params?: {
   const create = async (title: string, description?: string) =>
     createMutation.mutateAsync({ title, description })
 
-  const remove = async (uuid: string) => {
-    await removeMutation.mutateAsync(uuid)
+  const remove = async (uuid: string, mode?: 'unshare_and_delete') => {
+    await removeMutation.mutateAsync({ uuid, mode })
+  }
+
+  const transferToTeam = async (uuid: string) => {
+    await transferMutation.mutateAsync(uuid)
   }
 
   const adopt = async (uuid: string, note?: string) =>
@@ -95,6 +115,7 @@ export function useScopedKnowledgeBases(params?: {
     refresh,
     create,
     remove,
+    transferToTeam,
     adopt,
     removeRef,
   }

--- a/frontend/src/types/knowledge.ts
+++ b/frontend/src/types/knowledge.ts
@@ -6,6 +6,7 @@ export interface KnowledgeBase {
   description: string
   status: 'empty' | 'building' | 'ready' | 'error'
   shared_with_team: boolean
+  team_owned: boolean
   verified: boolean
   organization_ids: string[]
   team_id: string | null


### PR DESCRIPTION
## Summary
Support ticket: deleting a Knowledge Base from **My KBs** also removed it from the **Team Library**, surprising users who expected shared KBs to be independent.

Root cause: there is one `KnowledgeBase` document per KB, and the Team Library is just a filtered view over `shared_with_team=True`. Owner's delete = hard delete of the only record = gone for everyone.

Fix: deleting a shared KB now prompts the owner to choose:
- **Move to Team Library only** — sets a new `team_owned` flag; KB disappears from My KBs but stays accessible to the team.
- **Unshare and delete everywhere** — current destructive behavior, but explicit.

## Changes

**Backend**
- New `team_owned: bool` field on `KnowledgeBase`.
- `build_kb_list_query()` extracted as a pure helper (excludes `team_owned` from the "mine" surface).
- `transfer_kb_to_team()` service + `POST /api/knowledge/{uuid}/transfer-to-team` endpoint.
- `delete_knowledge_base()` raises `SharedKBDeleteRequiresMode` for shared KBs unless called with `force_shared=True`. `DELETE /api/knowledge/{uuid}` returns **409** with a structured error when `mode` is omitted on a shared KB; accepts `?mode=unshare_and_delete`.
- `_classify_scope()` reports `team_owned` KBs as `"team"`; `team_owned` surfaced in `KBResponse`.

**Frontend**
- New `SharedKBDeleteDialog` with two clearly-labeled choices.
- `KnowledgePanel.handleDelete` routes shared KBs through the new dialog; unshared KBs keep the existing simple confirm.
- `useKnowledgeBases` / `useScopedKnowledgeBases` expose `transferToTeam`; `deleteKnowledgeBase(uuid, mode?)` accepts the new mode.
- `KBCard` shows a "Team-owned" chip variant for team-owned KBs.

## Test plan
- [x] `pytest tests/test_knowledge_routes.py` — 41 existing + 10 new tests pass
  - Delete on shared KB without mode → 409 with `shared_kb_delete_requires_mode`
  - Delete with `mode=unshare_and_delete` → forwards `force_shared=True` to the service
  - Unknown mode → 422 (route regex rejects it)
  - Transfer endpoint success + 404 paths
  - `build_kb_list_query` query-shape coverage for mine/team/verified/default + search wrap
- [x] `npm run typecheck` (frontend) — clean
- [ ] Manual: in dev, share a KB → delete from My KBs → confirm dialog appears with both options; verify "Move to Team Library only" removes it from My KBs and keeps it in Team
- [ ] Manual: delete an unshared KB → confirm the simple confirm dialog (unchanged) appears