### PR TITLE
Add Stop button to cancel a running workflow

### DIFF
--- a/backend/app/models/workflow.py
+++ b/backend/app/models/workflow.py
@@ -92,6 +92,10 @@ class WorkflowResult(Document):
     #          "oversize_documents": [{"uuid": ..., "title": ..., "token_count": ...}]}
     error_payload: Optional[dict] = None
     session_id: str
+    # Celery task id of the execution job, captured at enqueue time so a user
+    # can cancel an in-flight run (revoke + terminate). None for runs created
+    # before this field existed or for runs that never enqueued a task.
+    celery_task_id: Optional[str] = None
     current_step_name: Optional[str] = None
     current_step_detail: Optional[str] = None
     current_step_preview: Optional[str] = None

--- a/backend/app/routers/workflows.py
+++ b/backend/app/routers/workflows.py
@@ -991,6 +991,15 @@ async def run_workflow(request: Request, workflow_id: str, req: RunWorkflowReque
         raise HTTPException(status_code=404, detail=str(e))
 
 
+@router.post("/sessions/{session_id}/cancel")
+async def cancel_workflow_run(session_id: str, user: User = Depends(get_current_user)):
+    """Stop an in-flight workflow run (single-run sessions)."""
+    result = await svc.cancel_workflow(session_id, user)
+    if result is None:
+        raise HTTPException(status_code=404, detail="Workflow run not found")
+    return result
+
+
 @router.post("/steps/test")
 @limiter.limit("20/minute")
 async def test_step(request: Request, req: TestStepRequest, user: User = Depends(get_current_user)):

--- a/backend/app/services/workflow_engine.py
+++ b/backend/app/services/workflow_engine.py
@@ -1133,6 +1133,12 @@ class KnowledgeBaseQueryNode(Node):
 # Workflow Engine
 # ---------------------------------------------------------------------------
 
+class WorkflowCancelled(Exception):
+    """Raised inside execute() when a user-requested cancel is detected between
+    steps. Callers should treat this as a clean terminal stop (status
+    ``canceled``), not an error, and must not retry the task."""
+
+
 class WorkflowEngine:
     def __init__(self) -> None:
         self.nodes: list[Node] = []
@@ -1149,13 +1155,18 @@ class WorkflowEngine:
     def get_topological_order(self) -> list[Node]:
         return list(reversed(tuple(self.graph.static_order())))
 
-    def execute(self, workflow_result_updater=None, start_index=0, initial_output=None):
+    def execute(self, workflow_result_updater=None, start_index=0, initial_output=None,
+                should_cancel=None):
         """Execute workflow. Returns (final_output, step_data_list).
 
         Args:
             workflow_result_updater: Optional callable(update_dict) for progress.
             start_index: Index to start execution from (for resumption after approval).
             initial_output: Output to feed into the first node when resuming.
+            should_cancel: Optional callable() -> bool, polled before each step.
+                When it returns True the run is aborted with WorkflowCancelled.
+                This is the cooperative backstop for the between-steps case; an
+                in-flight step is interrupted out-of-band via Celery revocation.
         """
         data = []
         nodes = self.get_topological_order()
@@ -1165,6 +1176,11 @@ class WorkflowEngine:
             # Skip already-executed nodes when resuming
             if idx < start_index:
                 continue
+
+            # Cooperative cancellation: bail before starting the next step if the
+            # user requested a stop while we were between steps.
+            if should_cancel is not None and should_cancel():
+                raise WorkflowCancelled()
 
             if workflow_result_updater:
                 workflow_result_updater({

--- a/backend/app/services/workflow_service.py
+++ b/backend/app/services/workflow_service.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import datetime
+import logging
 import uuid as uuid_mod
 from typing import TYPE_CHECKING
 
@@ -30,6 +31,8 @@ from app.services.config_service import get_user_model_name
 
 if TYPE_CHECKING:
     from app.models.user import User
+
+logger = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
@@ -502,6 +505,10 @@ async def run_workflow(
         model = await get_user_model_name(user_id)
 
     session_id = str(uuid_mod.uuid4())[:8]
+    # Generate the Celery task id up front so we can persist it before the task
+    # is dispatched (no race where the task finishes before we record the id).
+    # It is the handle the cancel endpoint uses to revoke/terminate the run.
+    celery_task_id = str(uuid_mod.uuid4())
 
     result = WorkflowResult(
         workflow=wf.id,
@@ -509,6 +516,7 @@ async def run_workflow(
         status="queued",
         num_steps_total=len(wf.steps),
         input_context={"doc_uuids": document_uuids},
+        celery_task_id=celery_task_id,
     )
     await result.insert()
 
@@ -524,6 +532,7 @@ async def run_workflow(
             "activity_id": activity_id,
         },
         queue="workflows",
+        task_id=celery_task_id,
     )
 
     return session_id
@@ -575,6 +584,66 @@ async def get_workflow_status(session_id: str, user: User | None = None) -> dict
         "workflow_name": workflow_name,
         "document_title": result.document_title,
     }
+
+
+async def cancel_workflow(session_id: str, user: User) -> dict | None:
+    """Cancel an in-flight workflow run.
+
+    Flips the result to ``canceled`` (which the engine's between-steps check and
+    the frontend poller both treat as terminal) and revokes the Celery task with
+    ``terminate=True`` so a step that is mid-LLM-call is interrupted rather than
+    running to completion. Idempotent: a run that already reached a terminal
+    state is returned unchanged. Returns ``None`` when the run is not found or
+    the user is not authorized for it.
+    """
+    result = await _get_authorized_workflow_result(session_id, user)
+    if not result:
+        return None
+
+    terminal = {"completed", "error", "failed", "canceled"}
+    if result.status in terminal:
+        return {"session_id": session_id, "status": result.status}
+
+    # Set the terminal state first so the UI reflects the stop immediately and
+    # the engine's cooperative check (if it happens to be between steps) bails.
+    result.status = "canceled"
+    result.error = "Canceled by user"
+    await result.save()
+
+    # Interrupt the worker. revoke(terminate=True) kills the prefork child
+    # running this task id; if the task is still queued it is dropped before it
+    # starts. Best-effort — the DB flip above is the source of truth for the UI.
+    if result.celery_task_id:
+        try:
+            celery_app.control.revoke(
+                result.celery_task_id, terminate=True, signal="SIGTERM",
+            )
+        except Exception:
+            logger.warning(
+                "Failed to revoke Celery task %s for session %s",
+                result.celery_task_id, session_id, exc_info=True,
+            )
+
+    # Best-effort: mark the matching activity-rail entry canceled too, so the
+    # run doesn't linger as "running" in the activity feed.
+    try:
+        from app.models.activity import ActivityEvent, ActivityStatus
+
+        act = await ActivityEvent.find_one(
+            ActivityEvent.workflow_session_id == session_id,
+        )
+        if act and act.is_running:
+            act.status = ActivityStatus.CANCELED.value
+            act.error = "Canceled by user"
+            act.finished_at = datetime.datetime.now(datetime.timezone.utc)
+            await act.save()
+    except Exception:
+        logger.warning(
+            "Failed to mark activity canceled for session %s",
+            session_id, exc_info=True,
+        )
+
+    return {"session_id": session_id, "status": result.status}
 
 
 async def run_workflow_batch(

--- a/backend/app/tasks/workflow_tasks.py
+++ b/backend/app/tasks/workflow_tasks.py
@@ -102,7 +102,11 @@ def execute_workflow_task(self, workflow_result_id, workflow_id, trigger_step_da
     """
     from bson import ObjectId
 
-    from app.services.workflow_engine import build_workflow_engine, sanitize_step_name
+    from app.services.workflow_engine import (
+        WorkflowCancelled,
+        build_workflow_engine,
+        sanitize_step_name,
+    )
 
     db = _get_db()
 
@@ -330,8 +334,46 @@ def execute_workflow_task(self, workflow_result_id, workflow_id, trigger_step_da
         except Exception as e:
             logger.warning("Could not update activity to running: %s", e)
 
+    # Polled by the engine between steps. The cancel endpoint flips the result
+    # status to "canceled"; this lets a run that is between steps stop cleanly
+    # (a mid-step stop is handled out-of-band by Celery task revocation).
+    def should_cancel() -> bool:
+        try:
+            doc = db.workflow_result.find_one(
+                {"_id": ObjectId(workflow_result_id)}, {"status": 1},
+            )
+            return bool(doc and doc.get("status") == "canceled")
+        except Exception:
+            return False
+
     try:
-        final_output, data = engine.execute(workflow_result_updater=update_progress)
+        final_output, data = engine.execute(
+            workflow_result_updater=update_progress,
+            should_cancel=should_cancel,
+        )
+    except WorkflowCancelled:
+        logger.info(
+            "Workflow %s canceled by user (result %s)", workflow_id, workflow_result_id,
+        )
+        db.workflow_result.update_one(
+            {"_id": ObjectId(workflow_result_id)},
+            {"$set": {"status": "canceled", "error": "Canceled by user"}},
+        )
+        if activity_id:
+            try:
+                from datetime import datetime, timezone
+                db.activity_event.update_one(
+                    {"_id": ObjectId(activity_id)},
+                    {"$set": {
+                        "status": "canceled",
+                        "error": "Canceled by user",
+                        "finished_at": datetime.now(timezone.utc),
+                    }},
+                )
+            except Exception:
+                pass
+        # Clean terminal stop — do not re-raise (no retry).
+        return {"status": "canceled", "result_id": workflow_result_id}
     except Exception as e:
         logger.error("Workflow execution failed for %s: %s", workflow_id, e)
         db.workflow_result.update_one(

--- a/frontend/src/api/workflows.ts
+++ b/frontend/src/api/workflows.ts
@@ -121,6 +121,15 @@ export function getWorkflowStatus(sessionId: string) {
   return apiFetch<WorkflowStatus>(`/api/workflows/status?session_id=${encodeURIComponent(sessionId)}`)
 }
 
+// Stop an in-flight single run. The backend flips the result to "canceled" and
+// revokes the Celery task (terminate) so a mid-step run is interrupted.
+export function cancelWorkflow(sessionId: string) {
+  return apiFetch<{ session_id: string; status: string }>(
+    `/api/workflows/sessions/${encodeURIComponent(sessionId)}/cancel`,
+    { method: 'POST' },
+  )
+}
+
 export interface BatchStatusItem {
   session_id: string
   document_title: string | null
@@ -185,7 +194,12 @@ export function streamWorkflowStatus(
               return
             }
             onStatus(data as WorkflowStatus)
-            if (data.status === 'completed' || data.status === 'error' || data.status === 'failed') {
+            if (
+              data.status === 'completed' ||
+              data.status === 'error' ||
+              data.status === 'failed' ||
+              data.status === 'canceled'
+            ) {
               return
             }
           } catch {

--- a/frontend/src/components/workspace/WorkflowEditorPanel.tsx
+++ b/frontend/src/components/workspace/WorkflowEditorPanel.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useRef, useState, type CSSProperties } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
 import {
-  X, Play, Loader2, Plus, Trash2, Pencil, SlidersHorizontal,
+  X, Play, Square, Loader2, Plus, Trash2, Pencil, SlidersHorizontal,
   FileText, Filter, Outdent, Globe, Image, Code,
   Bug, Search, Zap, Download, Package, CheckCircle, XCircle,
   MousePointerClick, PenTool, ClipboardCheck, Flag,
@@ -846,32 +846,63 @@ export function WorkflowEditorPanel() {
             Select a document to run this workflow
           </div>
         )}
-        <button
-          onClick={handleRun}
-          disabled={runner.running || (isTextInput ? !textInput.trim() : selectedDocUuids.length === 0)}
-          style={{
-            width: '100%', padding: '12px 16px', fontSize: 14, fontWeight: 700,
-            fontFamily: 'inherit', borderRadius: 'var(--ui-radius, 8px)', border: 'none',
-            backgroundColor: 'var(--highlight-color, #eab308)',
-            color: 'var(--highlight-text-color, #000)',
-            cursor: runner.running || (isTextInput ? !textInput.trim() : selectedDocUuids.length === 0) ? 'not-allowed' : 'pointer',
-            opacity: (isTextInput ? !textInput.trim() : selectedDocUuids.length === 0) && !runner.running ? 0.5 : 1,
-            textTransform: 'uppercase', letterSpacing: '0.05em',
-            display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 8,
-          }}
-        >
-          {runner.running ? (
-            <>
-              <Loader2 style={{ width: 16, height: 16, animation: 'spin 1s linear infinite' }} />
-              WORKFLOW RUNNING
-            </>
-          ) : (
-            <>
-              <Play style={{ width: 16, height: 16 }} />
-              RUN
-            </>
-          )}
-        </button>
+        {runner.running && !runner.batchId ? (
+          // Single run in progress — offer an active STOP (red, matches the
+          // app's destructive-action convention; same geometry as RUN).
+          <button
+            onClick={runner.stop}
+            disabled={runner.cancelling}
+            style={{
+              width: '100%', padding: '12px 16px', fontSize: 14, fontWeight: 700,
+              fontFamily: 'inherit', borderRadius: 'var(--ui-radius, 8px)', border: 'none',
+              backgroundColor: '#dc2626', color: '#fff',
+              cursor: runner.cancelling ? 'wait' : 'pointer',
+              opacity: runner.cancelling ? 0.7 : 1,
+              textTransform: 'uppercase', letterSpacing: '0.05em',
+              display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 8,
+            }}
+          >
+            {runner.cancelling ? (
+              <>
+                <Loader2 style={{ width: 16, height: 16, animation: 'spin 1s linear infinite' }} />
+                STOPPING
+              </>
+            ) : (
+              <>
+                <Square style={{ width: 14, height: 14, fill: '#fff' }} />
+                STOP
+              </>
+            )}
+          </button>
+        ) : (
+          <button
+            onClick={handleRun}
+            disabled={runner.running || (isTextInput ? !textInput.trim() : selectedDocUuids.length === 0)}
+            title={runner.running && runner.batchId ? 'Stop is not yet available for batch runs' : undefined}
+            style={{
+              width: '100%', padding: '12px 16px', fontSize: 14, fontWeight: 700,
+              fontFamily: 'inherit', borderRadius: 'var(--ui-radius, 8px)', border: 'none',
+              backgroundColor: 'var(--highlight-color, #eab308)',
+              color: 'var(--highlight-text-color, #000)',
+              cursor: runner.running || (isTextInput ? !textInput.trim() : selectedDocUuids.length === 0) ? 'not-allowed' : 'pointer',
+              opacity: (isTextInput ? !textInput.trim() : selectedDocUuids.length === 0) && !runner.running ? 0.5 : 1,
+              textTransform: 'uppercase', letterSpacing: '0.05em',
+              display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 8,
+            }}
+          >
+            {runner.running ? (
+              <>
+                <Loader2 style={{ width: 16, height: 16, animation: 'spin 1s linear infinite' }} />
+                {runner.batchId ? 'BATCH RUNNING' : 'WORKFLOW RUNNING'}
+              </>
+            ) : (
+              <>
+                <Play style={{ width: 16, height: 16 }} />
+                RUN
+              </>
+            )}
+          </button>
+        )}
       </div>
 
       {/* ===== EDIT STEP OVERLAY ===== */}
@@ -3893,8 +3924,9 @@ function WorkflowOutputCard({ status, sessionId, workflowName, running, runElaps
 }) {
   const isCompleted = status?.status === 'completed'
   const isError = status?.status === 'error' || status?.status === 'failed'
+  const isCanceled = status?.status === 'canceled'
   const isPendingApproval = status?.status === 'pending_approval'
-  const isDone = isCompleted || isError
+  const isDone = isCompleted || isError || isCanceled
 
   const [approval, setApproval] = useState<ReviewDetail | null>(null)
   const [approvalComments, setApprovalComments] = useState('')
@@ -3955,13 +3987,13 @@ function WorkflowOutputCard({ status, sessionId, workflowName, running, runElaps
       backgroundColor: '#fff', borderRadius: 'var(--ui-radius, 8px)',
       boxShadow: '0 6px 18px rgba(0,0,0,0.05)', padding: 20,
       border: isDone
-        ? (isError ? '2px solid #fca5a5' : '2px solid #86efac')
+        ? (isError ? '2px solid #fca5a5' : isCanceled ? '2px solid #d1d5db' : '2px solid #86efac')
         : isPendingApproval ? '2px solid #fbbf24'
         : '2px solid #e5e7eb',
     }}>
       <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 8, gap: 8 }}>
         <div style={{ fontWeight: 600, fontSize: 14, color: '#202124' }}>
-          {running ? 'Workflow Running' : isCompleted ? 'Output' : isError ? 'Error' : isPendingApproval ? 'Awaiting Approval' : 'View Output'}
+          {running ? 'Workflow Running' : isCompleted ? 'Output' : isCanceled ? 'Stopped' : isError ? 'Error' : isPendingApproval ? 'Awaiting Approval' : 'View Output'}
         </div>
         {isPendingApproval && status?.approval_request_id && (
           <a

--- a/frontend/src/hooks/useWorkflowRunner.ts
+++ b/frontend/src/hooks/useWorkflowRunner.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { getBatchStatus, getWorkflowStatus, runWorkflow } from '../api/workflows'
+import { cancelWorkflow, getBatchStatus, getWorkflowStatus, runWorkflow } from '../api/workflows'
 import type { BatchStatus } from '../api/workflows'
 import { useWorkspace } from '../contexts/WorkspaceContext'
 import type { WorkflowStatus } from '../types/workflow'
@@ -11,6 +11,7 @@ export function useWorkflowRunner() {
   const [status, setStatus] = useState<WorkflowStatus | null>(null)
   const [batchStatus, setBatchStatus] = useState<BatchStatus | null>(null)
   const [running, setRunning] = useState(false)
+  const [cancelling, setCancelling] = useState(false)
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
 
   const stopPolling = useCallback(() => {
@@ -24,7 +25,7 @@ export function useWorkflowRunner() {
     try {
       const s = await getWorkflowStatus(sid)
       setStatus(s)
-      const terminal = s.status === 'completed' || s.status === 'error' || s.status === 'failed'
+      const terminal = s.status === 'completed' || s.status === 'error' || s.status === 'failed' || s.status === 'canceled'
       const paused = s.status === 'pending_approval'
       setRunning(!terminal && !paused)
       if (terminal) stopPolling()
@@ -71,6 +72,22 @@ export function useWorkflowRunner() {
     }
   }, [poll, pollBatch, bumpActivitySignal])
 
+  // Stop an in-flight single run. Batch runs are not cancellable yet, so this
+  // no-ops when only a batch is active. After the request returns, poll once so
+  // the UI flips to "canceled" immediately rather than waiting for the next tick.
+  const stop = useCallback(async () => {
+    if (!sessionId || batchId) return
+    setCancelling(true)
+    try {
+      await cancelWorkflow(sessionId)
+      await poll(sessionId)
+    } catch {
+      // Leave the run as-is on failure; the poller keeps the UI honest.
+    } finally {
+      setCancelling(false)
+    }
+  }, [sessionId, batchId, poll])
+
   const loadSession = useCallback(async (sid: string) => {
     stopPolling()
     setSessionId(sid)
@@ -79,7 +96,7 @@ export function useWorkflowRunner() {
     try {
       const s = await getWorkflowStatus(sid)
       setStatus(s)
-      const isTerminal = s.status === 'completed' || s.status === 'error' || s.status === 'failed'
+      const isTerminal = s.status === 'completed' || s.status === 'error' || s.status === 'failed' || s.status === 'canceled'
       const isPaused = s.status === 'pending_approval'
       setRunning(!isTerminal && !isPaused)
       if (!isTerminal) {
@@ -97,6 +114,7 @@ export function useWorkflowRunner() {
     setStatus(null)
     setBatchStatus(null)
     setRunning(false)
+    setCancelling(false)
     stopPolling()
   }, [stopPolling])
 
@@ -105,5 +123,5 @@ export function useWorkflowRunner() {
     return () => stopPolling()
   }, [stopPolling])
 
-  return { sessionId, batchId, status, batchStatus, running, start, loadSession, reset }
+  return { sessionId, batchId, status, batchStatus, running, cancelling, start, stop, loadSession, reset }
 }


### PR DESCRIPTION
## Summary

Adds an immediate **Stop** for single-document workflow runs. Once a run started there was previously no way to cancel it — it had to finish, error, or be abandoned while continuing to consume compute.

## What it does

- **Persist the Celery task id** on `WorkflowResult` at enqueue time, so an in-flight run can be targeted for cancellation.
- **New endpoint** `POST /api/workflows/sessions/{session_id}/cancel`: flips the run (and its activity event) to `canceled` and revokes/terminates the Celery task (`SIGTERM`), so an in-flight step — including a long LLM call — is interrupted, not just the next step.
- **Cooperative backstop**: `WorkflowEngine.execute` polls a `should_cancel` callback between steps and raises `WorkflowCancelled`, treated as a clean terminal stop (no retry).
- **Frontend**: `useWorkflowRunner` gains `stop()` / `cancelling`; the gold Run button is replaced by a red Stop button while a single run is active; the output card shows **Stopped**.

## Scope

Single-document runs only in this PR. Batch runs keep the disabled batch-running state with a tooltip noting Stop is not available for batches yet; batch cancellation is a follow-up.

## Testing

- Backend `py_compile` clean; frontend `tsc -b && vite build` clean.
- Verified locally against a self-hosted model server: started a single run, clicked Stop mid-step, the run flips to **Stopped** and the worker is terminated; re-running afterward starts a clean run.

Closes #456
