### PR TITLE
Fix production FD-exhaustion: per-call LLM/Redis client leaks + graceful frontend failures

### DIFF
--- a/backend/app/services/credentials_service.py
+++ b/backend/app/services/credentials_service.py
@@ -118,9 +118,21 @@ def metadata_view(credential_doc: dict) -> dict:
 # OAuth client_credentials JWT-assertion flow
 # ---------------------------------------------------------------------------
 
+# Process-wide sync Redis client, created once and reused. A new redis.Redis()
+# per call opens a fresh connection pool whose sockets are never reclaimed
+# (callers here don't close it), leaking file descriptors until the process hits
+# [Errno 24] Too many open files — get_bearer_token() runs on every credentialed
+# workflow API call. redis.Redis is thread-safe and pools internally, so a
+# singleton is both correct and what avoids the leak.
+_redis_singleton: "redis.Redis | None" = None
+
+
 def _redis_client() -> redis.Redis:
-    redis_host = os.environ.get("redis_host", "localhost")
-    return redis.Redis(host=redis_host, port=6379, db=0, decode_responses=True)
+    global _redis_singleton
+    if _redis_singleton is None:
+        redis_host = os.environ.get("redis_host", "localhost")
+        _redis_singleton = redis.Redis(host=redis_host, port=6379, db=0, decode_responses=True)
+    return _redis_singleton
 
 
 def _build_client_assertion(payload: dict) -> str:

--- a/backend/app/services/llm_service.py
+++ b/backend/app/services/llm_service.py
@@ -1,5 +1,7 @@
 """LLM service  - provider classes and agent creation, ported from agents.py."""
 
+import asyncio
+import weakref
 from dataclasses import dataclass
 from typing import Optional
 
@@ -32,6 +34,53 @@ def clear_agent_caches():
     _extraction_agent_cache.clear()
     _rag_agent_cache.clear()
     _prompt_agent_cache.clear()
+
+
+# ---------------------------------------------------------------------------
+# Per-event-loop HTTP client
+# ---------------------------------------------------------------------------
+# One shared httpx.AsyncClient per event loop, reused across every LLM call on
+# that loop. Why per-loop instead of per-call or process-wide:
+#   * pydantic-ai's process-wide `cached_async_http_client` is shared across ALL
+#     loops. The workflow MultiTaskNode runs each task via run_sync() on its own
+#     ThreadPoolExecutor thread (each thread gets its own event loop), so reusing
+#     one client's connection pool across loops raises "bound to a different
+#     event loop", which the OpenAI SDK re-wraps as a zero-token "Connection
+#     error" (#455).
+#   * The first fix for #455 built a fresh client on EVERY call. But run_sync
+#     reuses one long-lived loop per worker thread, so those per-call clients —
+#     never closed — piled their connection pools + sockets onto that live loop
+#     until the process hit `[Errno 24] Too many open files` (prod incident
+#     2026-06-03, Sentry 7517108223; the AutoReconnect surfaced on the healthy
+#     Mongo singleton, the victim, not the cause).
+# Caching one client per loop gives both properties: never shared across loops
+# (event-loop safe) and bounded to the small number of live loops. The
+# WeakKeyDictionary drops a loop's entry once the loop is garbage-collected
+# (e.g. when a workflow's ThreadPoolExecutor thread exits), letting its client —
+# and the file descriptors it holds — be reclaimed.
+_loop_http_clients: "weakref.WeakKeyDictionary[asyncio.AbstractEventLoop, httpx.AsyncClient]" = (
+    weakref.WeakKeyDictionary()
+)
+
+
+def _get_loop_http_client() -> httpx.AsyncClient:
+    """Return the httpx.AsyncClient bound to the current event loop, creating it
+    on first use. Reused across calls so we never leak a client per call."""
+    from app.config import Settings
+
+    read_timeout = max(30, Settings().workflow_llm_timeout_seconds)
+    # Mirror pydantic-ai's own run_sync() loop resolution so we key off the exact
+    # loop the request will run on.
+    try:
+        loop = asyncio.get_event_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+    client = _loop_http_clients.get(loop)
+    if client is None or client.is_closed:
+        client = httpx.AsyncClient(timeout=httpx.Timeout(read_timeout, connect=10.0))
+        _loop_http_clients[loop] = client
+    return client
 
 
 # ---------------------------------------------------------------------------
@@ -287,7 +336,13 @@ def get_agent_model(
         from pydantic_ai.models.anthropic import AnthropicModel
         from pydantic_ai.providers.anthropic import AnthropicProvider
         model_name = agent_model.split("/", 1)[1] if agent_model.startswith("anthropic/") else agent_model
-        provider_kwargs: dict = {"api_key": api_key}
+        # Pass the per-loop httpx client so this provider doesn't fall back to
+        # pydantic-ai's process-wide cached_async_http_client. The cached client
+        # is shared across loops and breaks under the workflow ThreadPoolExecutor
+        # ("bound to a different event loop" -> zero-token Connection error, #455);
+        # the per-loop client is event-loop safe and reused, not leaked — see
+        # _get_loop_http_client above.
+        provider_kwargs: dict = {"api_key": api_key, "http_client": _get_loop_http_client()}
         if endpoint:
             provider_kwargs["base_url"] = endpoint
         return AnthropicModel(model_name=model_name, provider=AnthropicProvider(**provider_kwargs))
@@ -303,35 +358,47 @@ def get_agent_model(
         model_name = agent_model.split("/", 1)[1] if agent_model.startswith("openrouter/") else agent_model
         if endpoint:
             from openai import AsyncOpenAI
-            client = AsyncOpenAI(api_key=api_key, base_url=endpoint, timeout=120.0)
+            # Reuse the per-loop httpx client so we don't leak an SDK client (and
+            # its connection pool) per call — see _get_loop_http_client above.
+            client = AsyncOpenAI(
+                api_key=api_key, base_url=endpoint, timeout=120.0,
+                http_client=_get_loop_http_client(),
+            )
             provider = OpenRouterProvider(openai_client=client, app_title="Vandalizer")
         else:
-            provider = OpenRouterProvider(api_key=api_key, app_title="Vandalizer")
+            # Pass the per-loop httpx client so we don't fall back to the
+            # cross-loop-unsafe process-wide cache — see _get_loop_http_client.
+            provider = OpenRouterProvider(
+                api_key=api_key, app_title="Vandalizer",
+                http_client=_get_loop_http_client(),
+            )
         return OpenAIModel(model_name=model_name, provider=provider)
 
     # Handle external models with OpenAI protocol (use OpenAI SDK directly)
     if model_config and model_config.get("external", False) and api_protocol == "openai":
         model_name = agent_model.split("/")[-1] if "/" in agent_model else agent_model
         from openai import AsyncOpenAI
-        client_kwargs: dict = {"api_key": api_key, "timeout": 120.0}
+        # Reuse the per-loop httpx client so we don't leak an SDK client (and its
+        # connection pool) per call — see _get_loop_http_client above.
+        client_kwargs: dict = {
+            "api_key": api_key,
+            "timeout": 120.0,
+            "http_client": _get_loop_http_client(),
+        }
         if endpoint:
             client_kwargs["base_url"] = endpoint
         client = AsyncOpenAI(**client_kwargs)
         return OpenAIModel(model_name=model_name, openai_client=client)
 
-    # Build a dedicated httpx client per call instead of letting the provider
-    # fall back to pydantic-ai's process-wide cached_async_http_client. The
-    # cached client is shared across the workflow MultiTaskNode's
-    # ThreadPoolExecutor threads, each of which runs pydantic-ai's run_sync()
+    # Use the per-event-loop httpx client instead of pydantic-ai's process-wide
+    # cached_async_http_client. The cached client is shared across the workflow
+    # MultiTaskNode's ThreadPoolExecutor threads, each of which runs run_sync()
     # on its own event loop; reusing one client's connection pool across loops
     # raises "RuntimeError: bound to a different event loop", which the OpenAI
-    # SDK re-wraps as a zero-token "Connection error". A fresh client per call
-    # binds only to the loop that uses it.
-    from app.config import Settings
-    read_timeout = max(30, Settings().workflow_llm_timeout_seconds)
-    dedicated_client = httpx.AsyncClient(
-        timeout=httpx.Timeout(read_timeout, connect=10.0)
-    )
+    # SDK re-wraps as a zero-token "Connection error". The per-loop client binds
+    # only to the loop that uses it, and is reused (not rebuilt per call) so it
+    # doesn't leak file descriptors — see _get_loop_http_client above.
+    dedicated_client = _get_loop_http_client()
     if api_protocol == "ollama":
         provider = OllamaProvider(api_key=api_key, endpoint=endpoint, http_client=dedicated_client)
     elif api_protocol == "vllm":

--- a/backend/tests/test_credentials_service.py
+++ b/backend/tests/test_credentials_service.py
@@ -318,6 +318,30 @@ class TestExchangeToken:
 
 
 # ---------------------------------------------------------------------------
+# Redis client singleton
+# ---------------------------------------------------------------------------
+
+class TestRedisClientSingleton:
+    """_redis_client must reuse one process-wide client, never build one per
+    call. Regression guard for the file-descriptor leak (prod incident
+    2026-06-03): a new redis.Redis() per call opened connection pools that were
+    never closed, contributing to [Errno 24] Too many open files.
+    """
+
+    def test_reuses_single_client(self):
+        credentials_service._redis_singleton = None
+        try:
+            with patch("app.services.credentials_service.redis.Redis") as mock_redis:
+                mock_redis.side_effect = lambda *a, **k: object()
+                first = credentials_service._redis_client()
+                second = credentials_service._redis_client()
+                assert first is second, "must reuse the cached client, not rebuild it"
+                assert mock_redis.call_count == 1, "redis.Redis() must be constructed exactly once"
+        finally:
+            credentials_service._redis_singleton = None
+
+
+# ---------------------------------------------------------------------------
 # Bearer cache
 # ---------------------------------------------------------------------------
 

--- a/backend/tests/test_llm_service.py
+++ b/backend/tests/test_llm_service.py
@@ -1,5 +1,8 @@
 """Tests for app.services.llm_service — protocol detection."""
 
+import asyncio
+
+from app.services import llm_service
 from app.services.llm_service import (
     SUPPORTED_PROTOCOLS,
     detect_api_protocol,
@@ -66,3 +69,61 @@ class TestNameBasedDetection:
 def test_supported_protocols_contains_all_branches():
     """Guard against the enum drifting away from the routing branches."""
     assert set(SUPPORTED_PROTOCOLS) == {"openai", "anthropic", "openrouter", "ollama", "vllm"}
+
+
+class TestPerLoopHttpClient:
+    """The httpx client must be reused per event loop, never rebuilt per call.
+
+    Regression guard for the file-descriptor leak (prod incident 2026-06-03,
+    Sentry 7517108223): a fresh client per LLM call piled connection pools onto
+    each long-lived worker-thread loop until the process hit [Errno 24].
+    """
+
+    def test_same_loop_returns_same_client(self):
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        try:
+            first = llm_service._get_loop_http_client()
+            second = llm_service._get_loop_http_client()
+            assert first is second, "client must be reused within a loop, not rebuilt per call"
+            assert not first.is_closed
+        finally:
+            loop.run_until_complete(first.aclose())
+            loop.close()
+            asyncio.set_event_loop(None)
+
+    def test_distinct_loops_get_distinct_clients(self):
+        # Each event loop gets its own client — sharing one across loops is what
+        # caused pydantic-ai's "bound to a different event loop" error (#455).
+        loop_a = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop_a)
+        client_a = llm_service._get_loop_http_client()
+
+        loop_b = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop_b)
+        client_b = llm_service._get_loop_http_client()
+        try:
+            assert client_a is not client_b
+        finally:
+            loop_a.run_until_complete(client_a.aclose())
+            loop_b.run_until_complete(client_b.aclose())
+            loop_a.close()
+            loop_b.close()
+            asyncio.set_event_loop(None)
+
+    def test_dropped_loop_is_evicted_from_registry(self):
+        # When a loop is garbage-collected (e.g. a workflow worker thread exits),
+        # its entry must drop out of the WeakKeyDictionary so the client — and
+        # the file descriptors it holds — can be reclaimed.
+        import gc
+
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        client = llm_service._get_loop_http_client()
+        loop.run_until_complete(client.aclose())
+        loop.close()
+        asyncio.set_event_loop(None)
+        assert loop in llm_service._loop_http_clients
+        del loop, client
+        gc.collect()
+        assert len(llm_service._loop_http_clients) == 0

--- a/frontend/src/components/certification/CertificationPanel.tsx
+++ b/frontend/src/components/certification/CertificationPanel.tsx
@@ -221,7 +221,14 @@ export function CertificationPanel() {
 
   const handleValidate = async (moduleId: string) => {
     setValidating(true); setValidationResult(null)
-    try { setValidationResult(await validate(moduleId)) } finally { setValidating(false) }
+    // A bare try/finally re-throws on failure (e.g. a 5xx while the backend is
+    // restarting), escaping as a global "Request failed" unhandled rejection.
+    // Catch, notify, and keep the panel usable.
+    try {
+      setValidationResult(await validate(moduleId))
+    } catch {
+      toast('Could not validate the module right now. Please try again.', 'error')
+    } finally { setValidating(false) }
   }
 
   const handleComplete = async (moduleId: string) => {
@@ -242,12 +249,22 @@ export function CertificationPanel() {
       await provision(moduleId)
       // Invalidate document queries so the file browser shows the new files
       queryClient.invalidateQueries({ queryKey: ['documents'] })
+    } catch {
+      // Bare try/finally re-throws; catch so a failed provision doesn't escape
+      // as a global "Request failed" unhandled rejection.
+      toast('Could not set up the exercise right now. Please try again.', 'error')
     } finally { setProvisioning(false) }
   }
 
   const handleSubmitAssessment = async (moduleId: string, answers: Record<string, string>) => {
     setSubmittingAssessment(true)
-    try { await submitAssessment(moduleId, answers) } finally { setSubmittingAssessment(false) }
+    try {
+      await submitAssessment(moduleId, answers)
+    } catch {
+      // Bare try/finally re-throws; catch so a failed submit doesn't escape as a
+      // global "Request failed" unhandled rejection.
+      toast('Could not submit your answers right now. Please try again.', 'error')
+    } finally { setSubmittingAssessment(false) }
   }
 
   const handleModuleClick = (moduleId: string) => {

--- a/frontend/src/lib/sentry.ts
+++ b/frontend/src/lib/sentry.ts
@@ -26,6 +26,16 @@ export function initSentry() {
       // Surfaced as an ApiError; the auth/protected-route layer already
       // redirects to /landing, so an uncaught rejection here is just noise.
       'Not authenticated',
+      // Transient backend unavailability: apiFetch throws ApiError('Request
+      // failed') for any non-OK response with a non-JSON body (a 5xx / nginx
+      // gateway page during a backend restart or FD-exhaustion blip), and
+      // 'Request timed out' on a client-side timeout. These are infra events,
+      // not frontend bugs — the backend's own Sentry covers the outage, and
+      // any on-mount hook / fire-and-forget caller that misses a .catch()
+      // would otherwise spam this as a useless single-frame unhandled
+      // rejection. UI-facing callers still catch these to show a toast.
+      'Request failed',
+      'Request timed out',
       // pdf.js throws this when an in-flight page render is cancelled
       // (component unmount, doc close, zoom change). Normal behavior.
       'Rendering cancelled',

--- a/frontend/src/pages/Certification.tsx
+++ b/frontend/src/pages/Certification.tsx
@@ -984,6 +984,10 @@ export default function Certification() {
     try {
       const result = await validate(moduleId)
       setValidationResult(result)
+    } catch {
+      // A bare try/finally re-throws on failure (e.g. a 5xx while the backend is
+      // restarting), escaping as a global "Request failed" unhandled rejection.
+      toast('Could not validate the module right now. Please try again.', 'error')
     } finally {
       setValidating(false)
     }
@@ -1011,6 +1015,10 @@ export default function Certification() {
       await provision(moduleId)
       // Invalidate document queries so workspace shows the new files without a hard refresh
       queryClient.invalidateQueries({ queryKey: ['documents'] })
+    } catch {
+      // Bare try/finally re-throws; catch so a failed provision doesn't escape
+      // as a global "Request failed" unhandled rejection.
+      toast('Could not set up the exercise right now. Please try again.', 'error')
     } finally {
       setProvisioning(false)
     }
@@ -1020,6 +1028,10 @@ export default function Certification() {
     setSubmittingAssessment(true)
     try {
       await submitAssessment(moduleId, answers)
+    } catch {
+      // Bare try/finally re-throws; catch so a failed submit doesn't escape as a
+      // global "Request failed" unhandled rejection.
+      toast('Could not submit your answers right now. Please try again.', 'error')
     } finally {
       setSubmittingAssessment(false)
     }


### PR DESCRIPTION
## Summary

Production hit `[Errno 24] Too many open files` repeatedly on 2026-06-03, taking down backend workers throughout the day and cascading into frontend errors. This PR fixes the two backend file-descriptor leaks behind it and hardens the frontend to fail gracefully during backend blips.

The pymongo `AutoReconnect` / `ServerSelectionTimeoutError` crashes were **misleading** — the healthy Motor singleton was the *victim* of FD exhaustion, not the cause. The afternoon `/api/chat` trace caught the leak red-handed: the `OSError` fires *inside* `httpx.AsyncClient(...)` construction in `get_agent_model`.

## Root causes

### 1. `llm_service.get_agent_model` — a fresh `httpx.AsyncClient` per LLM call
Introduced by #455 to avoid pydantic-ai's process-wide `cached_async_http_client` (shared across event loops → "bound to a different event loop" → zero-token Connection error under the workflow `ThreadPoolExecutor`). But `run_sync` reuses **one long-lived event loop per worker thread**, so the per-call clients piled their connection pools + sockets onto that live loop and were never reclaimed — same effect on the async web/chat path's single loop.

**Fix:** a **per-event-loop cached client** (`_get_loop_http_client`, keyed by a `WeakKeyDictionary[loop -> AsyncClient]`):
- Never shared across loops → keeps the #455 fix.
- Bounded to the few live loops → no leak; the weak dict drops a loop's client when its worker-thread loop is GC'd.
- **All** provider branches now use it (anthropic, both OpenRouter branches, external OpenAI, ollama/vllm/insightai) — none fall back to the process-wide cache.

### 2. `credentials_service._redis_client` — a new sync `redis.Redis` per call
No caller closed it, and `get_bearer_token` runs on every credentialed workflow API call. **Fix:** a process-wide singleton (`redis.Redis` is thread-safe and pools internally).

### 3. Frontend — uncaught `ApiError` → global unhandled rejections
While the backend was down, on-mount hooks and async action handlers that don't catch surfaced `apiFetch`'s `ApiError("Request failed")` as `window.onunhandledrejection`. The Sentry fingerprint is just the minified `apiFetch` frame, so every such caller collapses into one recurring issue.
- `CertificationPanel` (app-wide → `transaction: /`) and the `Certification` page: `handleValidate`/`handleProvision`/`handleSubmitAssessment` used bare `try { await } finally {}` (which re-throws). Added `catch` + `toast`, matching the existing `handleComplete`.
- `sentry.ts`: extended the existing `ignoreErrors` list (already drops the expected `'Not authenticated'`) with `'Request failed'` / `'Request timed out'` as a backstop for the long tail of callers that can't all be hand-audited.

## Incident timeline (one continuous exhaustion event + afternoon recurrence)

| Time | Sentry | Endpoint | Surfaced as | Server |
|---|---|---|---|---|
| 9:24:40 | 7524578547 | `/api/automations/active` | ServerSelectionTimeout | 057af0… |
| 9:28:02 | 7524586758 | `/api/auth/refresh` | AutoReconnect | 057af0… |
| 9:30:51 | 7524274548 | `/api/automations` | AutoReconnect | 057af0… |
| 9:35:57 | 7517108223 | periodic monitor | AutoReconnect | 057af0… |
| 9:38 / 10:09 | 7519225656 / 7524644742 / 7524646653 | frontend `/` | unhandled rejection | — |
| 12:37:44 | 7525044420 | `/api/chat` | **OSError at httpx.AsyncClient in get_agent_model** | bbf6b8… |

The afternoon crash on a *different* server confirms the leak keeps crashing workers one at a time until the fix is deployed.

## Tests
- Backend: `TestPerLoopHttpClient` (reuse within a loop, distinct across loops, eviction on GC) + `TestRedisClientSingleton`. 45 passing, ruff clean.
- Frontend: `tsc` clean; per-call toasts added.

## Deploy note
⚠️ The deploy must **replace all running backend workers** — each leaked independently, so a partial rollout leaves leaking processes alive.

## Follow-up (not in this PR)
Wire up `@sentry/vite-plugin` source-map upload so minified frontend traces (`re`/`ie @ 519`) resolve to real source.