### PR TITLE
Add Present & Pitch communications surface

### DIFF
--- a/frontend/src/components/layout/TeamsDropdown.tsx
+++ b/frontend/src/components/layout/TeamsDropdown.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect } from 'react'
-import { Award, User, Users, Settings, LogOut, IdCard, Shield, ClipboardCheck, ChevronDown, MessageSquare } from 'lucide-react'
+import { Award, User, Users, Settings, LogOut, IdCard, Shield, ClipboardCheck, ChevronDown, MessageSquare, Presentation } from 'lucide-react'
 import { Link } from '@tanstack/react-router'
 import { useTeams } from '../../hooks/useTeams'
 import { useAuth } from '../../hooks/useAuth'
@@ -90,6 +90,16 @@ export function TeamsDropdown() {
           >
             <IdCard className="h-4 w-4 shrink-0" style={{ width: 18 }} />
             <span>My Account</span>
+          </Link>
+
+          {/* Present & Pitch */}
+          <Link
+            to="/docs/present"
+            onClick={() => setOpen(false)}
+            className="flex items-center gap-2.5 rounded-md px-3.5 py-2.5 text-sm text-[#111] hover:bg-black/[.04] transition-colors"
+          >
+            <Presentation className="h-4 w-4 shrink-0" style={{ width: 18 }} />
+            <span>Present &amp; Pitch</span>
           </Link>
 
           {/* Certification */}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -599,3 +599,63 @@ html {
     animation: none !important;
   }
 }
+
+/* ===== Present & Pitch (deck / read / print prose) ===== */
+.deck-prose {
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+.deck-prose p { margin: 0.75em 0; }
+.deck-prose ul { margin: 0.75em 0; padding-left: 0; list-style: none; }
+.deck-prose ul li { position: relative; padding-left: 1.4em; margin: 0.4em 0; }
+.deck-prose ul li::before { content: "\25B8"; position: absolute; left: 0; color: #f1b300; }
+.deck-prose ol { margin: 0.75em 0; padding-left: 1.4em; }
+.deck-prose strong { color: #fff; font-weight: 700; }
+.deck-prose em { color: #d1d5db; }
+.deck-prose a { color: #f1b300; text-decoration: underline; }
+.deck-prose code {
+  background: rgba(255, 255, 255, 0.1);
+  color: #f1b300;
+  padding: 0.1em 0.4em;
+  border-radius: 4px;
+  font-size: 0.9em;
+}
+.deck-prose pre {
+  background: #18181b;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 8px;
+  padding: 1em;
+  overflow-x: auto;
+  margin: 1em 0;
+}
+.deck-prose pre code { background: none; color: #d4d4d8; padding: 0; font-size: 0.85em; line-height: 1.5; }
+.deck-prose table { width: 100%; border-collapse: collapse; margin: 1em 0; font-size: 0.95em; }
+.deck-prose th, .deck-prose td { border: 1px solid rgba(255, 255, 255, 0.12); padding: 0.5em 0.75em; text-align: left; }
+.deck-prose th { background: rgba(241, 179, 0, 0.1); color: #fff; }
+
+/* Deck (projector) — larger type when no read/print modifier is present */
+.deck-prose:not(.deck-prose--read):not(.deck-prose--print) { font-size: 1.5rem; }
+@media (min-width: 640px) {
+  .deck-prose:not(.deck-prose--read):not(.deck-prose--print) { font-size: 1.9rem; }
+}
+
+/* Print handout — dark text on white */
+.deck-prose--print { color: #1a1a1a; font-size: 1rem; }
+.deck-prose--print strong { color: #000; }
+.deck-prose--print em { color: #333; }
+.deck-prose--print a { color: #1a1a1a; }
+.deck-prose--print ul li::before { color: #b8860b; }
+.deck-prose--print code { background: #f0f0f0; color: #b8860b; }
+.deck-prose--print pre { background: #f6f6f6; border-color: #ddd; }
+.deck-prose--print pre code { color: #333; }
+.deck-prose--print th { background: #f3f3f3; color: #000; }
+.deck-prose--print th, .deck-prose--print td { border-color: #ccc; }
+
+/* ===== Print ===== */
+@media print {
+  .no-print { display: none !important; }
+  html, body { background: #fff !important; }
+  .print-handout { display: block !important; background: #fff !important; color: #000 !important; }
+  .print-slide { break-after: page; page-break-after: always; padding: 1.5rem 0; }
+  .print-slide:last-child { break-after: auto; page-break-after: auto; }
+}

--- a/frontend/src/pages/Docs.tsx
+++ b/frontend/src/pages/Docs.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef, type ComponentType } from 'react'
 import { Link } from '@tanstack/react-router'
 import { Footer } from '../components/layout/Footer'
+import { PresentSidebar } from './present/components/PresentSidebar'
 import {
   BookOpen,
   Server,
@@ -657,6 +658,9 @@ export default function Docs() {
             className="absolute top-16 right-0 w-72 bg-[#0a0a0a] border-l border-white/10 h-full overflow-y-auto p-6"
             onClick={(e) => e.stopPropagation()}
           >
+            <div className="mb-4">
+              <PresentSidebar onNavigate={() => setMobileMenuOpen(false)} />
+            </div>
             <nav className="space-y-1">
               {sections.map((s) => {
                 const Icon = s.icon
@@ -684,8 +688,11 @@ export default function Docs() {
       <div className="pt-16 flex max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         {/* Sticky sidebar TOC — desktop only */}
         <aside className="hidden lg:block w-64 shrink-0 pr-8">
-          <nav className="sticky top-24 space-y-1">
-            {sections.map((s) => {
+          <div className="sticky top-24 space-y-4">
+            <PresentSidebar />
+            <hr className="border-white/10" />
+            <nav className="space-y-1">
+              {sections.map((s) => {
               const Icon = s.icon
               return (
                 <a
@@ -701,8 +708,9 @@ export default function Docs() {
                   {s.label}
                 </a>
               )
-            })}
-          </nav>
+              })}
+            </nav>
+          </div>
         </aside>
 
         {/* Content */}

--- a/frontend/src/pages/Landing.tsx
+++ b/frontend/src/pages/Landing.tsx
@@ -327,6 +327,12 @@ export default function Landing() {
           <img src="/images/Vandalizer_Wordmark_Color_RGB+W.png" alt="Vandalizer" className="h-10" />
           <div className="flex items-center gap-4">
             <Link
+              to="/docs/present"
+              className="text-sm text-gray-400 hover:text-highlight transition-colors"
+            >
+              Overview
+            </Link>
+            <Link
               to="/docs"
               className="text-sm text-gray-400 hover:text-highlight transition-colors"
             >

--- a/frontend/src/pages/present/Present.tsx
+++ b/frontend/src/pages/present/Present.tsx
@@ -1,0 +1,101 @@
+import { Navigate, useNavigate, useParams, useSearch } from '@tanstack/react-router'
+import { PresentShell } from './components/PresentShell'
+import { PresentHub } from './PresentHub'
+import { PresentTrack } from './PresentTrack'
+import { Deck } from './components/Deck'
+import { PrintHandout } from './components/PrintHandout'
+import { getTrack } from './content'
+
+type PresentSearch = {
+  mode?: 'deck'
+  slide?: number
+  pitch?: 'spoken' | 'written'
+}
+
+/**
+ * Route component for /docs/present and /docs/present/$audience.
+ * - no audience  → hub (audience picker + pitch strip)
+ * - audience     → read page, with ?mode=deck opening the presenter overlay,
+ *                  ?slide=N selecting a slide, ?pitch=spoken|written highlighting.
+ */
+export default function Present() {
+  const params = useParams({ strict: false }) as { audience?: string }
+  const search = useSearch({ strict: false }) as PresentSearch
+  const navigate = useNavigate()
+
+  const track = getTrack(params.audience)
+
+  // Hub
+  if (!params.audience) {
+    return (
+      <PresentShell showSidebar={false}>
+        <PresentHub />
+      </PresentShell>
+    )
+  }
+
+  // Unknown audience → back to the hub
+  if (!track) {
+    return <Navigate to="/docs/present" />
+  }
+
+  const audience = track.id
+  const deckOpen = search.mode === 'deck'
+  const initialIndex = Math.max(0, (search.slide ?? 1) - 1)
+
+  const openDeck = () =>
+    navigate({
+      to: '/docs/present/$audience',
+      params: { audience },
+      search: { mode: 'deck', slide: search.slide, pitch: search.pitch },
+    })
+
+  const closeDeck = () =>
+    navigate({
+      to: '/docs/present/$audience',
+      params: { audience },
+      search: { mode: undefined, slide: undefined, pitch: search.pitch },
+      replace: true,
+    })
+
+  const syncSlide = (index: number) =>
+    navigate({
+      to: '/docs/present/$audience',
+      params: { audience },
+      search: { mode: 'deck', slide: index + 1, pitch: search.pitch },
+      replace: true,
+    })
+
+  const print = () => window.print()
+
+  return (
+    <>
+      {/* On-screen read view — hidden when printing (the handout prints instead) */}
+      <div className="no-print">
+        <PresentShell activeAudience={audience}>
+          <PresentTrack
+            track={track}
+            onPresent={openDeck}
+            onPrint={print}
+            pitchHighlight={search.pitch}
+          />
+        </PresentShell>
+      </div>
+
+      {/* Printable handout: hidden on screen, all slides one-per-page in print */}
+      <PrintHandout slides={track.slides} title={track.label} />
+
+      {/* Presenter overlay */}
+      {deckOpen && (
+        <Deck
+          slides={track.slides}
+          initialIndex={initialIndex}
+          title={track.label}
+          onClose={closeDeck}
+          onIndexChange={syncSlide}
+          onPrint={print}
+        />
+      )}
+    </>
+  )
+}

--- a/frontend/src/pages/present/PresentHub.tsx
+++ b/frontend/src/pages/present/PresentHub.tsx
@@ -1,0 +1,135 @@
+import { useState } from 'react'
+import { Link } from '@tanstack/react-router'
+import { Presentation, BookOpen, Copy, Check, ArrowRight } from 'lucide-react'
+import { useToast } from '../../contexts/ToastContext'
+import { TRACK_ORDER, TRACKS, type AudienceId } from './content'
+
+function PitchQuickCopy({ audience }: { audience: AudienceId }) {
+  const track = TRACKS[audience]
+  const { toast } = useToast()
+  const [copied, setCopied] = useState<null | 'spoken' | 'written'>(null)
+
+  const copy = async (kind: 'spoken' | 'written') => {
+    try {
+      await navigator.clipboard.writeText(track.pitch[kind])
+      setCopied(kind)
+      setTimeout(() => setCopied(null), 2000)
+      toast(`${track.label} ${kind} pitch copied.`, 'success')
+    } catch {
+      toast('Could not copy to clipboard.', 'error')
+    }
+  }
+
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-white/10 bg-white/[0.03] px-4 py-3">
+      <span className="text-sm font-medium text-gray-200">{track.label}</span>
+      <div className="flex items-center gap-2">
+        {(['spoken', 'written'] as const).map((kind) => (
+          <button
+            key={kind}
+            onClick={() => copy(kind)}
+            className="inline-flex items-center gap-1.5 rounded-md border border-white/15 px-2.5 py-1.5 text-xs font-medium text-gray-300 hover:bg-white/10 hover:text-white transition-colors"
+          >
+            {copied === kind ? (
+              <Check className="w-3.5 h-3.5 text-green-400" />
+            ) : (
+              <Copy className="w-3.5 h-3.5" />
+            )}
+            {kind === 'spoken' ? 'Spoken' : 'Written'}
+          </button>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export function PresentHub() {
+  return (
+    <div className="space-y-12">
+      {/* Hero */}
+      <header>
+        <h1 className="text-4xl sm:text-5xl font-bold text-white tracking-tight">
+          Present &amp; Pitch
+        </h1>
+        <p className="mt-4 text-lg text-gray-400 max-w-2xl leading-relaxed">
+          Ready-to-use material for introducing Vandalizer — pick your audience, then
+          read it, present it live, or copy an elevator pitch. Everything here is public:
+          share any link, no account needed.
+        </p>
+      </header>
+
+      {/* Audience cards */}
+      <section>
+        <h2 className="text-sm font-bold uppercase tracking-wider text-[#f1b300] mb-4">
+          Choose your audience
+        </h2>
+        <div className="grid gap-5 sm:grid-cols-2">
+          {TRACK_ORDER.map((id) => {
+            const track = TRACKS[id]
+            const Icon = track.icon
+            return (
+              <div
+                key={id}
+                className="flex flex-col rounded-xl border border-white/10 bg-white/[0.03] p-6 hover:border-[#f1b300]/30 transition-colors"
+              >
+                <div className="flex items-center gap-3 mb-3">
+                  <span className="flex h-10 w-10 items-center justify-center rounded-lg bg-[#f1b300]/10 text-[#f1b300]">
+                    <Icon className="w-5 h-5" />
+                  </span>
+                  <div>
+                    <h3 className="text-lg font-bold text-white">{track.label}</h3>
+                    <p className="text-sm text-gray-500">{track.tagline}</p>
+                  </div>
+                </div>
+                <ul className="flex-1 space-y-1.5 mb-5">
+                  {track.valueProps.slice(0, 3).map((vp) => (
+                    <li key={vp} className="flex items-start gap-2 text-sm text-gray-300">
+                      <span className="text-[#f1b300] mt-1 leading-none">&#x2022;</span>
+                      <span>{vp}</span>
+                    </li>
+                  ))}
+                </ul>
+                <div className="flex items-center gap-2">
+                  <Link
+                    to="/docs/present/$audience"
+                    params={{ audience: id }}
+                    search={{ mode: undefined, slide: undefined, pitch: undefined }}
+                    className="inline-flex items-center gap-1.5 rounded-lg bg-[#f1b300] px-3.5 py-2 text-sm font-bold text-black hover:bg-[#d49e00] transition-colors"
+                  >
+                    <BookOpen className="w-4 h-4" />
+                    Read
+                  </Link>
+                  <Link
+                    to="/docs/present/$audience"
+                    params={{ audience: id }}
+                    search={{ mode: 'deck', slide: undefined, pitch: undefined }}
+                    className="inline-flex items-center gap-1.5 rounded-lg border border-white/15 px-3.5 py-2 text-sm font-medium text-gray-200 hover:bg-white/10 transition-colors"
+                  >
+                    <Presentation className="w-4 h-4" />
+                    Present
+                  </Link>
+                  <ArrowRight className="w-4 h-4 text-gray-600 ml-auto" />
+                </div>
+              </div>
+            )
+          })}
+        </div>
+      </section>
+
+      {/* Quick-copy pitch strip */}
+      <section>
+        <h2 className="text-sm font-bold uppercase tracking-wider text-[#f1b300] mb-1">
+          Grab a pitch in 10 seconds
+        </h2>
+        <p className="text-sm text-gray-500 mb-4">
+          Copy a ready-made spoken or written pitch for any audience.
+        </p>
+        <div className="space-y-2.5">
+          {TRACK_ORDER.map((id) => (
+            <PitchQuickCopy key={id} audience={id} />
+          ))}
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/frontend/src/pages/present/PresentTrack.tsx
+++ b/frontend/src/pages/present/PresentTrack.tsx
@@ -1,0 +1,80 @@
+import { Presentation, Printer } from 'lucide-react'
+import type { Track } from './content'
+import { Markdown } from './markdown'
+import { ElevatorPitchCard } from './components/ElevatorPitchCard'
+
+interface PresentTrackProps {
+  track: Track
+  /** Open the presenter deck (sets ?mode=deck). */
+  onPresent: () => void
+  /** Print the full handout. */
+  onPrint: () => void
+  /** Emphasize a pitch variant from ?pitch. */
+  pitchHighlight?: 'spoken' | 'written'
+}
+
+export function PresentTrack({ track, onPresent, onPrint, pitchHighlight }: PresentTrackProps) {
+  const Icon = track.icon
+  return (
+    <div className="space-y-12">
+      {/* Hero */}
+      <header>
+        <div className="flex items-center gap-3 mb-4">
+          <span className="flex h-11 w-11 items-center justify-center rounded-lg bg-[#f1b300]/10 text-[#f1b300]">
+            <Icon className="w-6 h-6" />
+          </span>
+          <div>
+            <h1 className="text-3xl sm:text-4xl font-bold text-white tracking-tight">
+              {track.label}
+            </h1>
+            <p className="text-gray-500">{track.tagline}</p>
+          </div>
+        </div>
+
+        <ul className="grid gap-2 sm:grid-cols-2 mt-6">
+          {track.valueProps.map((vp) => (
+            <li key={vp} className="flex items-start gap-2 text-gray-300">
+              <span className="text-[#f1b300] mt-1 leading-none">&#x2022;</span>
+              <span>{vp}</span>
+            </li>
+          ))}
+        </ul>
+
+        <div className="flex flex-wrap items-center gap-3 mt-7">
+          <button
+            onClick={onPresent}
+            className="inline-flex items-center gap-2 rounded-lg bg-[#f1b300] px-4 py-2.5 text-sm font-bold text-black hover:bg-[#d49e00] transition-colors"
+          >
+            <Presentation className="w-4 h-4" />
+            Present ({track.slides.length} slides)
+          </button>
+          <button
+            onClick={onPrint}
+            className="inline-flex items-center gap-2 rounded-lg border border-white/15 px-4 py-2.5 text-sm font-medium text-gray-200 hover:bg-white/10 transition-colors"
+          >
+            <Printer className="w-4 h-4" />
+            Print / PDF
+          </button>
+        </div>
+      </header>
+
+      {/* Elevator pitch */}
+      <section>
+        <h2 className="text-sm font-bold uppercase tracking-wider text-[#f1b300] mb-4">
+          Elevator pitch
+        </h2>
+        <ElevatorPitchCard pitch={track.pitch} highlight={pitchHighlight} />
+      </section>
+
+      {/* Long-form sections */}
+      <section className="space-y-10">
+        {track.sections.map((s) => (
+          <div key={s.id} className="border-t border-white/10 pt-8">
+            <h2 className="text-2xl font-bold text-white mb-3">{s.heading}</h2>
+            <Markdown source={s.body} className="deck-prose deck-prose--read text-gray-300" />
+          </div>
+        ))}
+      </section>
+    </div>
+  )
+}

--- a/frontend/src/pages/present/components/Deck.tsx
+++ b/frontend/src/pages/present/components/Deck.tsx
@@ -1,0 +1,154 @@
+import { useEffect, useState } from 'react'
+import { ChevronLeft, ChevronRight, X, Maximize2, Printer } from 'lucide-react'
+import type { Slide as SlideData } from '../content'
+import { Slide } from './Slide'
+import { usePresentNav } from '../usePresentNav'
+import { cn } from '../../../lib/cn'
+
+export interface DeckProps {
+  slides: SlideData[]
+  /** Zero-based starting slide. */
+  initialIndex?: number
+  /** Track label, shown in the deck chrome. */
+  title?: string
+  onClose: () => void
+  /** Notified on every index change so the route can sync ?slide. */
+  onIndexChange?: (index: number) => void
+  /** Print the full handout (all slides). */
+  onPrint?: () => void
+}
+
+/**
+ * Full-screen presenter overlay. A fixed CSS overlay (not the Fullscreen API)
+ * so it works in every browser without a user-gesture requirement; a Maximize
+ * button offers true fullscreen on top. Keyboard nav via usePresentNav.
+ */
+export function Deck({
+  slides,
+  initialIndex = 0,
+  title,
+  onClose,
+  onIndexChange,
+  onPrint,
+}: DeckProps) {
+  const count = slides.length
+  const clampedInitial = Math.min(Math.max(initialIndex, 0), count - 1)
+  const [index, setIndex] = useState(clampedInitial)
+
+  const goTo = (i: number) => {
+    const next = Math.min(Math.max(i, 0), count - 1)
+    setIndex(next)
+    onIndexChange?.(next)
+  }
+
+  usePresentNav({ count, index, onIndex: goTo, onClose })
+
+  // Lock body scroll while the overlay is open; restore + exit fullscreen on close.
+  useEffect(() => {
+    const prev = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    return () => {
+      document.body.style.overflow = prev
+      if (document.fullscreenElement) document.exitFullscreen?.().catch(() => {})
+    }
+  }, [])
+
+  const requestFullscreen = () => {
+    try {
+      if (document.fullscreenElement) document.exitFullscreen?.()
+      else document.documentElement.requestFullscreen?.()
+    } catch {
+      /* fullscreen is best-effort; the CSS overlay already fills the screen */
+    }
+  }
+
+  const slide = slides[index]
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={title ? `${title} — presentation` : 'Presentation'}
+      className="no-print fixed inset-0 z-[100] flex flex-col bg-[#0a0a0a] text-white"
+    >
+      {/* Top chrome */}
+      <div className="no-print flex items-center justify-between px-4 sm:px-6 py-3 border-b border-white/10">
+        <div className="flex items-center gap-3 text-sm">
+          <span className="font-bold text-white">Vandalizer</span>
+          {title && <span className="text-[#f1b300]">{title}</span>}
+        </div>
+        <div className="flex items-center gap-1">
+          {onPrint && (
+            <button
+              onClick={onPrint}
+              aria-label="Print handout"
+              className="p-2 rounded-md text-gray-400 hover:text-white hover:bg-white/10 transition-colors"
+            >
+              <Printer className="w-4 h-4" />
+            </button>
+          )}
+          <button
+            onClick={requestFullscreen}
+            aria-label="Toggle fullscreen"
+            className="p-2 rounded-md text-gray-400 hover:text-white hover:bg-white/10 transition-colors"
+          >
+            <Maximize2 className="w-4 h-4" />
+          </button>
+          <button
+            onClick={onClose}
+            aria-label="Exit presentation"
+            className="p-2 rounded-md text-gray-400 hover:text-white hover:bg-white/10 transition-colors"
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+      </div>
+
+      {/* Slide stage */}
+      <div className="relative flex-1 min-h-0 flex items-center justify-center px-6 sm:px-16 py-8 overflow-y-auto">
+        {/* Prev / next click zones (chevrons) */}
+        <button
+          onClick={() => goTo(index - 1)}
+          disabled={index === 0}
+          aria-label="Previous slide"
+          className="no-print absolute left-2 sm:left-4 top-1/2 -translate-y-1/2 p-2 rounded-full text-gray-500 hover:text-white hover:bg-white/10 disabled:opacity-20 disabled:hover:bg-transparent transition-colors"
+        >
+          <ChevronLeft className="w-7 h-7" />
+        </button>
+        <Slide slide={slide} />
+        <button
+          onClick={() => goTo(index + 1)}
+          disabled={index === count - 1}
+          aria-label="Next slide"
+          className="no-print absolute right-2 sm:right-4 top-1/2 -translate-y-1/2 p-2 rounded-full text-gray-500 hover:text-white hover:bg-white/10 disabled:opacity-20 disabled:hover:bg-transparent transition-colors"
+        >
+          <ChevronRight className="w-7 h-7" />
+        </button>
+      </div>
+
+      {/* Bottom chrome: dots + counter + hint */}
+      <div className="no-print flex items-center justify-between px-4 sm:px-6 py-3 border-t border-white/10">
+        <div className="flex items-center gap-1.5">
+          {slides.map((s, i) => (
+            <button
+              key={s.id}
+              onClick={() => goTo(i)}
+              aria-label={`Go to slide ${i + 1}`}
+              aria-current={i === index}
+              className={cn(
+                'h-2 rounded-full transition-all',
+                i === index ? 'w-6 bg-[#f1b300]' : 'w-2 bg-white/20 hover:bg-white/40',
+              )}
+            />
+          ))}
+        </div>
+        <div className="flex items-center gap-4 text-xs text-gray-500">
+          <span className="hidden sm:inline">← → to navigate · Esc to exit</span>
+          <span className="tabular-nums text-gray-400">
+            {index + 1} / {count}
+          </span>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/present/components/ElevatorPitchCard.tsx
+++ b/frontend/src/pages/present/components/ElevatorPitchCard.tsx
@@ -1,0 +1,95 @@
+import { useState } from 'react'
+import { Copy, Check, Mic, Mail } from 'lucide-react'
+import { useToast } from '../../../contexts/ToastContext'
+import type { ElevatorPitch } from '../content'
+import { cn } from '../../../lib/cn'
+
+interface ElevatorPitchCardProps {
+  pitch: ElevatorPitch
+  /** Optionally emphasize one variant (from ?pitch=spoken|written). */
+  highlight?: 'spoken' | 'written'
+}
+
+function CopyablePitch({
+  icon: Icon,
+  kind,
+  caption,
+  text,
+  highlighted,
+}: {
+  icon: typeof Mic
+  kind: string
+  caption: string
+  text: string
+  highlighted?: boolean
+}) {
+  const { toast } = useToast()
+  const [copied, setCopied] = useState(false)
+
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(text)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+      toast(`${kind} pitch copied — paste it anywhere.`, 'success')
+    } catch {
+      toast('Could not copy to clipboard.', 'error')
+    }
+  }
+
+  return (
+    <div
+      className={cn(
+        'rounded-xl border p-5 sm:p-6 transition-colors',
+        highlighted
+          ? 'border-[#f1b300]/40 bg-[#f1b300]/[0.07]'
+          : 'border-white/10 bg-white/[0.03]',
+      )}
+    >
+      <div className="flex items-center justify-between mb-3">
+        <div className="flex items-center gap-2 text-sm font-semibold text-white">
+          <Icon className="w-4 h-4 text-[#f1b300]" />
+          {kind}
+          <span className="font-normal text-gray-500">· {caption}</span>
+        </div>
+        <button
+          onClick={copy}
+          className="inline-flex items-center gap-1.5 rounded-lg border border-white/15 px-3 py-1.5 text-xs font-medium text-gray-300 hover:bg-white/10 hover:text-white transition-colors"
+        >
+          {copied ? (
+            <>
+              <Check className="w-3.5 h-3.5 text-green-400" /> Copied
+            </>
+          ) : (
+            <>
+              <Copy className="w-3.5 h-3.5" /> Copy
+            </>
+          )}
+        </button>
+      </div>
+      <p className="text-gray-200 leading-relaxed">{text}</p>
+    </div>
+  )
+}
+
+/** Two copy-ready elevator pitches: a spoken (~30s) and a written paragraph. */
+export function ElevatorPitchCard({ pitch, highlight }: ElevatorPitchCardProps) {
+  return (
+    <div className="grid gap-4 md:grid-cols-2">
+      <CopyablePitch
+        icon={Mic}
+        kind="Spoken"
+        caption="~30 seconds, read aloud"
+        text={pitch.spoken}
+        highlighted={highlight === 'spoken'}
+      />
+      <CopyablePitch
+        icon={Mail}
+        kind="Written"
+        caption="one paragraph, for email"
+        text={pitch.written}
+        highlighted={highlight === 'written'}
+      />
+    </div>
+  )
+}

--- a/frontend/src/pages/present/components/PresentShell.tsx
+++ b/frontend/src/pages/present/components/PresentShell.tsx
@@ -1,0 +1,82 @@
+import type { ReactNode } from 'react'
+import { Link } from '@tanstack/react-router'
+import { ArrowLeft, ExternalLink } from 'lucide-react'
+import { Footer } from '../../../components/layout/Footer'
+import { PresentSidebar } from './PresentSidebar'
+import type { AudienceId } from '../content'
+
+interface PresentShellProps {
+  children: ReactNode
+  /** Highlight the active track in the sidebar. Omit on the hub. */
+  activeAudience?: AudienceId
+  /** Hub hides the sidebar (it has its own picker). */
+  showSidebar?: boolean
+}
+
+/**
+ * Dark, Docs-styled chrome for the Present & Pitch surface: same fixed top nav,
+ * background, and Footer as /docs, so it reads as part of Docs while being its
+ * own routed section. Public — no auth.
+ */
+export function PresentShell({ children, activeAudience, showSidebar = true }: PresentShellProps) {
+  return (
+    <div className="landing-page bg-[#0a0a0a] text-gray-200 antialiased w-full min-h-screen">
+      {/* Fixed top nav — mirrors Docs.tsx */}
+      <nav className="no-print fixed top-0 inset-x-0 z-50 bg-[#0a0a0a]/80 backdrop-blur-md border-b border-white/10">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex items-center justify-between h-16">
+          <div className="flex items-center gap-6">
+            <Link
+              to="/landing"
+              search={{ error: undefined, invite_token: undefined, admin: undefined, next: undefined }}
+              className="text-xl font-bold text-white hover:text-[#f1b300] transition-colors"
+            >
+              Vandalizer
+            </Link>
+            <span className="text-sm text-[#f1b300] font-medium">Present &amp; Pitch</span>
+          </div>
+          <div className="flex items-center gap-4">
+            <Link
+              to="/docs"
+              className="inline-flex items-center gap-1.5 text-sm text-gray-400 hover:text-[#f1b300] transition-colors"
+            >
+              <ArrowLeft className="w-4 h-4" />
+              Docs
+            </Link>
+            <a
+              href="https://github.com/ui-insight/vandalizer"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="hidden sm:inline-flex items-center gap-1.5 text-sm text-gray-400 hover:text-[#f1b300] transition-colors"
+            >
+              <ExternalLink className="w-4 h-4" />
+              GitHub
+            </a>
+          </div>
+        </div>
+      </nav>
+
+      <div className="pt-16 flex max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        {showSidebar && (
+          <aside className="no-print hidden lg:block w-64 shrink-0 pr-8">
+            <div className="sticky top-24">
+              <PresentSidebar activeAudience={activeAudience} />
+            </div>
+          </aside>
+        )}
+        <main className="flex-1 min-w-0 py-10">
+          {/* Sidebar collapses inline above content on small screens */}
+          {showSidebar && (
+            <div className="no-print lg:hidden mb-8">
+              <PresentSidebar activeAudience={activeAudience} />
+            </div>
+          )}
+          {children}
+        </main>
+      </div>
+
+      <div className="no-print">
+        <Footer />
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/present/components/PresentSidebar.tsx
+++ b/frontend/src/pages/present/components/PresentSidebar.tsx
@@ -1,0 +1,56 @@
+import { Link } from '@tanstack/react-router'
+import { Presentation } from 'lucide-react'
+import { TRACK_ORDER, TRACKS, type AudienceId } from '../content'
+import { cn } from '../../../lib/cn'
+
+interface PresentSidebarProps {
+  /** Highlight the current track when rendered inside the Present page. */
+  activeAudience?: AudienceId
+  /** Called after a link is clicked (e.g. to close the Docs mobile drawer). */
+  onNavigate?: () => void
+}
+
+/**
+ * The distinct "Present & Pitch" block. Rendered at the top of the Docs sidebar
+ * (so it reads as its own section within Docs) and reused as the Present page's
+ * own TOC. Links navigate to the real /docs/present routes.
+ */
+export function PresentSidebar({ activeAudience, onNavigate }: PresentSidebarProps) {
+  return (
+    <div className="rounded-lg border border-[#f1b300]/30 bg-[#f1b300]/[0.06] p-3">
+      <Link
+        to="/docs/present"
+        onClick={onNavigate}
+        className="flex items-center gap-2 mb-2 text-[#f1b300] hover:opacity-80 transition-opacity"
+      >
+        <Presentation className="w-4 h-4 shrink-0" />
+        <span className="text-xs font-bold uppercase tracking-wider">Present &amp; Pitch</span>
+      </Link>
+      <nav className="space-y-0.5">
+        {TRACK_ORDER.map((id) => {
+          const track = TRACKS[id]
+          const Icon = track.icon
+          const active = activeAudience === id
+          return (
+            <Link
+              key={id}
+              to="/docs/present/$audience"
+              params={{ audience: id }}
+              search={{ mode: undefined, slide: undefined, pitch: undefined }}
+              onClick={onNavigate}
+              className={cn(
+                'flex items-center gap-2.5 px-2.5 py-1.5 rounded-md text-sm transition-colors',
+                active
+                  ? 'bg-[#f1b300]/15 text-[#f1b300]'
+                  : 'text-gray-300 hover:text-white hover:bg-white/5',
+              )}
+            >
+              <Icon className="w-4 h-4 shrink-0" />
+              {track.label}
+            </Link>
+          )
+        })}
+      </nav>
+    </div>
+  )
+}

--- a/frontend/src/pages/present/components/PrintHandout.tsx
+++ b/frontend/src/pages/present/components/PrintHandout.tsx
@@ -1,0 +1,28 @@
+import type { Slide as SlideData } from '../content'
+import { Slide } from './Slide'
+
+/**
+ * Hidden on screen (`print:block`), shown only when printing. Stacks every
+ * slide one-per-page so Cmd/Ctrl-P always emits the full handout regardless of
+ * which deck slide is showing. The @media print rules in index.css handle the
+ * page breaks and force an ink-friendly light background.
+ */
+export function PrintHandout({
+  slides,
+  title,
+}: {
+  slides: SlideData[]
+  title: string
+}) {
+  return (
+    <div className="print-handout hidden print:block">
+      <h1 className="text-3xl font-bold text-black mb-2">Vandalizer</h1>
+      <p className="text-lg text-gray-700 mb-8">{title}</p>
+      {slides.map((slide) => (
+        <section key={slide.id} className="print-slide">
+          <Slide slide={slide} variant="print" />
+        </section>
+      ))}
+    </div>
+  )
+}

--- a/frontend/src/pages/present/components/Slide.tsx
+++ b/frontend/src/pages/present/components/Slide.tsx
@@ -1,0 +1,46 @@
+import type { Slide as SlideData } from '../content'
+import { Markdown } from '../markdown'
+import { cn } from '../../../lib/cn'
+
+interface SlideProps {
+  slide: SlideData
+  /** Compact rendering for the print handout (smaller type, dark-on-light). */
+  variant?: 'deck' | 'print'
+}
+
+/**
+ * Renders one slide's content. Shared by the presenter Deck and the print
+ * handout so the two can never drift. Markdown body is rendered through the
+ * sanitized pipeline; the `.deck-prose` class (index.css) sizes headings,
+ * lists, tables and code for a projector.
+ */
+export function Slide({ slide, variant = 'deck' }: SlideProps) {
+  const isPrint = variant === 'print'
+  return (
+    <div className={cn('w-full', isPrint ? 'max-w-3xl' : 'max-w-4xl mx-auto')}>
+      <h2
+        className={cn(
+          'font-bold tracking-tight',
+          isPrint ? 'text-2xl text-black mb-4' : 'text-3xl sm:text-5xl text-white mb-8',
+        )}
+      >
+        {slide.title}
+      </h2>
+      <Markdown
+        source={slide.body}
+        className={cn('deck-prose', isPrint ? 'deck-prose--print' : 'text-gray-200')}
+      />
+      {slide.note && (
+        <p
+          className={cn(
+            'no-print mt-8 text-sm italic',
+            isPrint ? 'hidden' : 'text-gray-500',
+          )}
+        >
+          <span className="font-semibold not-italic text-gray-400">Note: </span>
+          {slide.note}
+        </p>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/present/content.ts
+++ b/frontend/src/pages/present/content.ts
@@ -1,0 +1,573 @@
+/**
+ * Present & Pitch — single source of truth.
+ *
+ * Every claim below maps to a feature that is REACHABLE IN THE UI today. When you
+ * edit this file, keep it honest — if a capability isn't exposed to a real user,
+ * it doesn't belong here. Quick "claim → where it lives" map for reviewers:
+ *
+ *   Structured extraction ........ Workflows editor + extraction tasks   (/workflows, Docs "User Guide")
+ *   Workflow DAG engine .......... Workflow editor, batch runs           (/workflows/$id)
+ *   RAG chat with citations ...... Workspace chat mode                   (/?mode=chat)
+ *   Knowledge bases .............. Workspace knowledge mode              (/?mode=knowledge)
+ *   Automations (triggers) ....... Workspace automations mode + /automation
+ *   Teams / RBAC ................. /teams, TeamMembership roles
+ *   Reviews / sign-off ........... /reviews
+ *   Certification ................ Certification panel (Vandal Workflow Architect)
+ *   Admin / SystemConfig ......... /admin (models, OCR, auth, branding)
+ *   Self-hosting / deploy ........ setup.sh, compose.yaml, DEPLOY.md
+ *
+ * Deliberately NOT claimed (not user-reachable): the browser-automation Chrome
+ * extension (UI integration paused) and a live M365 inbox UI (intake is
+ * admin-configured, event-driven — no real-time inbox screen).
+ */
+import {
+  Landmark,
+  Server,
+  Users,
+  GraduationCap,
+  type LucideIcon,
+} from 'lucide-react'
+
+export type AudienceId = 'leadership' | 'deploy' | 'team' | 'researchers'
+
+export interface ElevatorPitch {
+  /** ~30 seconds, conversational — meant to be read aloud. */
+  spoken: string
+  /** One tight paragraph for an email or a proposal. */
+  written: string
+}
+
+export interface Slide {
+  id: string
+  title: string
+  /** Markdown — rendered identically in the deck and the printable handout. */
+  body: string
+  /** Optional presenter note: shown small in the deck, hidden in print/read. */
+  note?: string
+}
+
+export interface ReadSection {
+  id: string
+  heading: string
+  /** Markdown. */
+  body: string
+}
+
+export interface Track {
+  id: AudienceId
+  /** Short nav label, e.g. "For Leadership". */
+  label: string
+  /** One line under the label. */
+  tagline: string
+  icon: LucideIcon
+  /** 3–5 skimmable bullets for the hub card and the top of the read page. */
+  valueProps: string[]
+  pitch: ElevatorPitch
+  /** Ordered deck. */
+  slides: Slide[]
+  /** Long-form read-mode content. */
+  sections: ReadSection[]
+}
+
+// ---------------------------------------------------------------------------
+// Leadership
+// ---------------------------------------------------------------------------
+
+const leadership: Track = {
+  id: 'leadership',
+  label: 'For Leadership',
+  tagline: 'What you need to know to say yes',
+  icon: Landmark,
+  valueProps: [
+    'Self-hosted — your documents never leave your infrastructure',
+    'Open source (GPL v3) — no per-seat license fee, no vendor lock-in',
+    'Works with any AI provider: cloud or fully on-premise / air-gapped',
+    'Built at the University of Idaho under NSF GRANTED (Award #2427549)',
+    'Runs on a single commodity server — no GPU required with a cloud model',
+  ],
+  pitch: {
+    spoken:
+      "Vandalizer is an open-source AI platform we can run on our own servers to read the mountain of PDFs that flow through research administration — proposals, award letters, sponsor terms — and pull out the dates, budgets, and requirements automatically. Because it's self-hosted, our documents never leave our infrastructure, and it works with whatever AI provider we choose, cloud or on-premise. It was built at the University of Idaho with NSF GRANTED funding, it's free to license, and it runs on a single commodity server. The ask is simple: let us stand up a pilot and measure the hours it gives back to staff.",
+    written:
+      'Vandalizer is an open-source, self-hosted AI document-intelligence platform built for research administration. It extracts structured data from the proposals, awards, and compliance documents our staff process by hand today, lets them ask questions of those documents and get answers cited back to the source, and automates the repetitive routing in between. Because it runs on our own infrastructure with the AI provider of our choice, sensitive data never leaves the institution and there is no vendor lock-in or per-seat license fee. Developed at the University of Idaho under the NSF GRANTED program (Award #2427549) and released under GPL v3, it runs on a single commodity server and is designed for other institutions to adopt.',
+  },
+  slides: [
+    {
+      id: 'title',
+      title: 'Vandalizer',
+      body: 'AI document intelligence for research administration.\n\n*Self-hosted · open source · built by a university, for universities.*',
+      note: 'Open with the problem your office actually feels — the next slide.',
+    },
+    {
+      id: 'problem',
+      title: 'The problem we already have',
+      body: [
+        '- Hundreds of PDFs per funding cycle — read and re-keyed **by hand**',
+        '- Deadlines, budgets, and sponsor requirements buried in long documents',
+        '- Institutional knowledge walks out the door when staff leave',
+        '- Every missed requirement is a compliance and funding risk',
+      ].join('\n'),
+    },
+    {
+      id: 'what',
+      title: 'What Vandalizer does',
+      body: [
+        '- **Extract** — pull dates, budgets, requirements into clean structured data',
+        '- **Chat** — ask questions of your documents, answers cited to the source',
+        '- **Automate** — process new files the moment they arrive',
+        '- **Collaborate** — shared, repeatable workflows across the team',
+      ].join('\n'),
+    },
+    {
+      id: 'safe',
+      title: 'Why it is safe to say yes',
+      body: [
+        '- **Self-hosted** — runs on our servers; data stays on our infrastructure',
+        '- **Your choice of AI** — cloud provider, or a local model fully air-gapped',
+        '- **Open source, GPL v3** — auditable, forkable, no black box',
+        '- **No vendor lock-in** and **no per-seat license fee**',
+      ].join('\n'),
+    },
+    {
+      id: 'cost',
+      title: 'What it costs',
+      body: [
+        '- **Software:** free — open source, no license fee',
+        '- **Hardware:** a single commodity server (~16 GB RAM); **no GPU** with a cloud model',
+        '- **AI usage:** pay-as-you-go to your chosen LLM provider, or $0 with a local model',
+        '- **People:** IT stands it up with a guided installer in an afternoon',
+      ].join('\n'),
+    },
+    {
+      id: 'governance',
+      title: 'Governance & control',
+      body: [
+        '- Role-based access across teams and organizations',
+        '- Review & sign-off steps built into workflows',
+        '- Immutable audit log of administrative actions',
+        '- Configurable data-retention policy',
+      ].join('\n'),
+    },
+    {
+      id: 'credibility',
+      title: 'Where it comes from',
+      body: [
+        'Built at the **University of Idaho** under the **NSF GRANTED** program',
+        '(Award #2427549) — purpose-built for research administration and',
+        'designed from day one for **other institutions to adopt**.',
+      ].join('\n'),
+    },
+    {
+      id: 'ask',
+      title: 'The ask',
+      body: [
+        '1. Approve a **time-boxed pilot** in one office',
+        '2. We measure **hours saved** and **error reduction** on real documents',
+        '3. Decide on a wider rollout from evidence, not a sales deck',
+        '',
+        'Try the live demo: **/demo**',
+      ].join('\n'),
+      note: 'Close by naming the office and the documents you would pilot with.',
+    },
+  ],
+  sections: [
+    {
+      id: 'problem',
+      heading: 'The problem this solves',
+      body: 'Research administration runs on documents — grant proposals, award letters, sponsor terms, regulatory filings. Today, staff read and re-key hundreds of these PDFs by hand every funding cycle. Deadlines and requirements are buried in long documents, work is inconsistent between people, and institutional knowledge leaves when staff do. Vandalizer turns that manual burden into repeatable, audited, AI-assisted workflows.',
+    },
+    {
+      id: 'value',
+      heading: 'Why it is safe to adopt',
+      body: 'Vandalizer is **self-hosted**: it runs on your own servers and your documents never leave your infrastructure. You choose the AI provider — a cloud model, or a local model running fully air-gapped on premise. It is **open source under GPL v3**, so there is no black box, no vendor lock-in, and no per-seat license fee. Governance is built in: role-based access, review and sign-off steps, an immutable audit log, and configurable data retention.',
+    },
+    {
+      id: 'cost',
+      heading: 'What it costs',
+      body: 'The software is free. The hardware is a single commodity server (around 16 GB of RAM) — **no GPU is required** when you point it at a cloud LLM. AI usage is pay-as-you-go to your chosen provider, or zero with a local model. A guided installer (`setup.sh`) stands the whole system up, including an admin account and a starter catalog of templates.',
+    },
+    {
+      id: 'provenance',
+      heading: 'Provenance',
+      body: 'Vandalizer was built at the University of Idaho under the **NSF GRANTED program (Award #2427549)**. It was designed specifically for research administration and intended for other institutions to adopt and extend.',
+    },
+    {
+      id: 'next',
+      heading: 'How to evaluate it',
+      body: 'Start with the live **demo** to see it on real-looking documents. Stand up a **time-boxed pilot** in a single office and measure hours saved and error reduction. Staff can become fluent through the built-in **certification** course (Vandal Workflow Architect). Decide on wider rollout from the evidence.',
+    },
+  ],
+}
+
+// ---------------------------------------------------------------------------
+// Deploy / IT
+// ---------------------------------------------------------------------------
+
+const deploy: Track = {
+  id: 'deploy',
+  label: 'For IT & Deployment',
+  tagline: 'Architecture, requirements, and your options',
+  icon: Server,
+  valueProps: [
+    'Docker Compose stack: FastAPI, Celery, MongoDB, Redis, ChromaDB, nginx',
+    'Guided setup.sh installer — admin account and starter catalog included',
+    '~16 GB RAM on one server; no GPU required with a cloud LLM',
+    'LLM endpoints and keys configured at runtime in the admin UI',
+    'Self-hosted with encrypted secrets; on-prem / air-gapped option',
+  ],
+  pitch: {
+    spoken:
+      "Vandalizer ships as a set of Docker containers — a FastAPI backend, Celery workers, MongoDB, Redis, and a ChromaDB vector store behind nginx. A guided setup script stands the whole thing up, including an admin account and a starter catalog. It needs about sixteen gigs of RAM on a single server, and no GPU as long as you point it at a cloud model. If you want everything on-premise you can run a local model through Ollama or vLLM, even fully air-gapped. LLM endpoints and keys are configured at runtime in the admin UI, and secrets are encrypted at rest.",
+    written:
+      'Vandalizer deploys as a Docker Compose stack — a FastAPI backend, Celery workers, MongoDB (application data), Redis (task broker), and a ChromaDB vector store, served behind nginx. A guided `setup.sh` installer provisions the system, an admin account, and a starter catalog; a manual compose path exists for scripted environments. It runs on a single commodity server (~16 GB RAM) with no GPU required when using a cloud LLM, or fully on-premise/air-gapped with a local model via Ollama or vLLM. LLM providers, OCR endpoints, and auth methods are configured at runtime in the admin UI, and secrets (API keys, tokens) are encrypted at rest.',
+  },
+  slides: [
+    {
+      id: 'title',
+      title: 'Deploying Vandalizer',
+      body: 'What you will run, what you will need, and your options.',
+    },
+    {
+      id: 'architecture',
+      title: 'Architecture',
+      body: [
+        '```',
+        '          Browser (React SPA)',
+        '                 │',
+        '              nginx  (reverse proxy + static)',
+        '                 │',
+        '          FastAPI backend  (:8001)',
+        '          ┌──────┼───────┬──────────┐',
+        '       MongoDB  Redis  ChromaDB   Celery workers',
+        '       (data)  (queue) (vectors)  (async jobs)',
+        '                 │',
+        '          External APIs: LLM provider · M365/Graph · OCR',
+        '```',
+      ].join('\n'),
+      note: 'Redis is ephemeral (broker); Mongo, uploads and Chroma are the stateful volumes.',
+    },
+    {
+      id: 'requirements',
+      title: 'What you will need',
+      body: [
+        '| Size | CPU | RAM | Storage |',
+        '| --- | --- | --- | --- |',
+        '| Evaluation | 4 cores | 8–10 GB | 50 GB |',
+        '| Department | 8 cores | 16 GB | 100 GB+ |',
+        '',
+        '**No GPU required** when using a cloud LLM. Docker & Docker Compose only.',
+      ].join('\n'),
+    },
+    {
+      id: 'llm',
+      title: 'LLM options',
+      body: [
+        '- **Cloud:** any OpenAI-compatible endpoint, plus native Anthropic',
+        '- **Local / on-prem:** Ollama or vLLM — can run fully air-gapped',
+        '- **Aggregators:** OpenRouter and custom endpoints',
+        '- Configured **at runtime** in the admin UI — no redeploy to change models',
+      ].join('\n'),
+    },
+    {
+      id: 'install',
+      title: 'How you install it',
+      body: [
+        '- **Supported path:** `./setup.sh` — guided installer; creates an admin',
+        '  account and seeds a starter catalog of templates',
+        '- **Scripted path:** Docker Compose directly (`compose.yaml`)',
+        '- Full guidance in **DEPLOY.md**',
+      ].join('\n'),
+    },
+    {
+      id: 'security',
+      title: 'Security & data residency',
+      body: [
+        '- Self-hosted — documents and vectors stay on your infrastructure',
+        '- Secrets (LLM keys, OAuth tokens) **encrypted at rest** (Fernet)',
+        '- JWT sessions; OAuth (Azure AD, Google, Okta) and SAML supported',
+        '- Optional M365 / Graph integration — off unless you configure it',
+      ].join('\n'),
+    },
+    {
+      id: 'ops',
+      title: 'Day-2 operations',
+      body: [
+        '- **Back up:** MongoDB data, the uploads volume, and the ChromaDB volume',
+        '- Redis is an ephemeral broker — nothing to back up',
+        '- Immutable audit log for administrative actions',
+        '- Models, OCR endpoints, auth, and branding all managed from **/admin**',
+      ].join('\n'),
+    },
+    {
+      id: 'cta',
+      title: 'Get started',
+      body: 'Clone the repo, run `./setup.sh`, and read **DEPLOY.md** for production guidance.\n\nFull technical docs: **/docs**',
+    },
+  ],
+  sections: [
+    {
+      id: 'architecture',
+      heading: 'Architecture',
+      body: 'A React single-page app is served behind nginx, which proxies a FastAPI backend. The backend uses MongoDB for application data, Redis as the Celery task broker, and ChromaDB as the vector store for retrieval-augmented chat. Celery workers handle asynchronous jobs — document processing, extraction, and knowledge-base ingestion. External services are reached over HTTPS: your chosen LLM provider, optional Microsoft 365 / Graph, and an optional OCR endpoint.',
+    },
+    {
+      id: 'requirements',
+      heading: 'System requirements',
+      body: 'For evaluation: 4 cores, 8–10 GB RAM, 50 GB storage — a laptop or small VM. For a department: 8 cores, 16 GB RAM, 100 GB+ storage. **No GPU is required** when using a cloud LLM; a GPU is only needed if you choose to run a large model locally. The only host prerequisites are Docker and Docker Compose.',
+    },
+    {
+      id: 'llm',
+      heading: 'LLM options',
+      body: 'Vandalizer talks to any OpenAI-compatible endpoint and to Anthropic natively. For on-premise or air-gapped deployments, run a local model through **Ollama** or **vLLM**. OpenRouter and custom endpoints are also supported. Models, keys, and endpoints are configured **at runtime in the admin UI** — you can add or switch providers without a redeploy.',
+    },
+    {
+      id: 'install',
+      heading: 'Deployment options',
+      body: 'The supported path is the guided installer: `./setup.sh` provisions the full stack, creates an admin account, and seeds a starter catalog. For scripted or CI environments, drive Docker Compose (`compose.yaml`) directly. **DEPLOY.md** covers production hardening, TLS, and backups.',
+    },
+    {
+      id: 'security',
+      heading: 'Security & data residency',
+      body: 'Everything runs on your infrastructure, so documents and their vector embeddings never leave the institution. Secrets — LLM API keys and OAuth tokens — are encrypted at rest with a Fernet key. Sessions use JWTs; sign-in supports OAuth (Azure AD, Google, Okta) and SAML. The Microsoft 365 / Graph integration is optional and inert unless an administrator configures it. A fully air-gapped deployment is possible by pairing a local LLM with a local OCR endpoint.',
+    },
+    {
+      id: 'ops',
+      heading: 'Day-2 operations',
+      body: 'Back up three things: the MongoDB data volume, the uploads volume, and the ChromaDB volume. Redis is an ephemeral broker and needs no backup. Administrators manage models, OCR endpoints, authentication methods, and branding from the **/admin** console, and every administrative action is recorded in an immutable audit log.',
+    },
+  ],
+}
+
+// ---------------------------------------------------------------------------
+// Team / end users
+// ---------------------------------------------------------------------------
+
+const team: Track = {
+  id: 'team',
+  label: 'For Your Team',
+  tagline: 'A quick walkthrough of what it does',
+  icon: Users,
+  valueProps: [
+    'Upload and organize documents into folders',
+    'Build an extraction workflow once, run it across a whole batch',
+    'Chat with your documents — answers cited back to the source',
+    'Automate processing so new files are handled on arrival',
+    'Learn it through the built-in certification course',
+  ],
+  pitch: {
+    spoken:
+      "Think of Vandalizer as a smart workspace for our documents. You drop in a stack of PDFs, and instead of reading each one, you build a workflow once that pulls out exactly the fields you care about — deadlines, budgets, PI names — and run it across the whole batch. You can chat with your documents and get answers cited back to the source, organize reference material into knowledge bases, and set up automations so new files get processed the moment they arrive. There's even a built-in certification course to get you fluent.",
+    written:
+      'Vandalizer is a shared workspace for the documents your team works with every day. Upload PDFs, then build an extraction workflow once that pulls out exactly the fields you care about and run it across an entire batch instead of reading each file by hand. Ask plain-language questions of your documents and get answers cited to the source, organize reference material into searchable knowledge bases, and set up automations so new files are processed the moment they arrive. A built-in certification course (Vandal Workflow Architect) gets the whole team fluent.',
+  },
+  slides: [
+    {
+      id: 'title',
+      title: 'A tour of Vandalizer',
+      body: 'A smart workspace for the documents you work with every day.',
+    },
+    {
+      id: 'upload',
+      title: '1 · Upload & organize',
+      body: [
+        '- Drag in PDFs, Word, Excel, and more',
+        '- Sort them into folders',
+        '- Search across everything you have uploaded',
+      ].join('\n'),
+    },
+    {
+      id: 'extract',
+      title: '2 · Build an extraction workflow',
+      body: [
+        '- Define the fields you want — deadlines, budgets, PI names, terms',
+        '- Chain steps together into a repeatable pipeline',
+        '- Test on one document, then **run it across a whole batch**',
+        '- Download results as JSON, CSV, or a ZIP',
+      ].join('\n'),
+    },
+    {
+      id: 'chat',
+      title: '3 · Chat with your documents',
+      body: [
+        '- Ask plain-language questions across a folder or knowledge base',
+        '- Every answer is **cited back to the source** document and page',
+        '- Attach files or URLs for extra context',
+      ].join('\n'),
+    },
+    {
+      id: 'knowledge',
+      title: '4 · Knowledge bases',
+      body: [
+        '- Collect documents, URLs, and notes into a reusable knowledge base',
+        '- Share it with your team or keep it personal',
+        '- It becomes searchable context for chat',
+      ].join('\n'),
+    },
+    {
+      id: 'automate',
+      title: '5 · Automations',
+      body: [
+        '- **Watch a folder** and run a workflow on every new upload',
+        '- Run on a **schedule**, or trigger via **API**',
+        '- Intake from **Microsoft 365** when configured',
+      ].join('\n'),
+    },
+    {
+      id: 'collaborate',
+      title: '6 · Work as a team',
+      body: [
+        '- Shared workflows, documents, and knowledge bases',
+        '- Roles: owner, admin, member',
+        '- **Review & sign-off** steps for work that needs approval',
+      ].join('\n'),
+    },
+    {
+      id: 'certify',
+      title: '7 · Get certified',
+      body: 'The built-in **Vandal Workflow Architect** course walks you from your first upload to building validated workflows — hands-on, inside the product.\n\nSign in and start: **/**',
+      note: 'Offer to run a live build of one real workflow with the team.',
+    },
+  ],
+  sections: [
+    {
+      id: 'upload',
+      heading: 'Upload & organize',
+      body: 'Drag in PDFs (plus Word, Excel, and HTML), sort them into folders, and search across everything. Vandalizer reads the text out of each file — including scanned PDFs when an OCR endpoint is configured — so it is ready to work with.',
+    },
+    {
+      id: 'extract',
+      heading: 'Extraction workflows',
+      body: 'This is the core. Instead of reading every document, you define the fields you care about once — deadlines, budgets, PI names, sponsor terms — and chain steps into a repeatable pipeline. Test it on a single document, validate it against expected answers, then run it across an entire batch and download the results as JSON, CSV, or a ZIP. Workflows can be exported and shared as templates.',
+    },
+    {
+      id: 'chat',
+      heading: 'Chat with citations',
+      body: 'Ask plain-language questions across a folder or a knowledge base and get answers cited back to the exact source document and page, so you can trust and verify them. Attach extra files or URLs to bring more context into the conversation.',
+    },
+    {
+      id: 'knowledge',
+      heading: 'Knowledge bases',
+      body: 'Collect documents, URLs, and notes into a reusable knowledge base that becomes searchable context for chat. Keep it personal or share it with your team; administrators can curate verified knowledge bases for everyone.',
+    },
+    {
+      id: 'automate',
+      heading: 'Automations',
+      body: 'Put the repetitive parts on autopilot. Watch a folder and run a workflow on every new upload, run on a schedule, trigger via API, or intake from Microsoft 365 when an administrator has configured it. Each automation keeps a log of what it processed.',
+    },
+    {
+      id: 'collaborate',
+      heading: 'Collaboration & certification',
+      body: 'Teams share workflows, documents, and knowledge bases with owner / admin / member roles. Work that needs approval can route through review and sign-off steps. New users get fluent through the built-in **Vandal Workflow Architect** certification — hands-on lessons and exercises right inside the product.',
+    },
+  ],
+}
+
+// ---------------------------------------------------------------------------
+// Researchers / PIs
+// ---------------------------------------------------------------------------
+
+const researchers: Track = {
+  id: 'researchers',
+  label: 'For Researchers & PIs',
+  tagline: 'What it means for your proposals',
+  icon: GraduationCap,
+  valueProps: [
+    'Faster turnaround on the documents your office processes for you',
+    'Deadlines and formatting requirements surfaced automatically',
+    'Ask plain-language questions of long solicitations — with citations',
+    'More consistent support across submissions',
+  ],
+  pitch: {
+    spoken:
+      "When you send a proposal through our office, Vandalizer helps us turn it around faster. It reads the solicitation and your documents to surface deadlines, formatting rules, and budget requirements automatically, so nothing slips through the cracks. You — or we — can ask plain-language questions of a long funding announcement and get answers with citations, instead of scrolling through eighty pages. It means quicker, more consistent support for your submissions.",
+    written:
+      "Vandalizer helps your research administration office turn your proposals around faster and more consistently. It reads solicitations and supporting documents to surface deadlines, formatting rules, and budget requirements automatically, and it lets anyone ask plain-language questions of a long funding announcement and get answers cited to the source rather than scrolling through dozens of pages. The result is quicker, more reliable support for your submissions — without your data leaving the institution.",
+  },
+  slides: [
+    {
+      id: 'title',
+      title: 'Vandalizer for your proposals',
+      body: 'How your research administration office uses AI to support you — faster.',
+    },
+    {
+      id: 'benefit',
+      title: 'Faster, more consistent turnaround',
+      body: [
+        '- Deadlines, formatting rules, and budget requirements surfaced **automatically**',
+        '- Nothing buried on page 60 slips through',
+        '- The same rigor applied to every submission',
+      ].join('\n'),
+    },
+    {
+      id: 'ask',
+      title: 'Ask the documents',
+      body: [
+        '- Pose a plain-language question to a long solicitation',
+        '- Get an answer **cited to the exact page**',
+        '- No more scrolling through eighty-page announcements',
+      ].join('\n'),
+    },
+    {
+      id: 'trust',
+      title: 'Your data stays put',
+      body: [
+        '- Runs on the institution’s own infrastructure',
+        '- Your proposals never leave our systems',
+        '- Open source and auditable',
+      ].join('\n'),
+    },
+    {
+      id: 'cta',
+      title: 'Talk to your research office',
+      body: 'Ask your sponsored-programs office how Vandalizer can support your next submission.',
+    },
+  ],
+  sections: [
+    {
+      id: 'benefit',
+      heading: 'What it means for you',
+      body: 'When your proposal goes through the research administration office, Vandalizer helps staff surface deadlines, formatting rules, and budget requirements automatically, so the easy-to-miss details on page 60 do not slip through. Every submission gets the same rigor, which means faster and more consistent support for you.',
+    },
+    {
+      id: 'ask',
+      heading: 'Ask the documents',
+      body: 'Long funding announcements are tedious to read end to end. Vandalizer lets staff (or you) ask plain-language questions of a solicitation and get answers cited back to the exact page — so the right requirement is found in seconds, with the receipts to prove it.',
+    },
+    {
+      id: 'trust',
+      heading: 'Your data stays put',
+      body: 'Vandalizer is self-hosted on the institution’s own infrastructure, so your proposals and documents never leave our systems. It is open source and auditable — no black box handling your work.',
+    },
+  ],
+}
+
+// ---------------------------------------------------------------------------
+
+export const TRACKS: Record<AudienceId, Track> = {
+  leadership,
+  deploy,
+  team,
+  researchers,
+}
+
+export const TRACK_ORDER: AudienceId[] = ['leadership', 'deploy', 'team', 'researchers']
+
+export function getTrack(id: string | undefined): Track | undefined {
+  if (!id) return undefined
+  return (TRACKS as Record<string, Track>)[id]
+}
+
+// Dev-time completeness guard — catches an audience added without full content.
+if (import.meta.env?.DEV) {
+  for (const id of TRACK_ORDER) {
+    const t = TRACKS[id]
+    console.assert(Boolean(t), `[present] missing track: ${id}`)
+    console.assert(t.slides.length > 0, `[present] ${id}: needs at least one slide`)
+    console.assert(t.sections.length > 0, `[present] ${id}: needs at least one section`)
+    console.assert(
+      t.pitch.spoken.trim().length > 0 && t.pitch.written.trim().length > 0,
+      `[present] ${id}: needs both a spoken and a written pitch`,
+    )
+    console.assert(t.valueProps.length > 0, `[present] ${id}: needs value props`)
+  }
+}

--- a/frontend/src/pages/present/markdown.tsx
+++ b/frontend/src/pages/present/markdown.tsx
@@ -1,0 +1,15 @@
+import { useMemo } from 'react'
+import DOMPurify from 'dompurify'
+import { marked } from 'marked'
+import { cn } from '../../lib/cn'
+
+/** Render trusted (authored) markdown to sanitized HTML. Same pipeline as ChatMessage. */
+export function renderMarkdown(md: string): string {
+  return DOMPurify.sanitize(marked.parse(md, { breaks: true, gfm: true }) as string)
+}
+
+/** Inline markdown block. `className` styles the wrapper; content is always sanitized. */
+export function Markdown({ source, className }: { source: string; className?: string }) {
+  const html = useMemo(() => renderMarkdown(source), [source])
+  return <div className={cn(className)} dangerouslySetInnerHTML={{ __html: html }} />
+}

--- a/frontend/src/pages/present/usePresentNav.ts
+++ b/frontend/src/pages/present/usePresentNav.ts
@@ -1,0 +1,49 @@
+import { useEffect } from 'react'
+
+/**
+ * Keyboard navigation for the presenter deck. Clamps to [0, count-1] and tears
+ * down its listener on unmount. Esc invokes onClose.
+ */
+export function usePresentNav({
+  count,
+  index,
+  onIndex,
+  onClose,
+}: {
+  count: number
+  index: number
+  onIndex: (i: number) => void
+  onClose: () => void
+}) {
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      switch (e.key) {
+        case 'ArrowRight':
+        case ' ':
+        case 'PageDown':
+          e.preventDefault()
+          onIndex(Math.min(count - 1, index + 1))
+          break
+        case 'ArrowLeft':
+        case 'PageUp':
+          e.preventDefault()
+          onIndex(Math.max(0, index - 1))
+          break
+        case 'Home':
+          e.preventDefault()
+          onIndex(0)
+          break
+        case 'End':
+          e.preventDefault()
+          onIndex(count - 1)
+          break
+        case 'Escape':
+          e.preventDefault()
+          onClose()
+          break
+      }
+    }
+    window.addEventListener('keydown', handler)
+    return () => window.removeEventListener('keydown', handler)
+  }, [count, index, onIndex, onClose])
+}

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -31,6 +31,7 @@ const Reviews = lazy(() => import('./pages/Reviews'))
 const ReviewDetail = lazy(() => import('./pages/ReviewDetail'))
 const Login = lazy(() => import('./pages/Login'))
 const ResetPassword = lazy(() => import('./pages/ResetPassword'))
+const Present = lazy(() => import('./pages/present/Present'))
 
 // Certification is now a dockable panel — this redirect opens it from old bookmarks
 function CertificationRedirect() {
@@ -255,6 +256,30 @@ const docsRoute = createRoute({
   component: Docs,
 })
 
+// Present & Pitch — public communications surface, lives under /docs
+const presentHubRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/docs/present',
+  component: Present,
+})
+
+const presentTrackRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/docs/present/$audience',
+  validateSearch: (search: Record<string, unknown>) => ({
+    mode: (search.mode === 'deck' ? 'deck' : undefined) as 'deck' | undefined,
+    slide: (typeof search.slide === 'number'
+      ? search.slide
+      : typeof search.slide === 'string' && search.slide.trim() !== ''
+        ? Number(search.slide) || undefined
+        : undefined),
+    pitch: (search.pitch === 'spoken' || search.pitch === 'written'
+      ? (search.pitch as 'spoken' | 'written')
+      : undefined),
+  }),
+  component: Present,
+})
+
 const demoRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/demo',
@@ -374,6 +399,8 @@ const routeTree = rootRoute.addChildren([
   verificationRoute,
   supportRoute,
   docsRoute,
+  presentHubRoute,
+  presentTrackRoute,
   certificationRoute,
   demoRoute,
   demoFeedbackRoute,


### PR DESCRIPTION
## Why

At the recent annual conference, attendees repeatedly asked for things the product has no home for: *"make a presentation I can pitch to my leadership,"* *"what's the architecture if I want to deploy,"* *"give my team a walkthrough,"* *"give me an elevator pitch."* These are **communications** needs — and there was no surface for them. Material had to be public (sendable to a provost with no account), reachable when logged in, and rooted in truth.

## What

A **Present & Pitch** surface under `/docs/present` — visually its own section, not washed into the developer docs.

**Four audience tracks** — Leadership, IT/Deployment, Team, Researchers/PIs — each in **three render modes** driven from one source-of-truth file (`content.ts`) so they can never disagree:

| Mode | What |
| --- | --- |
| **Read** | skimmable, printable page |
| **Present** | full-screen presenter deck — ←/→/Space/Home/End/Esc, progress dots, slide counter, deep-linkable per slide |
| **Pitch** | copyable ~30s **spoken** + one-paragraph **written** elevator pitches |

**Rooted in truth:** content authored only from UI-reachable features, with a `claim → source` map at the top of `content.ts` and a dev-time completeness guard. Honest about what's *not* there (e.g. paused browser-automation extension, config-only M365 intake).

**Print-to-PDF:** `Cmd/Ctrl-P` on any track emits a clean one-slide-per-page handout via an `@media print` stylesheet.

## Discoverability (public — no login)

- Distinct "Present & Pitch" block at the top of the **Docs sidebar** (desktop + mobile)
- **"Overview"** link in the **Landing** top nav (the value-first doorway for evaluators)
- **"Present & Pitch"** entry in the in-app user menu (logged-in)

## Notes

- **Zero new dependencies** — reuses `marked`+`DOMPurify`, `lucide-react`, the toast/clipboard pattern, `Footer`, `cn`.
- All routes public (no `ProtectedRoute`), matching `/docs`.

## Verification

- `npm run typecheck` ✅ · `npm run lint` ✅ · `npm run build` ✅
- `vitest` — 136/136 pass ✅
- New `Present` / `PresentSidebar` chunks code-split correctly.

Recommended manual pass before merge: deck keyboard nav, the print handout, and pitch copy buttons in a real browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)