### PR TITLE
Show document filenames instead of UUIDs in workflow and KB chips

### DIFF
--- a/backend/app/routers/knowledge.py
+++ b/backend/app/routers/knowledge.py
@@ -77,11 +77,12 @@ def _kb_response(kb, *, scope: str | None = None) -> KBResponse:
     )
 
 
-def _source_response(s) -> KBSourceResponse:
+def _source_response(s, document_title: str | None = None) -> KBSourceResponse:
     return KBSourceResponse(
         uuid=s.uuid,
         source_type=s.source_type,
         document_uuid=s.document_uuid,
+        document_title=document_title,
         url=s.url,
         url_title=s.url_title or "",
         status=s.status,
@@ -89,6 +90,20 @@ def _source_response(s) -> KBSourceResponse:
         chunk_count=s.chunk_count,
         created_at=s.created_at.isoformat() if s.created_at else None,
     )
+
+
+async def _lookup_document_titles(sources) -> dict[str, str]:
+    """Batch-fetch SmartDocument titles for document-type sources.
+
+    Returns a {uuid: title} map. Missing/deleted docs are simply absent.
+    """
+    from app.models.document import SmartDocument
+
+    doc_uuids = [s.document_uuid for s in sources if s.source_type == "document" and s.document_uuid]
+    if not doc_uuids:
+        return {}
+    docs = await SmartDocument.find({"uuid": {"$in": doc_uuids}}).to_list()
+    return {d.uuid: d.title for d in docs if d.title}
 
 
 @router.get("/list", response_model=list[KBResponse])
@@ -269,9 +284,10 @@ async def get_knowledge_base(uuid: str, user: User = Depends(get_current_user)):
     if not kb:
         raise HTTPException(status_code=404, detail="Knowledge base not found")
     sources = await svc.get_kb_sources(kb.uuid)
+    titles = await _lookup_document_titles(sources)
     return KBDetailResponse(
         **_kb_response(kb).model_dump(),
-        sources=[_source_response(s) for s in sources],
+        sources=[_source_response(s, titles.get(s.document_uuid or "")) for s in sources],
     )
 
 

--- a/backend/app/schemas/knowledge.py
+++ b/backend/app/schemas/knowledge.py
@@ -45,6 +45,7 @@ class KBSourceResponse(BaseModel):
     uuid: str
     source_type: str
     document_uuid: Optional[str] = None
+    document_title: Optional[str] = None  # filename, looked up at response time
     url: Optional[str] = None
     url_title: Optional[str] = None
     status: str

--- a/backend/app/services/document_service.py
+++ b/backend/app/services/document_service.py
@@ -136,4 +136,5 @@ async def poll_status(doc_uuid: str, user: User) -> dict | None:
         "path": doc.path,
         "error_message": doc.error_message,
         "processing": doc.processing,
+        "title": doc.title,
     }

--- a/backend/tests/test_knowledge_routes.py
+++ b/backend/tests/test_knowledge_routes.py
@@ -412,6 +412,13 @@ class TestKnowledgeCRUD:
             patch("app.dependencies.User") as MockUser,
             patch("app.routers.knowledge.svc") as mock_svc,
             patch("app.routers.knowledge.organization_service") as mock_org,
+            # SmartDocument.find requires Beanie initialization which the
+            # ASGI test client skips; stub the title lookup helper directly.
+            patch(
+                "app.routers.knowledge._lookup_document_titles",
+                new_callable=AsyncMock,
+                return_value={"doc-1": "Some Document.pdf"},
+            ),
         ):
             MockUser.find_one = AsyncMock(return_value=user)
             mock_org.get_user_org_ancestry = AsyncMock(return_value=[])
@@ -424,6 +431,7 @@ class TestKnowledgeCRUD:
         data = resp.json()
         assert data["uuid"] == "kb-uuid-1"
         assert len(data["sources"]) == 1
+        assert data["sources"][0]["document_title"] == "Some Document.pdf"
 
     @pytest.mark.asyncio
     async def test_get_detail_not_found(self, client):

--- a/frontend/src/components/workspace/KnowledgePanel.tsx
+++ b/frontend/src/components/workspace/KnowledgePanel.tsx
@@ -820,8 +820,13 @@ export function KnowledgePanel() {
                         <Globe size={14} style={{ color: '#888', flexShrink: 0 }} />
                       )}
                       <div style={{ flex: 1, minWidth: 0 }}>
-                        <div style={{ fontSize: 12, color: '#e5e5e5', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                          {source.source_type === 'url' ? (source.url_title || source.url) : source.document_uuid}
+                        <div
+                          style={{ fontSize: 12, color: '#e5e5e5', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+                          title={source.source_type === 'url' ? (source.url || '') : (source.document_uuid || '')}
+                        >
+                          {source.source_type === 'url'
+                            ? (source.url_title || source.url)
+                            : (source.document_title || source.document_uuid)}
                         </div>
                         {source.error_message && (
                           <div style={{ fontSize: 11, color: '#ef4444', marginTop: 2 }}>{source.error_message}</div>

--- a/frontend/src/components/workspace/WorkflowEditorPanel.tsx
+++ b/frontend/src/components/workspace/WorkflowEditorPanel.tsx
@@ -28,7 +28,7 @@ import { RunHistoryTab } from './RunHistoryTab'
 import type { ValidationCheck, ValidationCheckDefinition, ValidationInputDefinition, QualityHistoryRun, BatchStatus, WorkflowQualityStatus, PromptImprovement } from '../../api/workflows'
 import { ItemPickerModal } from './ItemPickerModal'
 import { getModels } from '../../api/config'
-import { searchDocuments } from '../../api/documents'
+import { searchDocuments, pollStatus as pollDocumentStatus } from '../../api/documents'
 import { convertDocumentsToKB } from '../../api/knowledge'
 import { listCredentials } from '../../api/credentials'
 import type { Credential } from '../../types/credential'
@@ -1890,8 +1890,20 @@ function TaskEditModal({ task, selectedDocUuids, workflow, workflowId, onClose, 
     (task.data.selected_document_uuid as string) || ''
   )
   const [docSearchQuery, setDocSearchQuery] = useState('')
+  const [selectedDocTitle, setSelectedDocTitle] = useState('')
   const [docSearchResults, setDocSearchResults] = useState<{ uuid: string; title: string }[]>([])
   const [showDocDropdown, setShowDocDropdown] = useState(false)
+
+  // Saved tasks only store the UUID — fetch the title so the chip shows the
+  // filename instead of a raw UUID when the editor reopens.
+  useEffect(() => {
+    if (!selectedDocUuid) { setSelectedDocTitle(''); return }
+    let cancelled = false
+    pollDocumentStatus(selectedDocUuid)
+      .then(res => { if (!cancelled && res?.title) setSelectedDocTitle(res.title) })
+      .catch(() => { /* leave title empty; chip will fall back to UUID */ })
+    return () => { cancelled = true }
+  }, [selectedDocUuid])
 
   // Fixed documents for workflow_documents input source
   const inputCfg = (workflow as unknown as Record<string, unknown>)?.input_config as Record<string, unknown> | undefined
@@ -3458,6 +3470,7 @@ function TaskEditModal({ task, selectedDocUuids, workflow, workflowId, onClose, 
                               key={doc.uuid}
                               onMouseDown={() => {
                                 setSelectedDocUuid(doc.uuid)
+                                setSelectedDocTitle(doc.title)
                                 setDocSearchQuery(doc.title)
                                 setShowDocDropdown(false)
                               }}
@@ -3483,9 +3496,14 @@ function TaskEditModal({ task, selectedDocUuids, workflow, workflowId, onClose, 
                           padding: '6px 10px', backgroundColor: '#f3f4f6', borderRadius: 6, fontSize: 12,
                         }}>
                           <FileText style={{ width: 12, height: 12, color: '#6b7280' }} />
-                          <span style={{ color: '#374151', flex: 1 }}>{docSearchQuery || selectedDocUuid}</span>
+                          <span
+                            style={{ color: '#374151', flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+                            title={selectedDocTitle ? `${selectedDocTitle} (${selectedDocUuid})` : selectedDocUuid}
+                          >
+                            {selectedDocTitle || selectedDocUuid}
+                          </span>
                           <button
-                            onClick={() => { setSelectedDocUuid(''); setDocSearchQuery('') }}
+                            onClick={() => { setSelectedDocUuid(''); setSelectedDocTitle(''); setDocSearchQuery('') }}
                             style={{ background: 'none', border: 'none', cursor: 'pointer', padding: 2, color: '#9ca3af', display: 'flex' }}
                           >
                             <X style={{ width: 12, height: 12 }} />

--- a/frontend/src/types/document.ts
+++ b/frontend/src/types/document.ts
@@ -47,4 +47,5 @@ export interface PollStatusResponse {
   path: string | null
   error_message: string | null
   processing: boolean
+  title: string
 }

--- a/frontend/src/types/knowledge.ts
+++ b/frontend/src/types/knowledge.ts
@@ -28,6 +28,7 @@ export interface KnowledgeBaseSource {
   uuid: string
   source_type: 'document' | 'url'
   document_uuid?: string
+  document_title?: string
   url?: string
   url_title?: string
   status: 'pending' | 'processing' | 'ready' | 'error'


### PR DESCRIPTION
## Summary
- Workflow step editor's "Select a Document" chip now shows the document's filename instead of the raw UUID (UUID is preserved as a hover tooltip).
- Knowledge Base sources list shows the document filename instead of the UUID. Works for existing KBs — title is looked up at response time, no backfill needed.
- `poll_status` and `KBSourceResponse` gain a `title` / `document_title` field respectively.

Reported by Marwa Elsayed (QA): chips showed `EB62B54C0E254EFCB0B5364C5348EED2` instead of filenames in two places.

## Test plan
- [ ] Open an existing workflow with a step that has a saved "Select a Document" — chip displays the filename, hover shows the UUID.
- [ ] Search and pick a new document — chip updates to the new filename.
- [ ] Clear the selection (X button) — chip disappears, search input clears.
- [ ] Open a Knowledge Base that already has document sources — each source row shows its filename, not a UUID.
- [ ] Add a new document to a KB — appears in the list with its filename.
- [ ] URL sources still display correctly (title or URL).
- [ ] Source whose underlying SmartDocument was deleted falls back to UUID (no crash).