### PR TITLE
Full white-label branding: custom icon, landing logos, branded emails

### DIFF
--- a/backend/app/models/system_config.py
+++ b/backend/app/models/system_config.py
@@ -155,10 +155,13 @@ class SystemConfig(Document):
     ui_radius: str = "12px"
 
     # Branding — empty strings mean "use the built-in Vandalizer defaults".
-    # logo_data_url accepts a data: URL (base64-encoded image) so the logo can
-    # be served by the same public theme endpoint without separate storage.
+    # logo_data_url / icon_data_url accept a data: URL (base64-encoded image) so
+    # the brand assets can be served by the same public theme endpoint without
+    # separate storage. logo_data_url is the wordmark; icon_data_url is the small
+    # square mascot/icon shown beside it (replaces the default Joe Vandal mark).
     org_name: str = ""
     logo_data_url: str = ""
+    icon_data_url: str = ""
 
     # Authentication
     auth_methods: list[str] = ["password"]

--- a/backend/app/routers/config.py
+++ b/backend/app/routers/config.py
@@ -144,19 +144,19 @@ async def update_user_config(req: UpdateUserConfigRequest, user: User = Depends(
 _MAX_LOGO_DATA_URL_BYTES = 500_000  # ~375KB after base64 — plenty for a wordmark
 
 
-def _validate_logo_data_url(value: str) -> str:
+def _validate_image_data_url(value: str, field: str) -> str:
     value = (value or "").strip()
     if not value:
         return ""
     if not value.startswith("data:image/"):
         raise HTTPException(
             status_code=400,
-            detail="logo_data_url must be a data:image/* URL",
+            detail=f"{field} must be a data:image/* URL",
         )
     if len(value) > _MAX_LOGO_DATA_URL_BYTES:
         raise HTTPException(
             status_code=400,
-            detail=f"logo image too large (max {_MAX_LOGO_DATA_URL_BYTES // 1024} KB encoded)",
+            detail=f"image too large (max {_MAX_LOGO_DATA_URL_BYTES // 1024} KB encoded)",
         )
     return value
 
@@ -170,6 +170,7 @@ async def get_theme():
         ui_radius=config.ui_radius,
         org_name=config.org_name,
         logo_data_url=config.logo_data_url,
+        icon_data_url=config.icon_data_url,
     )
 
 
@@ -185,7 +186,9 @@ async def update_theme(req: UpdateThemeConfigRequest, user: User = Depends(get_c
     if req.org_name is not None:
         config.org_name = req.org_name.strip()
     if req.logo_data_url is not None:
-        config.logo_data_url = _validate_logo_data_url(req.logo_data_url)
+        config.logo_data_url = _validate_image_data_url(req.logo_data_url, "logo_data_url")
+    if req.icon_data_url is not None:
+        config.icon_data_url = _validate_image_data_url(req.icon_data_url, "icon_data_url")
     config.updated_at = datetime.datetime.now(datetime.timezone.utc)
     config.updated_by = user.user_id
     await config.save()
@@ -194,6 +197,7 @@ async def update_theme(req: UpdateThemeConfigRequest, user: User = Depends(get_c
         ui_radius=config.ui_radius,
         org_name=config.org_name,
         logo_data_url=config.logo_data_url,
+        icon_data_url=config.icon_data_url,
     )
 
 

--- a/backend/app/schemas/config.py
+++ b/backend/app/schemas/config.py
@@ -39,6 +39,7 @@ class ThemeConfigResponse(BaseModel):
     ui_radius: str = "12px"
     org_name: str = ""
     logo_data_url: str = ""
+    icon_data_url: str = ""
 
 
 class UpdateThemeConfigRequest(BaseModel):
@@ -46,6 +47,7 @@ class UpdateThemeConfigRequest(BaseModel):
     ui_radius: Optional[str] = None
     org_name: Optional[str] = None
     logo_data_url: Optional[str] = None
+    icon_data_url: Optional[str] = None
 
 
 class OnboardingStatusResponse(BaseModel):

--- a/backend/app/services/email_service.py
+++ b/backend/app/services/email_service.py
@@ -96,6 +96,41 @@ async def _log_send(
         logger.exception("Failed to persist EmailLog for %s", recipient)
 
 
+#: Brand defaults baked into the email templates below. When an admin customizes
+#: branding in System Config, these are swapped out at send time (see
+#: _apply_branding) so every template — current and future — is white-labeled
+#: without threading branding through 20+ template signatures.
+_EMAIL_DEFAULT_NAME = "Vandalizer"
+_EMAIL_DEFAULT_COLOR = "#f1b300"
+#: The theme's own default highlight; if highlight_color still equals this, the
+#: admin hasn't picked a brand color, so leave the email gold (#f1b300) alone.
+_THEME_DEFAULT_COLOR = "#eab308"
+
+
+async def _apply_branding(subject: str, html_body: str) -> tuple[str, str]:
+    """Swap the baked-in Vandalizer name/color for the deployment's branding.
+
+    Best-effort: any failure (DB unavailable in a worker, etc.) falls back to the
+    default Vandalizer branding rather than blocking the email. The name swap is
+    case-sensitive on the capitalized product name, so lowercase URLs/domains
+    (e.g. https://vandalizer.example.edu) are never rewritten.
+    """
+    try:
+        from app.models.system_config import SystemConfig
+
+        config = await SystemConfig.get_config()
+        org = (config.org_name or "").strip()
+        if org and org != _EMAIL_DEFAULT_NAME:
+            subject = subject.replace(_EMAIL_DEFAULT_NAME, org)
+            html_body = html_body.replace(_EMAIL_DEFAULT_NAME, org)
+        color = (config.highlight_color or "").strip()
+        if color and color.lower() != _THEME_DEFAULT_COLOR:
+            html_body = html_body.replace(_EMAIL_DEFAULT_COLOR, color)
+    except Exception:
+        logger.exception("Failed to apply email branding; sending with defaults")
+    return subject, html_body
+
+
 async def send_email(
     to: str,
     subject: str,
@@ -109,6 +144,8 @@ async def send_email(
     """
     if settings is None:
         settings = Settings()
+
+    subject, html_body = await _apply_branding(subject, html_body)
 
     provider = settings.email_provider if settings.email_provider == "resend" else "smtp"
     if provider == "resend":

--- a/frontend/src/api/config.ts
+++ b/frontend/src/api/config.ts
@@ -25,6 +25,7 @@ export interface ThemeConfig {
   ui_radius: string
   org_name: string
   logo_data_url: string
+  icon_data_url: string
 }
 
 export function getThemeConfig() {
@@ -36,6 +37,7 @@ export function updateThemeConfig(data: {
   ui_radius?: string
   org_name?: string
   logo_data_url?: string
+  icon_data_url?: string
 }) {
   return apiFetch<ThemeConfig>('/api/config/theme', {
     method: 'PUT',

--- a/frontend/src/components/chat/ChatPanel.tsx
+++ b/frontend/src/components/chat/ChatPanel.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState, useCallback, type DragEvent } from 'react'
-import { Loader2, BookOpen, X, ArrowDown, ChevronRight, Shield, CheckCircle2, Upload, Link2 } from 'lucide-react'
+import { Loader2, BookOpen, X, ArrowDown, ChevronRight, Shield, CheckCircle2, Upload, Link2, Sparkles } from 'lucide-react'
 import { useQueryClient } from '@tanstack/react-query'
 import { ChatMessage } from './ChatMessage'
 import { ChatInput } from './ChatInput'
@@ -10,7 +10,7 @@ import { useChat } from '../../hooks/useChat'
 import { useOnboarding } from '../../hooks/useOnboarding'
 import { useWorkspace, type PendingChatMessage } from '../../contexts/WorkspaceContext'
 import { useToast } from '../../contexts/ToastContext'
-import { useBranding, DEFAULT_LOGO_URL } from '../../contexts/BrandingContext'
+import { useBranding } from '../../contexts/BrandingContext'
 import { useShareLink } from '../../lib/shareLink'
 import { addLink, removeDocument, removeLink, truncateContext, compactContext, clearContext } from '../../api/chat'
 import { uploadFile } from '../../api/files'
@@ -60,7 +60,7 @@ interface ChatPanelProps {
 
 export function ChatPanel({ conversationToLoad, pendingMessage, onPendingMessageConsumed }: ChatPanelProps) {
   const branding = useBranding()
-  const showJoeVandal = branding.logoUrl === DEFAULT_LOGO_URL
+  const brandIcon = branding.iconUrl
   const {
     messages,
     setMessages,
@@ -551,9 +551,9 @@ export function ChatPanel({ conversationToLoad, pendingMessage, onPendingMessage
                 }}
               />
               <div className="relative z-[1] flex items-center gap-4">
-                {showJoeVandal && (
+                {brandIcon && (
                   <div style={{ animation: 'float 3s ease-in-out infinite' }} className="shrink-0">
-                    <img src="/images/joevandal.png" alt="Joe Vandal" style={{ width: 22, height: 35 }} className="opacity-90" />
+                    <img src={brandIcon} alt={branding.orgName} style={{ width: 22, height: 35, objectFit: 'contain' }} className="opacity-90" />
                   </div>
                 )}
                 <div>
@@ -667,8 +667,10 @@ export function ChatPanel({ conversationToLoad, pendingMessage, onPendingMessage
                     <Loader2 className="h-7 w-7 opacity-90 animate-spin" />
                   ) : activeKBUuid ? (
                     <BookOpen className="h-7 w-7 opacity-90" />
+                  ) : brandIcon ? (
+                    <img src={brandIcon} alt={branding.orgName} style={{ width: 22, height: 35, objectFit: 'contain' }} className="opacity-90" />
                   ) : (
-                    <img src="/images/joevandal.png" alt="Joe Vandal" style={{ width: 22, height: 35 }} className="opacity-90" />
+                    <Sparkles className="h-7 w-7 opacity-90" />
                   )}
                 </div>
                 <div>

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -6,14 +6,14 @@ import { NotificationBell } from './NotificationBell'
 import { SupportChatPanel } from '../support/SupportChatPanel'
 import { FeedbackPromptCard } from '../support/FeedbackPromptCard'
 import { useOptionalWorkspace } from '../../contexts/WorkspaceContext'
-import { useBranding, DEFAULT_LOGO_URL } from '../../contexts/BrandingContext'
+import { useBranding } from '../../contexts/BrandingContext'
 import { useFeedbackPrompt } from '../../hooks/useFeedbackPrompt'
 
 export function Header() {
   const navigate = useNavigate()
   const workspace = useOptionalWorkspace()
   const branding = useBranding()
-  const usingDefaultLogo = branding.logoUrl === DEFAULT_LOGO_URL
+  const brandIcon = branding.iconUrl
   const [supportOpen, setSupportOpen] = useState(false)
   const [supportTicket, setSupportTicket] = useState<string | undefined>()
   const [promptCardHidden, setPromptCardHidden] = useState(false)
@@ -90,13 +90,13 @@ export function Header() {
         {/* Left: Logo images */}
         <div className="flex items-center">
           <button onClick={handleLogoClick} aria-label="Go to home page" className="flex items-center" style={{ background: 'none', border: 'none', cursor: 'pointer', padding: 0 }}>
-            {usingDefaultLogo && (
-              <img src="/images/joevandal.png" alt="" style={{ width: 25, height: 40, marginTop: 4 }} />
+            {brandIcon && (
+              <img src={brandIcon} alt="" style={{ width: 25, height: 40, marginTop: 4, objectFit: 'contain' }} />
             )}
             <img
               src={branding.logoUrl}
               alt={branding.orgName}
-              style={{ height: 50, maxWidth: 240, objectFit: 'contain', marginLeft: usingDefaultLogo ? 4 : 0 }}
+              style={{ height: 50, maxWidth: 240, objectFit: 'contain', marginLeft: brandIcon ? 4 : 0 }}
             />
           </button>
         </div>

--- a/frontend/src/contexts/BrandingContext.tsx
+++ b/frontend/src/contexts/BrandingContext.tsx
@@ -5,6 +5,7 @@ import { getContrastTextColor, getComplementaryColor, getHoverColor } from '../u
 export const DEFAULT_ORG_NAME = 'Vandalizer'
 export const DEFAULT_LOGO_URL = '/images/Vandalizer_Wordmark_RGB.png'
 export const DEFAULT_LOGO_DARK_URL = '/images/Vandalizer_Wordmark_Color_RGB+W.png'
+export const DEFAULT_ICON_URL = '/images/joevandal.png'
 
 export interface Branding {
   /** Display name for this deployment. Always non-empty (falls back to "Vandalizer"). */
@@ -13,6 +14,14 @@ export interface Branding {
   logoUrl: string
   /** Logo for dark backgrounds (auth pages, footer). Same as logoUrl when admin uploads a custom one. */
   logoDarkUrl: string
+  /**
+   * Small square mascot/icon shown beside the wordmark (header, chat banners).
+   * - Default (un-branded) deployment: the Joe Vandal mark.
+   * - Custom icon uploaded: that icon.
+   * - Branded (custom logo/name) but no custom icon: `null` — so Joe Vandal does
+   *   NOT leak onto a white-labeled deployment. Render the icon only when set.
+   */
+  iconUrl: string | null
   /** True when the admin has overridden the default name. Used to surface "Powered by Vandalizer" attribution. */
   isCustomized: boolean
   /** Re-fetch from server (called by admin after saving theme). */
@@ -33,13 +42,27 @@ function applyTheme(theme: ThemeConfig) {
 function resolve(theme: ThemeConfig | null): Omit<Branding, 'refresh'> {
   const orgName = (theme?.org_name || '').trim() || DEFAULT_ORG_NAME
   const customLogo = (theme?.logo_data_url || '').trim()
+  const customIcon = (theme?.icon_data_url || '').trim()
   const isCustomized = orgName !== DEFAULT_ORG_NAME || !!customLogo
   return {
     orgName,
     logoUrl: customLogo || DEFAULT_LOGO_URL,
     logoDarkUrl: customLogo || DEFAULT_LOGO_DARK_URL,
+    iconUrl: customIcon || (isCustomized ? null : DEFAULT_ICON_URL),
     isCustomized,
   }
+}
+
+/** Point the browser-tab favicon at a custom icon (data URL) when one is set. */
+function applyFavicon(iconUrl: string | null) {
+  if (!iconUrl || !iconUrl.startsWith('data:')) return
+  let link = document.querySelector<HTMLLinkElement>('link[rel="icon"]')
+  if (!link) {
+    link = document.createElement('link')
+    link.rel = 'icon'
+    document.head.appendChild(link)
+  }
+  link.href = iconUrl
 }
 
 export function BrandingProvider({ children }: { children: ReactNode }) {
@@ -49,7 +72,9 @@ export function BrandingProvider({ children }: { children: ReactNode }) {
     try {
       const theme = await getThemeConfig()
       applyTheme(theme)
-      setState(resolve(theme))
+      const resolved = resolve(theme)
+      applyFavicon(resolved.iconUrl)
+      setState(resolved)
     } catch {
       // Keep defaults if fetch fails (e.g., not logged in or backend down).
     }
@@ -78,6 +103,7 @@ export function useBranding(): Branding {
       orgName: DEFAULT_ORG_NAME,
       logoUrl: DEFAULT_LOGO_URL,
       logoDarkUrl: DEFAULT_LOGO_DARK_URL,
+      iconUrl: DEFAULT_ICON_URL,
       isCustomized: false,
       refresh: async () => {},
     }

--- a/frontend/src/pages/Admin.tsx
+++ b/frontend/src/pages/Admin.tsx
@@ -19,7 +19,7 @@ import { useAuth } from '../hooks/useAuth'
 import { useTeams } from '../hooks/useTeams'
 import { getThemeConfig, updateThemeConfig } from '../api/config'
 import type { ThemeConfig } from '../api/config'
-import { useBranding, DEFAULT_ORG_NAME } from '../contexts/BrandingContext'
+import { useBranding, DEFAULT_ORG_NAME, DEFAULT_ICON_URL } from '../contexts/BrandingContext'
 import {
   getUsageStats, getUsageTimeseries, getUserLeaderboard, getTeamLeaderboard,
   getTeamDetail, getUserDetail, getUserHistory,
@@ -2642,6 +2642,8 @@ function ConfigTab() {
   const [themeOrgName, setThemeOrgName] = useState('')
   const [themeLogo, setThemeLogo] = useState('')
   const [themeLogoError, setThemeLogoError] = useState<string | null>(null)
+  const [themeIcon, setThemeIcon] = useState('')
+  const [themeIconError, setThemeIconError] = useState<string | null>(null)
   const [themeSaving, setThemeSaving] = useState(false)
   const [themeSaved, setThemeSaved] = useState(false)
 
@@ -2807,6 +2809,7 @@ function ConfigTab() {
       setThemeRadius(parseInt(t.ui_radius) || 12)
       setThemeOrgName(t.org_name || '')
       setThemeLogo(t.logo_data_url || '')
+      setThemeIcon(t.icon_data_url || '')
     }).catch(() => {})
   }, [])
 
@@ -2862,6 +2865,7 @@ function ConfigTab() {
         ui_radius: `${themeRadius}px`,
         org_name: themeOrgName.trim(),
         logo_data_url: themeLogo,
+        icon_data_url: themeIcon,
       })
       applyThemeToDOM(updated)
       await branding.refresh()
@@ -2888,6 +2892,25 @@ function ConfigTab() {
       setThemeLogo(dataUrl)
     } catch {
       setThemeLogoError('Could not read the selected file.')
+    }
+  }
+
+  const handleIconFile = async (file: File | null) => {
+    setThemeIconError(null)
+    if (!file) return
+    if (!file.type.startsWith('image/')) {
+      setThemeIconError('Please choose an image file (PNG, SVG, JPG).')
+      return
+    }
+    try {
+      const dataUrl = await readFileAsDataUrl(file)
+      if (dataUrl.length > MAX_LOGO_BYTES) {
+        setThemeIconError(`Image too large — keep encoded size under ${Math.round(MAX_LOGO_BYTES / 1024)} KB.`)
+        return
+      }
+      setThemeIcon(dataUrl)
+    } catch {
+      setThemeIconError('Could not read the selected file.')
     }
   }
 
@@ -4001,6 +4024,56 @@ ${playgroundResult.request.user_prompt}`}
               </div>
               {themeLogoError && (
                 <div style={{ fontSize: 12, color: '#b91c1c', marginTop: 6 }}>{themeLogoError}</div>
+              )}
+            </div>
+            <div>
+              <label style={labelStyle}>Icon / Mascot</label>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+                <div style={{
+                  width: 56, height: 56, borderRadius: 'var(--ui-radius, 12px)',
+                  border: '1px solid #e5e7eb', background: '#f9fafb',
+                  display: 'flex', alignItems: 'center', justifyContent: 'center', overflow: 'hidden',
+                }}>
+                  {themeIcon ? (
+                    <img src={themeIcon} alt="Icon preview" style={{ maxWidth: '100%', maxHeight: '100%', objectFit: 'contain' }} />
+                  ) : (
+                    <img src={DEFAULT_ICON_URL} alt="Default Joe Vandal icon" style={{ maxWidth: '70%', maxHeight: '90%', objectFit: 'contain', opacity: 0.7 }} />
+                  )}
+                </div>
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+                  <label style={{
+                    padding: '6px 12px', borderRadius: 'var(--ui-radius, 12px)',
+                    border: '1px solid #d1d5db', background: '#fff',
+                    fontSize: 12, fontWeight: 500, cursor: 'pointer', textAlign: 'center',
+                  }}>
+                    {themeIcon ? 'Replace' : 'Upload'}
+                    <input
+                      type="file"
+                      accept="image/png,image/jpeg,image/svg+xml,image/webp"
+                      onChange={e => handleIconFile(e.target.files?.[0] || null)}
+                      style={{ display: 'none' }}
+                    />
+                  </label>
+                  {themeIcon && (
+                    <button
+                      type="button"
+                      onClick={() => { setThemeIcon(''); setThemeIconError(null) }}
+                      style={{
+                        padding: '6px 12px', borderRadius: 'var(--ui-radius, 12px)',
+                        border: '1px solid #fee2e2', background: '#fff',
+                        color: '#b91c1c', fontSize: 12, fontWeight: 500, cursor: 'pointer',
+                      }}
+                    >
+                      Clear
+                    </button>
+                  )}
+                </div>
+              </div>
+              <div style={{ fontSize: 11, color: '#9ca3af', marginTop: 6 }}>
+                Small square mark shown beside the logo (header & chat) and as the browser-tab favicon. A square, transparent PNG works best. The default Joe Vandal mark shows only on un-branded deployments — once you set an organization name or logo, leave this blank to hide it, or upload your own.
+              </div>
+              {themeIconError && (
+                <div style={{ fontSize: 12, color: '#b91c1c', marginTop: 6 }}>{themeIconError}</div>
               )}
             </div>
           </div>

--- a/frontend/src/pages/Landing.tsx
+++ b/frontend/src/pages/Landing.tsx
@@ -3,6 +3,7 @@ import { Link, Navigate, useSearch } from '@tanstack/react-router'
 import { useAuth } from '../hooks/useAuth'
 import { getAuthConfig, type AuthConfig } from '../api/auth'
 import { Footer } from '../components/layout/Footer'
+import { useBranding } from '../contexts/BrandingContext'
 import {
   FileText,
   Cpu,
@@ -275,6 +276,7 @@ function safeNextPath(raw: string | undefined): string | null {
 
 export default function Landing() {
   const { user, loading, demoExpired, demoFeedbackToken } = useAuth()
+  const branding = useBranding()
   const [authConfig, setAuthConfig] = useState<AuthConfig | null>(null)
   const search = useSearch({ strict: false }) as Record<string, string | undefined>
   const inviteToken = search?.invite_token
@@ -331,7 +333,7 @@ export default function Landing() {
       {/* Fixed top nav */}
       <nav className="fixed top-0 inset-x-0 z-50 bg-[#0a0a0a]/80 backdrop-blur-md border-b border-white/10">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex items-center justify-between h-16">
-          <img src="/images/Vandalizer_Wordmark_Color_RGB+W.png" alt="Vandalizer" className="h-10" />
+          <img src={branding.logoDarkUrl} alt={branding.orgName} className="h-10" style={{ maxWidth: 220, objectFit: 'contain' }} />
           <div className="flex items-center gap-4">
             <Link
               to="/docs/present"
@@ -405,9 +407,10 @@ export default function Landing() {
 
           {/* Logo */}
           <img
-            src="/images/Vandalizer_Wordmark_Color_RGB+W.png"
-            alt="Vandalizer"
+            src={branding.logoDarkUrl}
+            alt={branding.orgName}
             className="w-full max-w-[500px] mb-5"
+            style={{ objectFit: 'contain' }}
           />
 
           {/* Tagline */}


### PR DESCRIPTION
## Summary

Extends **UI Theme & Branding** beyond the wordmark logo so a deployment can fully white-label itself. Also surfaces the fix for a logo/org-name persistence issue (those fields were added after older backend builds, which silently dropped them — this branch is what the server needs rebuilt to).

## What changed

**New configurable Icon/Mascot asset** (`icon_data_url`) — replaces the hardcoded Joe Vandal mark.
- Stored on `SystemConfig`, served via the public `/api/config/theme` endpoint, exposed as `branding.iconUrl`, uploadable in the admin panel.
- Defaults to Joe Vandal on un-branded deployments; **hides itself** once a custom logo/name is set (so it can't leak onto a white-labeled install); a custom icon shows everywhere.
- Also drives the **browser-tab favicon**.

**Components**
- `Header` and the two chat banners render `branding.iconUrl` instead of `joevandal.png`; chat empty-state falls back to a neutral icon when none is set.

**Landing page**
- Nav + hero wordmarks now use `branding.logoDarkUrl` / `branding.orgName` instead of the hardcoded Vandalizer wordmark. Marketing prose + GPL/NSF/footer attribution left intentionally untouched.

**Emails**
- White-labeled centrally in `send_email()`: the baked-in `Vandalizer` name and `#f1b300` brand color are swapped for the configured `org_name` / `highlight_color`, covering all 22 templates (and future ones) without per-template edits. Best-effort with a fallback to defaults if the DB is unreachable in a worker. Name swap is case-sensitive so lowercase URLs/domains aren't rewritten.

**Backend**
- Generalized the logo data-URL validator to cover both image fields.

## Behavior preserved
`resolve()` keeps the existing "hide Joe Vandal on customized deployments" behavior:
```
iconUrl: customIcon || (isCustomized ? null : DEFAULT_ICON_URL)
```

## Testing
- `tsc --noEmit` clean; eslint clean on changed files (pre-existing warnings only).
- Backend config tests pass (`test_config_routes`, `test_config_service`, `test_config` — 31 passed).
- Verified a 450 KB logo round-trips through the real model → Mongo → response schema.