### PR TITLE
Let team members contribute to team libraries

### DIFF
--- a/backend/app/services/access_control.py
+++ b/backend/app/services/access_control.py
@@ -244,6 +244,28 @@ def can_manage_library(
     return False
 
 
+def can_contribute_library(
+    library: Library,
+    user: User,
+    team_access: TeamAccessContext,
+    *,
+    allow_admin: bool = False,
+) -> bool:
+    """Can the user add items to this library?
+
+    Looser than ``can_manage_library``: any team member can contribute to a
+    team library, while library-level operations (rename/delete) stay
+    admin-only. Verified library still requires admin.
+    """
+    if user.is_admin:
+        return True
+    if library.scope == LibraryScope.PERSONAL:
+        return library.owner_user_id == user.user_id
+    if library.scope == LibraryScope.TEAM:
+        return _has_team_membership(str(library.team) if library.team else None, team_access)
+    return False
+
+
 def can_view_library_folder(
     folder: LibraryFolder,
     user: User,
@@ -284,6 +306,7 @@ async def get_authorized_library(
     user: User,
     *,
     manage: bool = False,
+    contribute: bool = False,
     allow_admin: bool = False,
     team_access: TeamAccessContext | None = None,
 ) -> Library | None:
@@ -295,11 +318,12 @@ async def get_authorized_library(
         return None
 
     access = team_access or await get_team_access_context(user)
-    allowed = (
-        can_manage_library(library, user, access, allow_admin=allow_admin)
-        if manage
-        else can_view_library(library, user, access, allow_admin=allow_admin)
-    )
+    if manage:
+        allowed = can_manage_library(library, user, access, allow_admin=allow_admin)
+    elif contribute:
+        allowed = can_contribute_library(library, user, access, allow_admin=allow_admin)
+    else:
+        allowed = can_view_library(library, user, access, allow_admin=allow_admin)
     return library if allowed else None
 
 

--- a/backend/app/services/library_service.py
+++ b/backend/app/services/library_service.py
@@ -232,7 +232,7 @@ async def add_item(
     tags: list[str] | None = None,
     folder: str | None = None,
 ) -> dict | None:
-    lib = await access_control.get_authorized_library(library_id, user, manage=True)
+    lib = await access_control.get_authorized_library(library_id, user, contribute=True)
     if not lib:
         return None
     is_verified = False

--- a/backend/tests/test_access_control.py
+++ b/backend/tests/test_access_control.py
@@ -7,6 +7,7 @@ import pytest
 from app.models.library import LibraryScope
 from app.services.access_control import (
     TeamAccessContext,
+    can_contribute_library,
     can_manage_automation,
     can_manage_document,
     can_manage_folder,
@@ -560,6 +561,56 @@ class TestLibraryAccess:
         access = _team_access()
         assert can_view_library(lib, user, access) is True
         assert can_manage_library(lib, user, access) is False
+
+
+class TestCanContributeLibrary:
+    def test_owner_can_contribute_to_personal_library(self):
+        user = _make_user("owner1")
+        lib = _make_library(owner_user_id="owner1")
+        access = _team_access()
+        assert can_contribute_library(lib, user, access) is True
+
+    def test_non_owner_cannot_contribute_to_personal_library(self):
+        user = _make_user("other")
+        lib = _make_library(owner_user_id="owner1")
+        access = _team_access()
+        assert can_contribute_library(lib, user, access) is False
+
+    def test_team_member_can_contribute_to_team_library(self):
+        user = _make_user("member1")
+        lib = _make_library(scope=LibraryScope.TEAM, owner_user_id="owner1", team="team-obj-1")
+        access = _team_access(
+            team_object_ids={"team-obj-1"},
+            object_roles={"team-obj-1": "member"},
+        )
+        assert can_contribute_library(lib, user, access) is True
+
+    def test_team_admin_can_contribute_to_team_library(self):
+        user = _make_user("admin1")
+        lib = _make_library(scope=LibraryScope.TEAM, owner_user_id="owner1", team="team-obj-1")
+        access = _team_access(
+            team_object_ids={"team-obj-1"},
+            object_roles={"team-obj-1": "admin"},
+        )
+        assert can_contribute_library(lib, user, access) is True
+
+    def test_non_member_cannot_contribute_to_team_library(self):
+        user = _make_user("outsider")
+        lib = _make_library(scope=LibraryScope.TEAM, owner_user_id="owner1", team="team-obj-1")
+        access = _team_access()
+        assert can_contribute_library(lib, user, access) is False
+
+    def test_non_admin_cannot_contribute_to_verified_library(self):
+        user = _make_user("viewer")
+        lib = _make_library(scope=LibraryScope.VERIFIED, owner_user_id="system")
+        access = _team_access()
+        assert can_contribute_library(lib, user, access) is False
+
+    def test_admin_can_contribute_to_verified_library(self):
+        user = _make_user("admin", is_admin=True)
+        lib = _make_library(scope=LibraryScope.VERIFIED, owner_user_id="system")
+        access = _team_access()
+        assert can_contribute_library(lib, user, access) is True
 
 
 class TestLibraryFolderAccess:

--- a/backend/tests/test_library_service.py
+++ b/backend/tests/test_library_service.py
@@ -273,6 +273,34 @@ class TestAddItem:
             assert result is None
 
     @pytest.mark.asyncio
+    async def test_uses_contribute_authorization_not_manage(self):
+        # Regression guard: members must be able to add items to team libraries,
+        # so add_item should request contribute-level access (not manage).
+        lib = _make_library()
+        user = _make_user()
+        mock_wf = MagicMock()
+        mock_wf.name = "WF"
+        mock_wf.description = "d"
+        item_id = str(PydanticObjectId())
+        with (
+            patch("app.services.library_service.access_control") as mock_ac,
+            patch("app.services.library_service.LibraryItem") as MockItem,
+            patch("app.services.library_service.Workflow") as MockWF,
+        ):
+            mock_ac.get_authorized_library = AsyncMock(return_value=lib)
+            mock_ac.get_authorized_workflow = AsyncMock(return_value=mock_wf)
+            MockItem.return_value = _make_library_item()
+            MockWF.get = AsyncMock(return_value=mock_wf)
+
+            from app.services.library_service import add_item
+
+            await add_item(str(lib.id), user, item_id, "workflow")
+            mock_ac.get_authorized_library.assert_awaited_once()
+            _, kwargs = mock_ac.get_authorized_library.call_args
+            assert kwargs.get("contribute") is True
+            assert kwargs.get("manage") is not True
+
+    @pytest.mark.asyncio
     async def test_propagates_verified_flag_for_workflow(self):
         # Saving a verified workflow into a personal/team library should mark
         # the LibraryItem verified so the row shows the verified badge and

--- a/frontend/src/components/library/AddToLibraryDialog.tsx
+++ b/frontend/src/components/library/AddToLibraryDialog.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { X } from 'lucide-react'
 import type { Library, LibraryItemKind } from '../../types/library'
 import { addItem } from '../../api/library'
+import { useToast } from '../../contexts/ToastContext'
 
 interface Props {
   libraries: Library[]
@@ -14,6 +15,7 @@ interface Props {
 export function AddToLibraryDialog({ libraries, itemId, kind, onClose, onAdded }: Props) {
   const [selectedLibraryId, setSelectedLibraryId] = useState(libraries[0]?.id ?? '')
   const [saving, setSaving] = useState(false)
+  const { toast } = useToast()
 
   const handleSubmit = async () => {
     if (!selectedLibraryId) return
@@ -22,6 +24,9 @@ export function AddToLibraryDialog({ libraries, itemId, kind, onClose, onAdded }
       await addItem(selectedLibraryId, { item_id: itemId, kind })
       onAdded()
       onClose()
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to add item'
+      toast(message, 'error')
     } finally {
       setSaving(false)
     }


### PR DESCRIPTION
## Summary

- Team `member`s can now add items to a team library. Previously this was gated on `manage` access (owner/admin only) — they saw the team library in the "Save to Library" picker but every add returned 404. This matches the user-reported "can add to our library but not to our team" support ticket.
- New `can_contribute_library` helper draws the line at the right place: personal libraries stay owner-only, team libraries accept any member, verified library stays admin-only. Library-level operations (rename, delete) and item edit/remove still require `manage`.
- Fixed `AddToLibraryDialog` swallowing errors silently — that's how this 404 went unreported. It now catches and toasts.

## Test plan

- [x] `pytest tests/test_access_control.py tests/test_library_service.py` — 115 passed, 2 pre-existing skips.
- [x] New regression test in `test_library_service.py` asserts `add_item` passes `contribute=True` (and not `manage=True`).
- [x] 7 new cases in `test_access_control.py` cover `can_contribute_library` across personal/team/verified × owner/member/admin/outsider.
- [ ] Manual: as a team `member`, save a workflow from the Explore tab to the team library and confirm it lands in the team library catalog.
- [ ] Manual: as a team `member`, confirm errors surface in the dialog (e.g. force a 500) instead of silently doing nothing.