### PR TITLE
Add Test Step button for Knowledge Base Query tasks

### DIFF
--- a/backend/app/tasks/workflow_tasks.py
+++ b/backend/app/tasks/workflow_tasks.py
@@ -546,6 +546,7 @@ def execute_task_step_test(self, task_name, task_data, doc_uuids):
         ExtractionNode,
         FormatNode,
         FormFillerNode,
+        KnowledgeBaseQueryNode,
         MultiTaskNode,
         PackageBuilderNode,
         PromptNode,
@@ -608,6 +609,8 @@ def execute_task_step_test(self, task_name, task_data, doc_uuids):
         process_node = PackageBuilderNode(data=task_data)
     elif task_name == "BrowserAutomation":
         process_node = BrowserAutomationNode(data=task_data)
+    elif task_name == "KnowledgeBaseQuery":
+        process_node = KnowledgeBaseQueryNode(data=task_data)
     else:
         raise ValueError(f"Unknown task type: {task_name}")
 

--- a/frontend/src/components/workspace/WorkflowEditorPanel.tsx
+++ b/frontend/src/components/workspace/WorkflowEditorPanel.tsx
@@ -164,12 +164,13 @@ const TEST_MESSAGES = [
 ]
 
 // Task types where Test Step is meaningful and safe. Excludes:
-//   - Approval, KnowledgeBaseQuery: backend test handler doesn't support them
+//   - Approval: backend test handler doesn't support it
 //   - APINode, BrowserAutomation, CodeNode: real side effects make "test" misleading
+// KnowledgeBaseQuery is read-only (a vector lookup), so it is safe to test.
 const TEST_STEP_SUPPORTED_TYPES = new Set([
   'Extraction', 'Prompt', 'Formatter', 'Format', 'AddWebsite', 'AddDocument',
   'DescribeImage', 'CrawlerNode', 'ResearchNode', 'DocumentRenderer',
-  'FormFiller', 'DataExport', 'PackageBuilder',
+  'FormFiller', 'DataExport', 'PackageBuilder', 'KnowledgeBaseQuery',
 ])
 
 const TEST_STEP_TOOLTIP = [


### PR DESCRIPTION
## Summary

Adds the **Test Step** button to **Knowledge Base Query** tasks, so you can run a KB query in isolation and see exactly which chunks it retrieves — the same self-check every other Test-Step-eligible task already supports.

## Why it was missing

- Frontend gated the button on a `TEST_STEP_SUPPORTED_TYPES` allowlist that omitted `KnowledgeBaseQuery`.
- The backend step-test handler (`execute_task_step_test`) had no `KnowledgeBaseQuery` branch, so testing one would raise `Unknown task type`.

The original exclusion lumped it in with `Approval`, but a KB query is **read-only** — just a vector lookup via `DocumentManager.query_kb`, no side effects — so it is as safe to test as Prompt or Extraction.

## Changes

- **Backend** (`workflow_tasks.py`): add a `KnowledgeBaseQuery` branch to `execute_task_step_test` that builds a `KnowledgeBaseQueryNode` — the same node `build_workflow_engine` uses in a real run, wrapped in a `MultiTaskNode` exactly as the other test steps are — so the test output matches real execution.
- **Frontend** (`WorkflowEditorPanel.tsx`): add `KnowledgeBaseQuery` to `TEST_STEP_SUPPORTED_TYPES` (and update the explanatory comment).

## Testing

- Backend `py_compile` clean; frontend `tsc -b && vite build` clean.
- Verified locally: the Test Step button now appears on a Knowledge Base Query task and returns the retrieved chunks (with source/page labels) — what gets injected as context downstream during a real run.

Closes #458
