### PR TITLE
Make validation-plan evaluation schema-tolerant (fixes Validate KeyError)

### DIFF
--- a/backend/app/services/workflow_service.py
+++ b/backend/app/services/workflow_service.py
@@ -843,11 +843,13 @@ async def reorder_steps(workflow_id: str, step_ids: list[str], user: User) -> bo
 # ---------------------------------------------------------------------------
 
 async def get_validation_plan(workflow_id: str, user: User) -> list[dict]:
-    """Return the workflow's persisted validation plan."""
+    """Return the workflow's persisted validation plan (normalized to the
+    canonical runtime schema so imported/alternate-shaped plans display and
+    edit correctly)."""
     wf = await get_authorized_workflow(workflow_id, user)
     if not wf:
         raise ValueError("Workflow not found")
-    return wf.validation_plan
+    return _normalize_validation_plan(wf.validation_plan)
 
 
 async def update_validation_plan(workflow_id: str, checks: list[dict], user: User) -> list[dict]:
@@ -1240,6 +1242,58 @@ _CATEGORY_WEIGHTS = {
     "formatting": 0.7,
 }
 
+# Canonical runtime categories plus aliases for the alternate
+# {check_id, check_name, check_description, check_type} schema that some
+# workflow exports embed. Mapping check_type onto a canonical category lets a
+# mismatched plan validate instead of KeyError-ing the evaluator.
+_VALIDATION_CATEGORY_ALIASES = {
+    "completeness": "completeness",
+    "accuracy": "accuracy",
+    "content": "content",
+    "formatting": "formatting",
+    "format": "formatting",
+    "presence": "completeness",
+    "correctness": "accuracy",
+    "consistency": "accuracy",
+    "arithmetic": "accuracy",
+    "constraints": "accuracy",
+    "hallucination": "accuracy",
+}
+
+
+def _normalize_validation_plan(plan: list[dict] | None) -> list[dict]:
+    """Coerce a stored/imported validation plan into the canonical runtime
+    schema ``{id, name, description, category}``.
+
+    The editor and ``generate_validation_plan`` produce that shape, but some
+    workflow exports embed the alternate ``{check_id, check_name,
+    check_description, check_type, severity}`` shape. The evaluator and the
+    multi-run merge index checks by ``c["id"]`` / ``c["name"]``, so an
+    alternate-shaped plan would raise ``KeyError`` on Validate. Normalizing on
+    read makes either shape work and never raises on a malformed entry. The id
+    is derived from an existing ``id``/``check_id`` (stable across calls) and
+    only synthesized when neither is present.
+    """
+    normalized: list[dict] = []
+    for raw in plan or []:
+        if not isinstance(raw, dict):
+            continue
+        cid = raw.get("id") or raw.get("check_id")
+        cid = str(cid) if cid else uuid_mod.uuid4().hex
+        name = str(raw.get("name") or raw.get("check_name") or "")[:60]
+        description = str(raw.get("description") or raw.get("check_description") or "")
+        category_raw = str(
+            raw.get("category") or raw.get("check_type") or "content"
+        ).lower().strip()
+        category = _VALIDATION_CATEGORY_ALIASES.get(category_raw, "content")
+        normalized.append({
+            "id": cid,
+            "name": name,
+            "description": description,
+            "category": category,
+        })
+    return normalized
+
 
 def _text_similarity(a: str, b: str) -> float:
     """Jaccard similarity over whitespace-split tokens (case-insensitive)."""
@@ -1345,7 +1399,7 @@ async def validate_workflow(workflow_id: str, user: User | None = None) -> dict:
         if not wf:
             raise ValueError("Workflow not found")
 
-    plan = wf.validation_plan
+    plan = _normalize_validation_plan(wf.validation_plan)
     if not plan:
         raise ValueError("No validation plan - generate or add checks first")
 

--- a/backend/tests/test_workflow_service.py
+++ b/backend/tests/test_workflow_service.py
@@ -814,3 +814,62 @@ class TestParseJsonArray:
         from app.services.workflow_service import _parse_json_array
         result = _parse_json_array("[]")
         assert result == []
+
+
+class TestNormalizeValidationPlan:
+    """_normalize_validation_plan must accept the canonical runtime schema AND
+    the alternate {check_id, check_name, check_description, check_type} export
+    schema, never raising KeyError on the evaluator's c["id"]/c["name"] access.
+    """
+
+    def test_canonical_schema_passthrough(self):
+        from app.services.workflow_service import _normalize_validation_plan
+        plan = [{"id": "abc", "name": "N", "description": "D", "category": "accuracy"}]
+        out = _normalize_validation_plan(plan)
+        assert out == [{"id": "abc", "name": "N", "description": "D", "category": "accuracy"}]
+
+    def test_alternate_schema_is_mapped(self):
+        from app.services.workflow_service import _normalize_validation_plan
+        plan = [{
+            "check_id": "CHK-01",
+            "check_name": "Monetary preservation",
+            "check_description": "Amounts match source",
+            "check_type": "format",
+            "severity": "error",
+        }]
+        out = _normalize_validation_plan(plan)
+        assert out[0]["id"] == "CHK-01"          # stable id from check_id
+        assert out[0]["name"] == "Monetary preservation"
+        assert out[0]["description"] == "Amounts match source"
+        assert out[0]["category"] == "formatting"  # check_type "format" -> "formatting"
+
+    def test_check_type_aliases(self):
+        from app.services.workflow_service import _normalize_validation_plan
+        for check_type, expected in [
+            ("arithmetic", "accuracy"),
+            ("consistency", "accuracy"),
+            ("correctness", "accuracy"),
+            ("presence", "completeness"),
+            ("completeness", "completeness"),
+            ("hallucination", "accuracy"),
+            ("totally-unknown", "content"),
+        ]:
+            out = _normalize_validation_plan([{"check_id": "x", "check_type": check_type}])
+            assert out[0]["category"] == expected, check_type
+
+    def test_synthesizes_id_when_absent(self):
+        from app.services.workflow_service import _normalize_validation_plan
+        out = _normalize_validation_plan([{"name": "no id here"}])
+        assert out[0]["id"]  # non-empty synthesized id
+        assert out[0]["category"] == "content"
+
+    def test_skips_malformed_entries_without_raising(self):
+        from app.services.workflow_service import _normalize_validation_plan
+        out = _normalize_validation_plan([None, "string", 42, {"id": "ok", "name": "n"}])
+        assert len(out) == 1
+        assert out[0]["id"] == "ok"
+
+    def test_none_and_empty(self):
+        from app.services.workflow_service import _normalize_validation_plan
+        assert _normalize_validation_plan(None) == []
+        assert _normalize_validation_plan([]) == []


### PR DESCRIPTION
## What

Makes validation-plan evaluation **schema-tolerant** so a workflow whose `validation_plan` uses the alternate `{check_id, check_name, check_description, check_type}` export schema no longer crashes **Validate** with `KeyError`.

Fixes #479.

## Why

The runtime/editor canonical check schema is `{id, name, description, category}`, but `export_import_service` copies an imported plan verbatim. When that plan uses the `{check_id, …}` shape, `_evaluate_checks_against_output` (and the multi-run merge / no-results path) index `c["id"]`/`c["name"]` and raise `KeyError: 'id'`. See #479 for the full trace.

## Changes

- **`backend/app/services/workflow_service.py`**
  - Add `_normalize_validation_plan(plan)` — coerces either schema into the canonical `{id, name, description, category}` shape:
    - `id` ← `id` | `check_id` (stable across calls; only synthesized via `uuid4` when neither is present)
    - `name` ← `name` | `check_name` (capped at 60 chars)
    - `description` ← `description` | `check_description`
    - `category` ← `category` | `check_type` mapped through `_VALIDATION_CATEGORY_ALIASES` (`format`→`formatting`; `arithmetic`/`consistency`/`correctness`/`constraints`/`hallucination`→`accuracy`; `presence`→`completeness`; unknown→`content`)
    - non-dict / malformed entries are skipped, never raising
  - Apply it in `validate_workflow` (the crash site) and `get_validation_plan` (so imported/alternate plans display and edit correctly).
- **`backend/tests/test_workflow_service.py`** — `TestNormalizeValidationPlan` with 6 cases: canonical passthrough, alternate-schema mapping, `check_type` alias table, id synthesis when absent, malformed-entry skipping, and `None`/empty input.

## Safety / scope

- Pure normalization on **read** — nothing is persisted or mutated, and well-formed canonical plans pass through byte-identical.
- No API contract change: `get_validation_plan` still returns `{id, name, description, category}` objects (now guaranteed even for imported plans).

## Test

```
cd backend && uv run pytest tests/test_workflow_service.py -q -k NormalizeValidationPlan
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
