### PR TITLE
Fix zero-token "Connection error" in parallel workflow LLM calls

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -79,6 +79,12 @@ class Settings(BaseSettings):
     web_fetcher_max_chars: int = 500_000
     web_fetcher_timeout_seconds: int = 30
 
+    # Per-request read timeout (seconds) for the dedicated httpx client used by
+    # workflow LLM calls. Reasoning models (e.g. gpt-oss) can think for a while
+    # over a large document before emitting the first token, so this is set
+    # generously above httpx's 5s default.
+    workflow_llm_timeout_seconds: int = 120
+
     @model_validator(mode="after")
     def _resolve_paths(self) -> "Settings":
         # Resolve relative paths against the backend directory (parent of app/)

--- a/backend/app/services/llm_service.py
+++ b/backend/app/services/llm_service.py
@@ -3,6 +3,7 @@
 from dataclasses import dataclass
 from typing import Optional
 
+import httpx
 from pydantic_ai.agent import Agent
 from pydantic_ai.models.openai import OpenAIModel
 from pydantic_ai.profiles import ModelProfile
@@ -51,9 +52,20 @@ class RagDeps:
 class InsightAIProvider(OpenRouterProvider):
     """Custom OpenRouter provider for UIdaho Insight AI server."""
 
-    def __init__(self, api_key: str, endpoint: Optional[str] = None):
+    def __init__(self, api_key: str, endpoint: Optional[str] = None,
+                 http_client: Optional[httpx.AsyncClient] = None):
         self._endpoint = endpoint
-        super().__init__(api_key=api_key)
+        # Passing a dedicated http_client makes pydantic-ai build a per-instance
+        # AsyncOpenAI rather than fall back to the process-wide
+        # cached_async_http_client. The shared cached client is unsafe under the
+        # workflow MultiTaskNode, whose ThreadPoolExecutor runs each task on its
+        # own event loop — reusing one client's connection pool across loops
+        # raises "bound to a different event loop", surfacing as a zero-token
+        # "Connection error".
+        if http_client is not None:
+            super().__init__(api_key=api_key, http_client=http_client)
+        else:
+            super().__init__(api_key=api_key)
 
     @property
     def name(self) -> str:
@@ -77,9 +89,13 @@ class InsightAIProvider(OpenRouterProvider):
 class OllamaProvider(OpenRouterProvider):
     """Provider for Ollama API-compatible servers."""
 
-    def __init__(self, api_key: str, endpoint: str):
+    def __init__(self, api_key: str, endpoint: str,
+                 http_client: Optional[httpx.AsyncClient] = None):
         self._endpoint = endpoint
-        super().__init__(api_key=api_key)
+        if http_client is not None:
+            super().__init__(api_key=api_key, http_client=http_client)
+        else:
+            super().__init__(api_key=api_key)
 
     @property
     def name(self) -> str:
@@ -103,9 +119,13 @@ class OllamaProvider(OpenRouterProvider):
 class VLLMProvider(OpenRouterProvider):
     """Provider for VLLM API-compatible servers."""
 
-    def __init__(self, api_key: str, endpoint: str):
+    def __init__(self, api_key: str, endpoint: str,
+                 http_client: Optional[httpx.AsyncClient] = None):
         self._endpoint = endpoint
-        super().__init__(api_key=api_key)
+        if http_client is not None:
+            super().__init__(api_key=api_key, http_client=http_client)
+        else:
+            super().__init__(api_key=api_key)
 
     @property
     def name(self) -> str:
@@ -299,12 +319,25 @@ def get_agent_model(
         client = AsyncOpenAI(**client_kwargs)
         return OpenAIModel(model_name=model_name, openai_client=client)
 
+    # Build a dedicated httpx client per call instead of letting the provider
+    # fall back to pydantic-ai's process-wide cached_async_http_client. The
+    # cached client is shared across the workflow MultiTaskNode's
+    # ThreadPoolExecutor threads, each of which runs pydantic-ai's run_sync()
+    # on its own event loop; reusing one client's connection pool across loops
+    # raises "RuntimeError: bound to a different event loop", which the OpenAI
+    # SDK re-wraps as a zero-token "Connection error". A fresh client per call
+    # binds only to the loop that uses it.
+    from app.config import Settings
+    read_timeout = max(30, Settings().workflow_llm_timeout_seconds)
+    dedicated_client = httpx.AsyncClient(
+        timeout=httpx.Timeout(read_timeout, connect=10.0)
+    )
     if api_protocol == "ollama":
-        provider = OllamaProvider(api_key=api_key, endpoint=endpoint)
+        provider = OllamaProvider(api_key=api_key, endpoint=endpoint, http_client=dedicated_client)
     elif api_protocol == "vllm":
-        provider = VLLMProvider(api_key=api_key, endpoint=endpoint)
+        provider = VLLMProvider(api_key=api_key, endpoint=endpoint, http_client=dedicated_client)
     else:
-        provider = InsightAIProvider(api_key=api_key, endpoint=endpoint)
+        provider = InsightAIProvider(api_key=api_key, endpoint=endpoint, http_client=dedicated_client)
 
     return OpenAIModel(model_name=agent_model, provider=provider)
 


### PR DESCRIPTION
## Summary
- Parallel-fanout workflow steps (`MultiTaskNode`) intermittently failed with a zero-token **"Connection error"** ~10s in, before any request reached the model server.
- Root cause: the non-external providers (`InsightAIProvider` / `OllamaProvider` / `VLLMProvider`) let pydantic-ai fall back to its process-wide shared `cached_async_http_client`. `MultiTaskNode` runs each fan-out task in a `ThreadPoolExecutor` thread with its own event loop, and reusing one shared `httpx.AsyncClient`'s connection pool across loops raises `RuntimeError: ... bound to a different event loop`, which the OpenAI SDK re-wraps as `APIConnectionError` → "Connection error".
- Fix: build a dedicated `httpx.AsyncClient` per `get_agent_model()` call and forward it through the provider to `AsyncOpenAI`, so each provider binds only to the loop that uses it.

## Changes
- **`backend/app/services/llm_service.py`** — `InsightAIProvider` / `OllamaProvider` / `VLLMProvider.__init__` now accept an optional `http_client` and forward it to `super().__init__`. `get_agent_model()` constructs a per-call `httpx.AsyncClient` (read timeout from the new setting, 10s connect) and passes it to whichever provider is selected.
- **`backend/app/config.py`** — add `workflow_llm_timeout_seconds` (default `120`) for the dedicated client's read timeout, since reasoning models can think for a while over a large document before emitting the first token.

## Why this is safe
- The `MultiTaskNode` fan-out topology is unchanged; this only changes how each provider obtains its HTTP client.
- The external-OpenAI path is untouched (it already builds a fresh `AsyncOpenAI` per call, which is why it never hit the bug).
- Providers still work without an explicit client (the `http_client is None` branch preserves prior behavior).

## Test plan
- [x] `python -m py_compile` on both changed files
- [x] Reproduced the failure on a multi-task workflow against an OpenAI-compatible gateway; worker log showed `RuntimeError: ... bound to a different event loop`
- [x] With the fix, the same parallel workflow completes and records non-zero input tokens

Closes #454
