### PR TITLE
Make workflow DOCX/PDF exports match the on-screen output

### DIFF
--- a/backend/app/routers/workflows.py
+++ b/backend/app/routers/workflows.py
@@ -171,14 +171,140 @@ def _add_runs_with_formatting(paragraph, text: str) -> None:
         pos = next_match.end()
 
 
+# Separator row of a GitHub-flavored markdown table (e.g. ``|---|:--:|-|``).
+# One-or-more dashes per column matches the GFM spec (and remark-gfm, which the
+# UI renders with), so a model emitting ``|--|--|`` still yields a real table.
+# Kept identical to pdf_service so DOCX and PDF detect the same tables.
+_MD_TABLE_SEP_RE = re.compile(r"^\s*\|?\s*:?-+:?\s*(\|\s*:?-+:?\s*)+\|?\s*$")
+# Horizontal rule: 3+ repeats of the same -, * or _ (e.g. ``---``). Mirrors
+# pdf_service so a standalone rule renders as a line, not literal text.
+_MD_HR_RE = re.compile(r"^\s{0,3}([-*_])(\s*\1){2,}\s*$")
+
+
+def _split_md_table_row(line: str) -> list[str]:
+    """Split a markdown table row into trimmed cell strings."""
+    line = line.strip()
+    if line.startswith("|"):
+        line = line[1:]
+    if line.endswith("|"):
+        line = line[:-1]
+    # Honor backslash-escaped pipes by stashing them behind a placeholder.
+    line = line.replace(r"\|", "\x00")
+    return [c.strip().replace("\x00", "|") for c in line.split("|")]
+
+
+# Downloaded-table theme — matches the gold PDF header in pdf_service so Word and
+# PDF downloads share the Vandalizer brand look (UI highlight color #eab308).
+_DOCX_TABLE_HEADER_FILL = "EAB308"   # brand gold header fill
+_DOCX_TABLE_STRIPE_FILL = "FDF9EB"   # faint gold tint for zebra striping
+_DOCX_TABLE_BORDER = "E5E7EB"        # light-gray grid
+_DOCX_HEADING_HEX = "191919"         # charcoal headings (override Word's blue)
+
+
+def _shade_docx_cell(cell, fill_hex: str) -> None:
+    """Set a table cell's background fill (python-docx has no high-level API)."""
+    from docx.oxml import OxmlElement
+    from docx.oxml.ns import qn
+
+    shd = OxmlElement("w:shd")
+    shd.set(qn("w:val"), "clear")
+    shd.set(qn("w:color"), "auto")
+    shd.set(qn("w:fill"), fill_hex)
+    cell._tc.get_or_add_tcPr().append(shd)
+
+
+def _set_docx_table_borders(table, color_hex: str) -> None:
+    """Apply a thin single-line grid border (color_hex) to every table edge."""
+    from docx.oxml import OxmlElement
+    from docx.oxml.ns import qn
+
+    borders = OxmlElement("w:tblBorders")
+    for edge in ("top", "left", "bottom", "right", "insideH", "insideV"):
+        el = OxmlElement(f"w:{edge}")
+        el.set(qn("w:val"), "single")
+        el.set(qn("w:sz"), "4")       # 4 eighths-of-a-point = 0.5pt
+        el.set(qn("w:space"), "0")
+        el.set(qn("w:color"), color_hex)
+        borders.append(el)
+    table._tbl.tblPr.append(borders)
+
+
+def _add_docx_hr(doc) -> None:
+    """Render a markdown horizontal rule as an empty paragraph with a thin,
+    light-gray bottom border (Word has no native ``<hr>``)."""
+    from docx.oxml import OxmlElement
+    from docx.oxml.ns import qn
+
+    p = doc.add_paragraph()
+    p_pr = p._p.get_or_add_pPr()
+    borders = OxmlElement("w:pBdr")
+    bottom = OxmlElement("w:bottom")
+    bottom.set(qn("w:val"), "single")
+    bottom.set(qn("w:sz"), "6")
+    bottom.set(qn("w:space"), "1")
+    bottom.set(qn("w:color"), _DOCX_TABLE_BORDER)
+    borders.append(bottom)
+    p_pr.append(borders)
+
+
+def _apply_docx_table_theme(table) -> None:
+    """Apply the Vandalizer gold table theme to a Word table.
+
+    Gold (#eab308) header row with bold black text, faint gold zebra striping on
+    body rows, and a light-gray grid. Replaces the built-in (blue) ``Light Grid
+    Accent 1`` style so DOCX downloads match the gold-headed PDF tables.
+    """
+    table.style = "Table Grid"
+    _set_docx_table_borders(table, _DOCX_TABLE_BORDER)
+    rows = table.rows
+    if not rows:
+        return
+    for cell in rows[0].cells:
+        _shade_docx_cell(cell, _DOCX_TABLE_HEADER_FILL)
+        for para in cell.paragraphs:
+            for run in para.runs:
+                run.bold = True
+    for idx, row in enumerate(rows[1:], start=1):
+        if idx % 2 == 0:  # zebra-stripe every other body row
+            for cell in row.cells:
+                _shade_docx_cell(cell, _DOCX_TABLE_STRIPE_FILL)
+
+
+def _add_markdown_table_to_docx(doc, headers: list[str], rows: list[list[str]]) -> None:
+    """Render parsed markdown-table cells as a real Word table.
+
+    Uses the shared gold table theme (see ``_apply_docx_table_theme``), with
+    inline **bold**/*italic*/`code` honored inside every cell.
+    """
+    col_count = max(len(headers), max((len(r) for r in rows), default=0)) or 1
+    headers = headers + [""] * (col_count - len(headers))
+
+    table = doc.add_table(rows=1, cols=col_count)
+
+    hdr_cells = table.rows[0].cells
+    for i, h in enumerate(headers):
+        _add_runs_with_formatting(hdr_cells[i].paragraphs[0], h)
+
+    for row in rows:
+        row = row + [""] * (col_count - len(row))
+        cells = table.add_row().cells
+        for i in range(col_count):
+            _add_runs_with_formatting(cells[i].paragraphs[0], row[i])
+
+    _apply_docx_table_theme(table)
+
+
 def _markdown_to_docx(text: str):
     """Render a markdown-ish string into a python-docx Document.
 
-    Handles ATX headings, unordered/ordered lists, blank-line paragraphs, and
-    inline bold/italic/code. Unknown syntax falls back to a plain paragraph.
+    Handles ATX headings, unordered/ordered lists, GitHub-flavored tables,
+    blank-line paragraphs, and inline bold/italic/code. Unknown syntax falls
+    back to a plain paragraph.
     """
     from docx import Document
-    from docx.shared import Inches, Pt
+    from docx.shared import Inches, Pt, RGBColor
+
+    heading_color = RGBColor.from_string(_DOCX_HEADING_HEX)
 
     doc = Document()
     for section in doc.sections:
@@ -192,32 +318,62 @@ def _markdown_to_docx(text: str):
     style.font.size = Pt(11)
 
     lines = (text or "").splitlines()
-    for raw in lines:
-        line = raw.rstrip()
+    n = len(lines)
+    i = 0
+    while i < n:
+        line = lines[i].rstrip()
         if not line.strip():
             doc.add_paragraph()
+            i += 1
+            continue
+
+        # Markdown table — a header row followed by a dash-separator row. Consume
+        # the header, separator, and all contiguous body rows into a real table.
+        if "|" in line and i + 1 < n and _MD_TABLE_SEP_RE.match(lines[i + 1].rstrip()):
+            headers = _split_md_table_row(line)
+            i += 2  # skip header + separator
+            rows: list[list[str]] = []
+            while i < n:
+                body = lines[i].rstrip()
+                if not body.strip() or "|" not in body:
+                    break
+                rows.append(_split_md_table_row(body))
+                i += 1
+            _add_markdown_table_to_docx(doc, headers, rows)
+            continue
+
+        # Horizontal rule (``---`` / ``***`` / ``___``) → a thin border, not text.
+        if _MD_HR_RE.match(line):
+            _add_docx_hr(doc)
+            i += 1
             continue
 
         heading = re.match(r"^(#{1,6})\s+(.+)$", line)
         if heading:
             level = min(len(heading.group(1)), 4)
-            doc.add_heading(heading.group(2).strip(), level=level)
+            h = doc.add_heading(heading.group(2).strip(), level=level)
+            for run in h.runs:
+                run.font.color.rgb = heading_color  # charcoal, not Word's blue
+            i += 1
             continue
 
         bullet = re.match(r"^\s*[-*+]\s+(.+)$", line)
         if bullet:
             p = doc.add_paragraph(style="List Bullet")
             _add_runs_with_formatting(p, bullet.group(1).strip())
+            i += 1
             continue
 
         numbered = re.match(r"^\s*\d+\.\s+(.+)$", line)
         if numbered:
             p = doc.add_paragraph(style="List Number")
             _add_runs_with_formatting(p, numbered.group(1).strip())
+            i += 1
             continue
 
         p = doc.add_paragraph()
         _add_runs_with_formatting(p, line)
+        i += 1
 
     return doc
 
@@ -246,17 +402,15 @@ def _data_to_docx_bytes(data) -> bytes:
         doc.styles["Normal"].font.size = Pt(11)
         headers = list(dict.fromkeys(k for row in data for k in row.keys()))
         table = doc.add_table(rows=1, cols=len(headers))
-        table.style = "Light Grid Accent 1"
         hdr_cells = table.rows[0].cells
         for i, h in enumerate(headers):
             hdr_cells[i].text = str(h)
-            for run in hdr_cells[i].paragraphs[0].runs:
-                run.bold = True
         for row in data:
             cells = table.add_row().cells
             for i, h in enumerate(headers):
                 val = row.get(h, "")
                 cells[i].text = json.dumps(val, default=str) if isinstance(val, (dict, list)) else str(val if val is not None else "")
+        _apply_docx_table_theme(table)
     elif isinstance(data, dict):
         doc = Document()
         for section in doc.sections:
@@ -265,17 +419,14 @@ def _data_to_docx_bytes(data) -> bytes:
         doc.styles["Normal"].font.name = "Arial"
         doc.styles["Normal"].font.size = Pt(11)
         table = doc.add_table(rows=1, cols=2)
-        table.style = "Light Grid Accent 1"
         hdr = table.rows[0].cells
         hdr[0].text = "Field"
         hdr[1].text = "Value"
-        for cell in hdr:
-            for run in cell.paragraphs[0].runs:
-                run.bold = True
         for k, v in data.items():
             cells = table.add_row().cells
             cells[0].text = str(k)
             cells[1].text = json.dumps(v, default=str) if isinstance(v, (dict, list)) else str(v)
+        _apply_docx_table_theme(table)
     elif isinstance(data, list):
         doc = _markdown_to_docx("\n".join(f"- {item}" for item in data))
     else:

--- a/backend/app/services/pdf_service.py
+++ b/backend/app/services/pdf_service.py
@@ -203,7 +203,9 @@ _MD_NUMBERED_RE = re.compile(r"^(\s*)(\d+)\.\s+(.+)$")
 _MD_BLOCKQUOTE_RE = re.compile(r"^>\s?(.*)$")
 _MD_HR_RE = re.compile(r"^\s{0,3}([-*_])(\s*\1){2,}\s*$")
 _MD_FENCE_RE = re.compile(r"^\s{0,3}(```+|~~~+)\s*([\w+-]*)\s*$")
-_MD_TABLE_SEP_RE = re.compile(r"^\s*\|?\s*:?-{3,}:?\s*(\|\s*:?-{3,}:?\s*)+\|?\s*$")
+# One-or-more dashes per column matches the GFM spec (and remark-gfm, which the
+# UI renders with), so a model emitting ``|--|--|`` still yields a real table.
+_MD_TABLE_SEP_RE = re.compile(r"^\s*\|?\s*:?-+:?\s*(\|\s*:?-+:?\s*)+\|?\s*$")
 
 
 # Unicode characters outside Helvetica's WinAnsi encoding render as ■ boxes.
@@ -299,7 +301,7 @@ def _styles() -> dict:
             fontSize=22,
             leading=26,
             spaceAfter=4,
-            textColor=colors.HexColor("#0f172a"),
+            textColor=colors.HexColor("#191919"),
             alignment=0,
         ),
         "meta": ParagraphStyle(
@@ -318,7 +320,7 @@ def _styles() -> dict:
             leading=22,
             spaceBefore=14,
             spaceAfter=6,
-            textColor=colors.HexColor("#0f172a"),
+            textColor=colors.HexColor("#191919"),
         ),
         "h2": ParagraphStyle(
             "WfH2",
@@ -328,7 +330,7 @@ def _styles() -> dict:
             leading=19,
             spaceBefore=12,
             spaceAfter=5,
-            textColor=colors.HexColor("#0f172a"),
+            textColor=colors.HexColor("#191919"),
         ),
         "h3": ParagraphStyle(
             "WfH3",
@@ -442,7 +444,8 @@ def _styles() -> dict:
             fontName="Helvetica-Bold",
             fontSize=9.5,
             leading=12,
-            textColor=colors.white,
+            # Black text on the gold (#eab308) header — see _build_table_flowable.
+            textColor=colors.HexColor("#111827"),
         ),
     }
     return s
@@ -497,13 +500,15 @@ def _build_table_flowable(headers: list[str], rows: list[list[str]], styles: dic
     table = Table(data, colWidths=col_widths, repeatRows=1)
     row_count = len(data)
     table.setStyle(TableStyle([
-        ("BACKGROUND", (0, 0), (-1, 0), colors.HexColor("#1e3a5f")),
-        ("TEXTCOLOR", (0, 0), (-1, 0), colors.white),
+        # Vandalizer brand gold header (#eab308) with black text.
+        ("BACKGROUND", (0, 0), (-1, 0), colors.HexColor("#eab308")),
+        ("TEXTCOLOR", (0, 0), (-1, 0), colors.HexColor("#111827")),
         ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
         ("FONTSIZE", (0, 0), (-1, 0), 9.5),
         ("BOTTOMPADDING", (0, 0), (-1, 0), 8),
         ("TOPPADDING", (0, 0), (-1, 0), 8),
-        ("ROWBACKGROUNDS", (0, 1), (-1, row_count - 1), [colors.white, colors.HexColor("#f9fafb")]),
+        # Faint gold-tinted zebra striping on body rows.
+        ("ROWBACKGROUNDS", (0, 1), (-1, row_count - 1), [colors.white, colors.HexColor("#fdf9eb")]),
         ("GRID", (0, 0), (-1, -1), 0.5, colors.HexColor("#e5e7eb")),
         ("VALIGN", (0, 0), (-1, -1), "TOP"),
         ("LEFTPADDING", (0, 0), (-1, -1), 8),
@@ -703,13 +708,15 @@ def _kv_table_flowable(data: dict, styles: dict, usable_width: float):
     table = Table(data_rows, colWidths=col_widths, repeatRows=1)
     row_count = len(data_rows)
     table.setStyle(TableStyle([
-        ("BACKGROUND", (0, 0), (-1, 0), colors.HexColor("#1e3a5f")),
-        ("TEXTCOLOR", (0, 0), (-1, 0), colors.white),
+        # Vandalizer brand gold header (#eab308) with black text.
+        ("BACKGROUND", (0, 0), (-1, 0), colors.HexColor("#eab308")),
+        ("TEXTCOLOR", (0, 0), (-1, 0), colors.HexColor("#111827")),
         ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
         ("FONTSIZE", (0, 0), (-1, 0), 9.5),
         ("BOTTOMPADDING", (0, 0), (-1, 0), 8),
         ("TOPPADDING", (0, 0), (-1, 0), 8),
-        ("ROWBACKGROUNDS", (0, 1), (-1, row_count - 1), [colors.white, colors.HexColor("#f9fafb")]),
+        # Faint gold-tinted zebra striping on body rows.
+        ("ROWBACKGROUNDS", (0, 1), (-1, row_count - 1), [colors.white, colors.HexColor("#fdf9eb")]),
         ("GRID", (0, 0), (-1, -1), 0.5, colors.HexColor("#e5e7eb")),
         ("VALIGN", (0, 0), (-1, -1), "TOP"),
         ("LEFTPADDING", (0, 0), (-1, -1), 8),


### PR DESCRIPTION
## Summary

Downloaded workflow output (PDF / Word) now faithfully matches the on-screen rendering. Fixes the "tables disappear" bug in Word, the intermittent "hit or miss" table failures in PDF, and brings the export styling in line with the Vandalizer brand.

Closes #460.

## What changed

**`backend/app/routers/workflows.py`**
- `_markdown_to_docx` now detects GitHub-flavored markdown tables and emits **real Word tables** (previously table lines fell through to a plain paragraph and were written as literal `| ... |` text).
- Added horizontal-rule support — `---` / `***` / `___` render as a thin divider instead of literal text.
- New shared helpers apply a brand-themed table style: gold (`#eab308`) header with bold black text, faint-gold zebra rows, light-gray (`#e5e7eb`) grid — replacing Word's blue `Light Grid Accent 1` across all three table paths (markdown-string, list-of-dicts, dict).
- Section headings are now charcoal (`#191919`) instead of Office blue.

**`backend/app/services/pdf_service.py`**
- Loosened the table-separator regex from `-{3,}` to one-or-more dashes (the GFM minimum, matching `remark-gfm` which the UI renders with), so sparse separators like `|--|--|` and `:-:` are detected — fixing the "hit or miss" PDF behavior. Kept identical to the DOCX regex so both formats detect the same tables.
- Themed PDF tables to the same gold header + faint-gold stripes, and switched headings to charcoal (`#191919`).

## Test plan

- [x] Markdown table inside a larger markdown doc → one real Word table + one PDF table; surrounding headings/bold/bullets/prose preserved.
- [x] 3-dash, 2-dash, and colon-aligned (`:-:`) separators all detected in both DOCX and PDF.
- [x] Standalone `---` is treated as a horizontal rule, not a table (no false positive).
- [x] Structured list-of-dicts and dict outputs still produce exactly one real table (no regression).
- [x] DOCX header cells carry gold fill (`EAB308`), zebra rows (`FDF9EB`), gray borders (`E5E7EB`); headings carry charcoal (`191919`); no `Light Grid Accent 1`.
- [x] PDF renders as a valid document end-to-end.
- [x] `python -m py_compile` passes on both files.
