### PR TITLE
Per-user activity history drill-down for auditing

### DIFF
--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -1,6 +1,7 @@
 """Admin API routes  - usage stats, leaderboards, system config management."""
 
 import datetime
+import logging
 import math
 import re
 from typing import Optional
@@ -14,12 +15,15 @@ from app.dependencies import get_current_user
 from app.models.activity import ActivityEvent
 from app.models.audit_log import AdminAuditLog
 from app.models.system_config import SystemConfig
+from app.services import audit_service
 from app.services.llm_service import clear_agent_caches, get_agent_model
 from app.services.version_service import get_update_status
 from app.utils.encryption import decrypt_value, encrypt_value
 from app.models.team import Team, TeamMembership
 from app.models.user import User
 from app.models.document import SmartDocument
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
@@ -1062,6 +1066,135 @@ async def user_detail(
         previous_period=previous_period,
         recent_workflows=recent_workflows,
     )
+
+
+# ---------------------------------------------------------------------------
+# 3d. GET /users/{user_id}/history  - Full per-user activity timeline
+# ---------------------------------------------------------------------------
+
+# Max rows pulled from each store before merging. A single user's audit +
+# activity rows within any reasonable window stay well under this; if either
+# store hits the cap we flag `capped` so the UI can prompt a narrower range
+# rather than silently dropping older events.
+HISTORY_FETCH_CAP = 1000
+
+
+class UserHistoryItem(BaseModel):
+    timestamp: Optional[datetime.datetime] = None
+    source: str  # "audit" | "activity"
+    action: str  # audit: e.g. "user.login"; activity: e.g. "workflow_run"
+    title: Optional[str] = None
+    resource_type: Optional[str] = None
+    resource_id: Optional[str] = None
+    status: Optional[str] = None  # activity status; None for audit rows
+    ip_address: Optional[str] = None
+    detail: dict = {}
+
+
+class UserHistoryResponse(BaseModel):
+    items: list[UserHistoryItem]
+    total: int
+    capped: bool
+
+
+@router.get("/users/{user_id}/history", response_model=UserHistoryResponse)
+async def user_history(
+    user_id: str,
+    days: int = Query(default=90, ge=1, le=MAX_ANALYTICS_DAYS),
+    skip: int = Query(default=0, ge=0),
+    limit: int = Query(default=50, ge=1, le=200),
+    user: User = Depends(get_current_user),
+):
+    """Full chronological activity history for a single user.
+
+    Merges the immutable audit trail (``AuditLog``, who-did-what) with feature
+    telemetry (``ActivityEvent``, conversations/searches/workflow runs) into one
+    reverse-chronological feed. Super-admin only, for leadership auditing.
+    """
+    await _require_superadmin(user)
+
+    target_user = await User.find_one(User.user_id == user_id)
+    if not target_user:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    cutoff = datetime.datetime.utcnow() - datetime.timedelta(days=days)
+
+    # Immutable audit trail (who-did-what), filtered to this actor.
+    audit_entries, _ = await audit_service.query_audit_log(
+        actor_user_id=user_id,
+        start_time=cutoff,
+        skip=0,
+        limit=HISTORY_FETCH_CAP,
+    )
+
+    # Feature telemetry for this user.
+    activity_events = (
+        await ActivityEvent.find(
+            {"user_id": user_id, "started_at": {"$gte": cutoff}}
+        )
+        .sort(-ActivityEvent.started_at)
+        .limit(HISTORY_FETCH_CAP)
+        .to_list()
+    )
+
+    capped = (
+        len(audit_entries) >= HISTORY_FETCH_CAP
+        or len(activity_events) >= HISTORY_FETCH_CAP
+    )
+    if capped:
+        logger.warning(
+            "user_history hit fetch cap for user_id=%s (audit=%d activity=%d, days=%d)",
+            user_id,
+            len(audit_entries),
+            len(activity_events),
+            days,
+        )
+
+    items: list[UserHistoryItem] = []
+    for e in audit_entries:
+        items.append(
+            UserHistoryItem(
+                timestamp=e.timestamp,
+                source="audit",
+                action=e.action,
+                title=e.resource_name,
+                resource_type=e.resource_type,
+                resource_id=e.resource_id,
+                status=None,
+                ip_address=e.ip_address,
+                detail=e.detail or {},
+            )
+        )
+    for ev in activity_events:
+        items.append(
+            UserHistoryItem(
+                timestamp=ev.started_at,
+                source="activity",
+                action=ev.type,
+                title=ev.title,
+                resource_type=ev.type,
+                resource_id=str(ev.id),
+                status=ev.status,
+                ip_address=None,
+                detail={
+                    "tokens_input": ev.tokens_input or 0,
+                    "tokens_output": ev.tokens_output or 0,
+                    "steps_completed": ev.steps_completed or 0,
+                    "steps_total": ev.steps_total or 0,
+                    "error": ev.error,
+                },
+            )
+        )
+
+    # Newest first; rows with no timestamp sort to the end.
+    items.sort(
+        key=lambda r: r.timestamp or datetime.datetime.min,
+        reverse=True,
+    )
+    total = len(items)
+    page = items[skip : skip + limit]
+
+    return UserHistoryResponse(items=page, total=total, capped=capped)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/routers/audit.py
+++ b/backend/app/routers/audit.py
@@ -81,12 +81,17 @@ async def query_audit_log(
 @router.get("/export")
 async def export_audit_log(
     action: Optional[str] = None,
+    actor_user_id: Optional[str] = None,
     resource_type: Optional[str] = None,
     start_time: Optional[str] = None,
     end_time: Optional[str] = None,
     user: User = Depends(get_current_user),
 ):
-    """Export audit log as CSV. Admin only."""
+    """Export audit log as CSV. Admin only.
+
+    Pass ``actor_user_id`` to scope the export to a single user's trail (used by
+    the per-user activity drill-down in the admin console).
+    """
     import csv
     import io
 
@@ -104,6 +109,7 @@ async def export_audit_log(
 
     entries, _ = await audit_service.query_audit_log(
         action=action,
+        actor_user_id=actor_user_id,
         resource_type=resource_type,
         start_time=parsed_start,
         end_time=parsed_end,

--- a/backend/tests/test_admin_routes.py
+++ b/backend/tests/test_admin_routes.py
@@ -1,5 +1,6 @@
 """Route tests for admin analytics scoping."""
 
+import datetime
 import secrets
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -394,3 +395,137 @@ class TestAdminAnalyticsScoping:
             "0123456789abcdef01234567",
             "team-uuid",
         ]
+
+
+class TestUserActivityHistory:
+    """The per-user audit drill-down (GET /users/{id}/history)."""
+
+    @staticmethod
+    def _activity_query_mock(events):
+        find = MagicMock()
+        find.sort.return_value.limit.return_value.to_list = AsyncMock(return_value=events)
+        return find
+
+    @pytest.mark.asyncio
+    async def test_staff_without_admin_rejected(self, client):
+        """Super-admin only: is_staff (require_admin elsewhere) must get 403."""
+        user = _make_user("staffer", is_admin=False)
+        user.is_staff = True
+        cookies, headers = _auth("staffer")
+
+        with (
+            patch("app.dependencies.decode_token", return_value={"sub": "staffer", "type": "access"}),
+            patch("app.dependencies.User") as MockUser,
+        ):
+            MockUser.find_one = AsyncMock(return_value=user)
+            resp = await client.get("/api/admin/users/member-1/history", cookies=cookies, headers=headers)
+
+        assert resp.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_merges_and_sorts_newest_first(self, client):
+        admin = _make_user("admin", is_admin=True)
+        cookies, headers = _auth("admin")
+
+        t1 = datetime.datetime(2026, 1, 1, 9, 0, 0)   # oldest  (activity)
+        t2 = datetime.datetime(2026, 1, 1, 10, 0, 0)  # middle  (audit)
+        t3 = datetime.datetime(2026, 1, 1, 11, 0, 0)  # newest  (activity)
+
+        audit_entry = SimpleNamespace(
+            timestamp=t2, action="user.login", resource_name=None,
+            resource_type="user", resource_id="member-1",
+            ip_address="10.0.0.1", detail={"method": "password"},
+        )
+        older_activity = SimpleNamespace(
+            started_at=t1, type="conversation", title="Chat A", status="completed",
+            id="act-1", tokens_input=1, tokens_output=2, steps_completed=0, steps_total=0, error=None,
+        )
+        newer_activity = SimpleNamespace(
+            started_at=t3, type="workflow_run", title="WF B", status="failed",
+            id="act-2", tokens_input=3, tokens_output=4, steps_completed=1, steps_total=2, error="boom",
+        )
+
+        with (
+            patch("app.dependencies.decode_token", return_value={"sub": "admin", "type": "access"}),
+            patch("app.dependencies.User") as MockUser,
+            patch("app.routers.admin.User") as MockRouteUser,
+            patch("app.routers.admin.audit_service") as MockAudit,
+            patch("app.routers.admin.ActivityEvent") as MockActivity,
+        ):
+            MockUser.find_one = AsyncMock(return_value=admin)
+            MockRouteUser.find_one = AsyncMock(
+                return_value=SimpleNamespace(user_id="member-1", name="Member One", email="m1@example.com")
+            )
+            MockAudit.query_audit_log = AsyncMock(return_value=([audit_entry], 1))
+            MockActivity.find.return_value = self._activity_query_mock([newer_activity, older_activity])
+
+            resp = await client.get("/api/admin/users/member-1/history", cookies=cookies, headers=headers)
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] == 3
+        assert data["capped"] is False
+        # Newest-first across both sources.
+        assert [it["source"] for it in data["items"]] == ["activity", "audit", "activity"]
+        assert data["items"][0]["action"] == "workflow_run"
+        assert data["items"][0]["status"] == "failed"
+        assert data["items"][1]["action"] == "user.login"
+        assert data["items"][1]["ip_address"] == "10.0.0.1"
+        # The audit query was scoped to the target user.
+        assert MockAudit.query_audit_log.call_args.kwargs["actor_user_id"] == "member-1"
+
+    @pytest.mark.asyncio
+    async def test_pagination_slices_merged_feed(self, client):
+        admin = _make_user("admin", is_admin=True)
+        cookies, headers = _auth("admin")
+
+        events = [
+            SimpleNamespace(
+                started_at=datetime.datetime(2026, 1, 1, h, 0, 0), type="conversation",
+                title=f"Chat {h}", status="completed", id=f"act-{h}",
+                tokens_input=0, tokens_output=0, steps_completed=0, steps_total=0, error=None,
+            )
+            for h in range(5)
+        ]
+
+        with (
+            patch("app.dependencies.decode_token", return_value={"sub": "admin", "type": "access"}),
+            patch("app.dependencies.User") as MockUser,
+            patch("app.routers.admin.User") as MockRouteUser,
+            patch("app.routers.admin.audit_service") as MockAudit,
+            patch("app.routers.admin.ActivityEvent") as MockActivity,
+        ):
+            MockUser.find_one = AsyncMock(return_value=admin)
+            MockRouteUser.find_one = AsyncMock(
+                return_value=SimpleNamespace(user_id="member-1", name="M", email="m@example.com")
+            )
+            MockAudit.query_audit_log = AsyncMock(return_value=([], 0))
+            MockActivity.find.return_value = self._activity_query_mock(events)
+
+            resp = await client.get(
+                "/api/admin/users/member-1/history?skip=2&limit=2", cookies=cookies, headers=headers
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] == 5
+        assert len(data["items"]) == 2
+        # Newest-first => hours 4,3,2,1,0; skip=2,limit=2 => hours 2 then 1.
+        assert data["items"][0]["title"] == "Chat 2"
+        assert data["items"][1]["title"] == "Chat 1"
+
+    @pytest.mark.asyncio
+    async def test_missing_user_returns_404(self, client):
+        admin = _make_user("admin", is_admin=True)
+        cookies, headers = _auth("admin")
+
+        with (
+            patch("app.dependencies.decode_token", return_value={"sub": "admin", "type": "access"}),
+            patch("app.dependencies.User") as MockUser,
+            patch("app.routers.admin.User") as MockRouteUser,
+        ):
+            MockUser.find_one = AsyncMock(return_value=admin)
+            MockRouteUser.find_one = AsyncMock(return_value=None)
+            resp = await client.get("/api/admin/users/ghost/history", cookies=cookies, headers=headers)
+
+        assert resp.status_code == 404

--- a/frontend/src/api/admin.ts
+++ b/frontend/src/api/admin.ts
@@ -154,6 +154,32 @@ export function getUserDetail(userId: string, days: number = 30) {
   return apiFetch<UserDetailResponse>(`/api/admin/users/${encodeURIComponent(userId)}/detail?days=${days}`)
 }
 
+// User Activity History (combined audit trail + activity telemetry)
+
+export interface UserHistoryItem {
+  timestamp: string | null
+  source: 'audit' | 'activity'
+  action: string
+  title: string | null
+  resource_type: string | null
+  resource_id: string | null
+  status: string | null
+  ip_address: string | null
+  detail: Record<string, unknown>
+}
+
+export interface UserHistoryResponse {
+  items: UserHistoryItem[]
+  total: number
+  capped: boolean
+}
+
+export function getUserHistory(userId: string, days: number = 90, skip: number = 0, limit: number = 50) {
+  return apiFetch<UserHistoryResponse>(
+    `/api/admin/users/${encodeURIComponent(userId)}/history?days=${days}&skip=${skip}&limit=${limit}`,
+  )
+}
+
 // Workflows
 
 export interface WorkflowEventItem {

--- a/frontend/src/api/audit.ts
+++ b/frontend/src/api/audit.ts
@@ -42,6 +42,7 @@ export function queryAuditLog(params: {
 
 export function exportAuditLog(params?: {
   action?: string
+  actor_user_id?: string
   resource_type?: string
   start_time?: string
   end_time?: string

--- a/frontend/src/pages/Admin.tsx
+++ b/frontend/src/pages/Admin.tsx
@@ -22,7 +22,7 @@ import type { ThemeConfig } from '../api/config'
 import { useBranding, DEFAULT_ORG_NAME } from '../contexts/BrandingContext'
 import {
   getUsageStats, getUsageTimeseries, getUserLeaderboard, getTeamLeaderboard,
-  getTeamDetail, getUserDetail,
+  getTeamDetail, getUserDetail, getUserHistory,
   getWorkflowEvents, getSystemConfig, updateSystemConfig, updateCompliancePolicyConfig,
   addModel, updateModel, deleteModel, setDefaultModel, testOcr, testModel, testPrompt, probeModel, addOAuthProvider,
   updateOAuthProvider, deleteOAuthProvider, updateAuthMethods,
@@ -52,7 +52,7 @@ import { PRE_SURVEY_FIELDS } from './Demo'
 import { SurveyFieldRenderer } from '../components/survey/SurveyFieldRenderer'
 import type {
   UsageStats, TimeseriesResponse, UserLeaderboardItem, TeamLeaderboardItem,
-  TeamDetailResponse, UserDetailResponse,
+  TeamDetailResponse, UserDetailResponse, UserHistoryItem,
   PaginatedWorkflows, SystemConfigData,
   QualitySummary, QualityTimelinePoint, RegressionResult,
   QualityAlert, QualityItem, QualityItemDetail,
@@ -741,6 +741,152 @@ function UserDrillDown({ userId, onBack }: { userId: string; onBack: () => void 
             </tbody>
           </table>
         </div>
+      )}
+
+      {/* Full activity history (audit trail + activity telemetry) */}
+      <UserActivityHistory userId={userId} email={data.email} />
+    </div>
+  )
+}
+
+const HISTORY_PAGE_SIZE = 50
+
+function SourceBadge({ source }: { source: 'audit' | 'activity' }) {
+  const c = source === 'audit'
+    ? { bg: '#e2e8f0', text: '#334155', label: 'Audit' }
+    : { bg: '#dbeafe', text: '#1e40af', label: 'Activity' }
+  return (
+    <span style={{
+      display: 'inline-block', padding: '1px 8px', borderRadius: 9999,
+      fontSize: 10, fontWeight: 700, backgroundColor: c.bg, color: c.text,
+      textTransform: 'uppercase', letterSpacing: 0.5,
+    }}>
+      {c.label}
+    </span>
+  )
+}
+
+function UserActivityHistory({ userId, email }: { userId: string; email: string | null }) {
+  const [items, setItems] = useState<UserHistoryItem[]>([])
+  const [total, setTotal] = useState(0)
+  const [capped, setCapped] = useState(false)
+  const [days, setDays] = useState(90)
+  const [loading, setLoading] = useState(true)
+  const [loadingMore, setLoadingMore] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  // Reload from scratch whenever the time range changes.
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+    setError(null)
+    getUserHistory(userId, days, 0, HISTORY_PAGE_SIZE)
+      .then(res => {
+        if (cancelled) return
+        setItems(res.items)
+        setTotal(res.total)
+        setCapped(res.capped)
+      })
+      .catch(e => { if (!cancelled) setError(e?.message || 'Failed to load history') })
+      .finally(() => { if (!cancelled) setLoading(false) })
+    return () => { cancelled = true }
+  }, [userId, days])
+
+  const loadMore = useCallback(() => {
+    setLoadingMore(true)
+    getUserHistory(userId, days, items.length, HISTORY_PAGE_SIZE)
+      .then(res => {
+        setItems(prev => [...prev, ...res.items])
+        setTotal(res.total)
+        setCapped(res.capped)
+      })
+      .catch(e => setError(e?.message || 'Failed to load history'))
+      .finally(() => setLoadingMore(false))
+  }, [userId, days, items.length])
+
+  const startTime = useMemo(
+    () => new Date(Date.now() - days * 86400000).toISOString(),
+    [days],
+  )
+
+  return (
+    <div style={{ background: '#fff', border: '1px solid #e5e7eb', borderRadius: 'var(--ui-radius, 12px)', overflow: 'hidden' }}>
+      <div style={{ padding: '16px 20px', borderBottom: '1px solid #e5e7eb', display: 'flex', alignItems: 'center', gap: 12, flexWrap: 'wrap' }}>
+        <div style={{ fontSize: 15, fontWeight: 600 }}>Activity History</div>
+        <div style={{ flex: 1 }} />
+        <TimeRangeSelector value={days} onChange={v => setDays(typeof v === 'number' ? v : 90)} />
+        <a
+          href={auditApi.exportAuditLog({ actor_user_id: userId, start_time: startTime })}
+          style={{
+            display: 'inline-flex', alignItems: 'center', gap: 6,
+            padding: '6px 12px', borderRadius: 'var(--ui-radius, 12px)',
+            border: '1px solid #e5e7eb', background: '#fff', cursor: 'pointer',
+            fontSize: 13, fontWeight: 600, color: '#374151', textDecoration: 'none',
+          }}
+          title="Download this user's immutable audit trail as CSV"
+        >
+          <Download size={14} /> Export audit trail
+        </a>
+      </div>
+
+      {capped && (
+        <div style={{ padding: '10px 20px', background: '#fffbeb', borderBottom: '1px solid #fde68a', fontSize: 13, color: '#92400e', display: 'flex', alignItems: 'center', gap: 8 }}>
+          <AlertCircle size={14} /> Showing the most recent events only — narrow the time range to see older history.
+        </div>
+      )}
+
+      {loading ? (
+        <div style={{ padding: 32, textAlign: 'center', color: '#6b7280', fontSize: 14 }}>Loading activity history...</div>
+      ) : error ? (
+        <div style={{ padding: 32, textAlign: 'center', color: '#dc2626', fontSize: 14 }}>Error: {error}</div>
+      ) : items.length === 0 ? (
+        <div style={{ padding: 32, textAlign: 'center', color: '#6b7280', fontSize: 14 }}>No recorded activity in this period.</div>
+      ) : (
+        <>
+          <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+            <thead>
+              <tr style={{ background: '#f9fafb', borderBottom: '1px solid #e5e7eb' }}>
+                <th style={{ padding: '10px 16px', textAlign: 'left', fontSize: 11, fontWeight: 600, color: '#6b7280', textTransform: 'uppercase' }}>When</th>
+                <th style={{ padding: '10px 16px', textAlign: 'left', fontSize: 11, fontWeight: 600, color: '#6b7280', textTransform: 'uppercase' }}>Source</th>
+                <th style={{ padding: '10px 16px', textAlign: 'left', fontSize: 11, fontWeight: 600, color: '#6b7280', textTransform: 'uppercase' }}>Action</th>
+                <th style={{ padding: '10px 16px', textAlign: 'left', fontSize: 11, fontWeight: 600, color: '#6b7280', textTransform: 'uppercase' }}>Resource</th>
+                <th style={{ padding: '10px 16px', textAlign: 'left', fontSize: 11, fontWeight: 600, color: '#6b7280', textTransform: 'uppercase' }}>Status</th>
+                <th style={{ padding: '10px 16px', textAlign: 'left', fontSize: 11, fontWeight: 600, color: '#6b7280', textTransform: 'uppercase' }}>IP</th>
+              </tr>
+            </thead>
+            <tbody>
+              {items.map((it, i) => (
+                <tr key={`${it.source}-${it.resource_id ?? ''}-${it.timestamp ?? ''}-${i}`} style={{ borderBottom: '1px solid #f3f4f6' }}>
+                  <td style={{ padding: '10px 16px', fontSize: 13, color: '#6b7280', whiteSpace: 'nowrap' }}>{formatDateTime(it.timestamp)}</td>
+                  <td style={{ padding: '10px 16px' }}><SourceBadge source={it.source} /></td>
+                  <td style={{ padding: '10px 16px', fontSize: 13, fontFamily: 'ui-monospace, monospace' }}>{it.action}</td>
+                  <td style={{ padding: '10px 16px', fontSize: 13 }}>
+                    {it.title || (it.resource_type ? <span style={{ color: '#9ca3af' }}>{it.resource_type}</span> : '-')}
+                  </td>
+                  <td style={{ padding: '10px 16px' }}>{it.status ? <StatusBadge status={it.status} /> : <span style={{ color: '#d1d5db' }}>—</span>}</td>
+                  <td style={{ padding: '10px 16px', fontSize: 12, color: '#6b7280', fontFamily: 'ui-monospace, monospace' }}>{it.ip_address || '—'}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          <div style={{ padding: '12px 20px', display: 'flex', alignItems: 'center', gap: 12, borderTop: '1px solid #f3f4f6' }}>
+            <span style={{ fontSize: 12, color: '#9ca3af' }}>Showing {items.length} of {total}{email ? ` · ${email}` : ''}</span>
+            <div style={{ flex: 1 }} />
+            {items.length < total && (
+              <button
+                onClick={loadMore}
+                disabled={loadingMore}
+                style={{
+                  padding: '6px 14px', borderRadius: 'var(--ui-radius, 12px)',
+                  border: '1px solid #e5e7eb', background: '#fff',
+                  cursor: loadingMore ? 'wait' : 'pointer', fontSize: 13, fontWeight: 600, color: '#374151',
+                }}
+              >
+                {loadingMore ? 'Loading...' : 'Load more'}
+              </button>
+            )}
+          </div>
+        </>
       )}
     </div>
   )


### PR DESCRIPTION
## Why

Leadership asked for the ability to **drill down into a single user's entire activity history for auditing**. Today the admin Users tab shows aggregate KPIs and the last 20 workflows, but there's no way to see the full chronological trail of what a user *did*. The two relevant stores were siloed:

- **`AuditLog`** — append-only, immutable: logins, document ops, org changes, workflow approvals (who-did-what)
- **`ActivityEvent`** — feature telemetry: conversations, searches, workflow runs with status/tokens

This merges them into one reverse-chronological **Activity History** feed per user, **embedded in the existing user drill-down** and gated to **super-admins only**.

## What changed

**Backend**
- `GET /api/admin/users/{user_id}/history` — super-admin gated (`_require_superadmin`). Fetches both stores filtered to the user, normalizes into a common `UserHistoryItem`, sorts newest-first, paginates (`skip`/`limit`/`days`). Caps each source at 1000 rows and returns `capped: true` (+ a `logger.warning`) when hit — no silent truncation. Reuses the existing `audit_service.query_audit_log(actor_user_id=...)`.
- `GET /api/audit/export` now honors `actor_user_id` (previously ignored — a real gap) so the per-user audit trail exports as CSV.

**Frontend**
- New `UserActivityHistory` component in the Users drill-down: timeline table (When / Source badge / Action / Resource / Status / IP), time-range selector, **Load more** pagination, capped notice, and an **Export audit trail** download link.
- `getUserHistory()` client + types; `exportAuditLog()` takes `actor_user_id`.

**Tests**
- 4 new admin-route tests: staff-without-admin → 403, merge/sort newest-first across both sources, pagination slicing, 404 for missing user.

## Verification
- `pytest tests/test_admin_routes.py` → 14 passed (incl. 4 new); `test_audit_routes.py` + `test_audit_service.py` → 7 passed
- Frontend `tsc --noEmit`, `eslint` (changed files), `ruff`, `npm run build` → all clean

Live check: Admin → Users → click a user → scroll to **Activity History**. Re-logging-in produces a `user.login` audit row and running a workflow produces an activity row, so the two sources interleave by time. Export downloads a CSV scoped to that one user.

## Note on scope
"Entire history" is only as complete as what's instrumented. The audit log currently has ~20 action types (comprehensive for logins/documents/orgs/workflow-approvals). Auditing additional actions (e.g. chat sends, file downloads) is a follow-up of adding `audit_service.log_event(...)` calls at those sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
