### PR TITLE
Handle fetch rejections in on-mount effects

### DIFF
--- a/frontend/src/components/support/SupportChatPanel.tsx
+++ b/frontend/src/components/support/SupportChatPanel.tsx
@@ -460,7 +460,7 @@ function ChatView({
     supportApi.markTicketRead(ticketUuid).catch(() => {})
     import('../../api/notifications').then(({ markReadForItem }) => {
       markReadForItem('support_ticket', ticketUuid).catch(() => {})
-    })
+    }).catch(() => {})
     const interval = setInterval(loadTicket, 15000)
     return () => clearInterval(interval)
   }, [loadTicket, ticketUuid])

--- a/frontend/src/components/workspace/WorkflowEditorPanel.tsx
+++ b/frontend/src/components/workspace/WorkflowEditorPanel.tsx
@@ -1991,7 +1991,7 @@ function TaskEditModal({ task, selectedDocUuids, workflow, workflowId, onClose, 
       getTeamMembers(teamUuid)
         .then(list => { if (!cancelled) setApprovalTeamMembers(list) })
         .catch(() => { if (!cancelled) setApprovalTeamMembers([]) })
-    )
+    ).catch(() => { if (!cancelled) setApprovalTeamMembers([]) })
     return () => { cancelled = true }
   }, [task.name, user?.current_team_uuid])
 

--- a/frontend/src/contexts/WorkspaceContext.tsx
+++ b/frontend/src/contexts/WorkspaceContext.tsx
@@ -344,6 +344,13 @@ export function WorkspaceProvider({ children }: { children: ReactNode }) {
             replace: true,
           })
         })
+    }).catch(() => {
+      // Chunk load failure for the lazy import — don't leak an unhandled
+      // rejection; clear the param so the URL doesn't keep retrying.
+      navigate({
+        search: (prev) => ({ ...emptyWorkspaceSearch(), ...prev, kb: undefined }),
+        replace: true,
+      })
     })
   }, [search.kb, navigate])
 

--- a/frontend/src/hooks/useQualitySparkline.ts
+++ b/frontend/src/hooks/useQualitySparkline.ts
@@ -27,7 +27,9 @@ export function useQualitySparkline(kind: 'search_set' | 'workflow', itemId: str
           .then(r => setScores(r.scores))
           .catch(() => {})
           .finally(() => setLoading(false))
-      })
+        // If the lazy import itself fails, clear loading so we don't spin
+        // forever and don't leak an unhandled rejection.
+      }).catch(() => setLoading(false))
     }
   }, [kind, itemId, refreshKey])
 

--- a/frontend/src/pages/Admin.tsx
+++ b/frontend/src/pages/Admin.tsx
@@ -2473,7 +2473,7 @@ function ConfigTab() {
       setChatRetentionDays((rc.chat_retention_days as number) ?? 365)
       setWorkflowResultRetentionDays((rc.workflow_result_retention_days as number) ?? 365)
       setStaleActivityMinutes((rc.activity_stale_threshold_minutes as number) ?? 30)
-    }).finally(() => setLoading(false))
+    }).catch(() => {}).finally(() => setLoading(false))
 
     getThemeConfig().then(t => {
       setThemeColor(t.highlight_color)
@@ -6629,7 +6629,7 @@ export default function Admin() {
   const [trialEnabled, setTrialEnabled] = useState(false)
 
   useEffect(() => {
-    getAuthConfig().then(c => setTrialEnabled(!!c.trial_system_enabled))
+    getAuthConfig().then(c => setTrialEnabled(!!c.trial_system_enabled)).catch(() => {})
   }, [])
 
   const isGlobalAdmin = !!user?.is_admin

--- a/frontend/src/pages/Landing.tsx
+++ b/frontend/src/pages/Landing.tsx
@@ -281,7 +281,14 @@ export default function Landing() {
   const nextPath = safeNextPath(search?.next)
 
   useEffect(() => {
-    getAuthConfig().then(setAuthConfig)
+    // A network-level fetch failure (Safari reports these as "Load failed")
+    // rejects the promise; without a .catch() it surfaces as an unhandled
+    // rejection in Sentry and leaves AuthBlock spinning forever. Fall back to
+    // the same default getAuthConfig() uses for non-OK responses so the
+    // password form still renders.
+    getAuthConfig()
+      .then(setAuthConfig)
+      .catch(() => setAuthConfig({ auth_methods: ['password'], oauth_providers: [] }))
   }, [])
 
   useEffect(() => {


### PR DESCRIPTION
## Problem

Sentry issue **7519478729** (`TypeError: Load failed`, Safari, `/landing`) is an unhandled promise rejection. Safari reports a network-level `fetch()` failure (connection drop, DNS hiccup, request aborted by tab backgrounding) as `"Load failed"`. On-mount `useEffect` hooks that call API helpers via `.then()` with **no `.catch()`** let that rejection escape to `window.onunhandledrejection` → Sentry.

The `/landing` case had a second, user-visible symptom: `AuthBlock` renders a spinner whenever its config is `null`, so a failed `getAuthConfig()` left the sign-in form spinning indefinitely.

## Fix

Added rejection handling at every on-mount fetch site found by auditing `frontend/src` for the pattern:

| File | Site | Behavior on failure |
|------|------|--------------------|
| `pages/Landing.tsx` | `getAuthConfig()` | Falls back to the default auth config so the password form renders |
| `pages/Admin.tsx` | `getSystemConfig()` | Swallow; loading still clears via `finally` |
| `pages/Admin.tsx` | `getAuthConfig()` | Swallow (trial flag stays false) |
| `hooks/useQualitySparkline.ts` | lazy `import('../api/client')` | Clears loading so the sparkline doesn't spin forever |
| `contexts/WorkspaceContext.tsx` | lazy `import('../api/knowledge')` | Clears the `kb` URL param |
| `components/workspace/WorkflowEditorPanel.tsx` | lazy `import('../../api/teams')` | Empties the assignee list |
| `components/support/SupportChatPanel.tsx` | lazy `import('../../api/notifications')` | No-op |

The dynamic-`import()` sites already handled their *inner* promise but left the import chain itself unguarded; this adds the outer `.catch()`.

## Testing

- `npx tsc --noEmit` — clean
- ESLint on changed files — clean (one pre-existing unrelated `exhaustive-deps` warning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)