### PR TITLE
Upload your own validation plan (secure import endpoint + editor button)

### DIFF
--- a/backend/app/routers/workflows.py
+++ b/backend/app/routers/workflows.py
@@ -24,6 +24,7 @@ from app.schemas.workflows import (
     BatchStatusResponse,
     CreateTempDocumentsRequest,
     CreateWorkflowRequest,
+    ImportValidationPlanRequest,
     ReorderStepsRequest,
     RunWorkflowRequest,
     TestStepRequest,
@@ -1383,6 +1384,24 @@ async def update_validation_plan(
 async def generate_validation_plan(request: Request, workflow_id: str, user: User = Depends(get_current_user)):
     try:
         checks = await svc.generate_validation_plan(workflow_id, user=user)
+        return ValidationPlanResponse(checks=checks)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+
+@router.post("/{workflow_id}/validation-plan/import", response_model=ValidationPlanResponse)
+@limiter.limit("10/minute")
+async def import_validation_plan(
+    request: Request,
+    workflow_id: str,
+    req: ImportValidationPlanRequest,
+    user: User = Depends(get_current_user),
+):
+    """Import a user-uploaded validation plan. The payload is strictly
+    validated and sanitized server-side (see
+    workflow_service._sanitize_uploaded_checks) before it is persisted."""
+    try:
+        checks = await svc.import_validation_plan(workflow_id, req.checks, user=user)
         return ValidationPlanResponse(checks=checks)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))

--- a/backend/app/schemas/workflows.py
+++ b/backend/app/schemas/workflows.py
@@ -137,6 +137,14 @@ class UpdateValidationPlanRequest(BaseModel):
     checks: list[ValidationCheckDefinition]
 
 
+class ImportValidationPlanRequest(BaseModel):
+    # Raw, user-uploaded checks. Accepted as arbitrary objects so the service
+    # can strictly validate/sanitize them and return friendly per-check errors
+    # instead of opaque 422s. Never trusted as-is — see
+    # workflow_service._sanitize_uploaded_checks.
+    checks: list[Any]
+
+
 class ValidationPlanResponse(BaseModel):
     checks: list[ValidationCheckDefinition]
 

--- a/backend/app/services/workflow_service.py
+++ b/backend/app/services/workflow_service.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import datetime
 import logging
+import re
 import uuid as uuid_mod
 from typing import TYPE_CHECKING
 
@@ -855,6 +856,116 @@ async def update_validation_plan(workflow_id: str, checks: list[dict], user: Use
     wf = await get_authorized_workflow(workflow_id, user, manage=True)
     if not wf:
         raise ValueError("Workflow not found")
+    wf.validation_plan = checks
+    wf.updated_at = datetime.datetime.now(tz=datetime.timezone.utc)
+    await wf.save()
+    return wf.validation_plan
+
+
+# ---------------------------------------------------------------------------
+# Uploaded validation plans (user-supplied JSON — must be sanitized)
+# ---------------------------------------------------------------------------
+
+# Hard limits for an uploaded validation plan. These bound the stored size and
+# the text that later flows into the LLM judge prompt.
+_UPLOAD_MAX_CHECKS = 50
+_UPLOAD_NAME_MAX = 120
+_UPLOAD_DESC_MAX = 2000
+_UPLOAD_CATEGORIES = {"completeness", "accuracy", "content", "formatting"}
+_UPLOAD_CATEGORY_ALIASES = {
+    "format": "formatting",
+    "presence": "completeness",
+    "correctness": "accuracy",
+    "consistency": "accuracy",
+    "arithmetic": "accuracy",
+    "constraints": "accuracy",
+    "hallucination": "accuracy",
+}
+# C0 control chars + DEL. Stripped from all user text so an uploaded plan can't
+# smuggle terminal/log-injection sequences or structure a prompt-injection
+# payload with raw newlines/escapes.
+_UPLOAD_CONTROL_CHARS = re.compile(r"[\x00-\x1f\x7f]")
+
+
+def _sanitize_uploaded_checks(raw_checks) -> list[dict]:
+    """Strictly validate and sanitize a user-uploaded validation plan.
+
+    Security-critical: the input is an untrusted file. This:
+    - requires a non-empty JSON array within a hard size cap;
+    - keeps ONLY the {id, name, description, category} fields (unknown keys are
+      dropped, so nothing extra is ever stored or evaluated);
+    - SYNTHESIZES the id server-side (client-supplied ids are ignored) so
+      checks can't collide or forge another check's identity;
+    - restricts category to the known enum (with a small alias map);
+    - strips control characters and caps every string length.
+
+    Raises ValueError with a user-facing message on the first problem. Returns
+    canonical check dicts. (XSS is additionally handled at render time — the
+    frontend renders these as text, never as HTML.)
+    """
+    if not isinstance(raw_checks, list):
+        raise ValueError("Validation plan must be a JSON array of checks.")
+    if not raw_checks:
+        raise ValueError("Validation plan is empty — include at least one check.")
+    if len(raw_checks) > _UPLOAD_MAX_CHECKS:
+        raise ValueError(
+            f"Too many checks: {len(raw_checks)} (maximum is {_UPLOAD_MAX_CHECKS})."
+        )
+
+    def _clean(value, field: str, idx: int, maxlen: int) -> str:
+        if not isinstance(value, str):
+            raise ValueError(f"Check #{idx + 1}: '{field}' must be a string.")
+        cleaned = _UPLOAD_CONTROL_CHARS.sub(" ", value)
+        cleaned = re.sub(r"\s{2,}", " ", cleaned).strip()
+        if len(cleaned) > maxlen:
+            raise ValueError(
+                f"Check #{idx + 1}: '{field}' exceeds {maxlen} characters."
+            )
+        return cleaned
+
+    sanitized: list[dict] = []
+    for idx, raw in enumerate(raw_checks):
+        if not isinstance(raw, dict):
+            raise ValueError(f"Check #{idx + 1} must be a JSON object.")
+
+        name = _clean(raw.get("name", ""), "name", idx, _UPLOAD_NAME_MAX)
+        if not name:
+            raise ValueError(f"Check #{idx + 1}: 'name' is required.")
+
+        description = _clean(raw.get("description", ""), "description", idx, _UPLOAD_DESC_MAX)
+        if not description:
+            raise ValueError(f"Check #{idx + 1}: 'description' is required.")
+
+        category_raw = raw.get("category", "content")
+        if not isinstance(category_raw, str):
+            raise ValueError(f"Check #{idx + 1}: 'category' must be a string.")
+        category = category_raw.lower().strip()
+        category = _UPLOAD_CATEGORY_ALIASES.get(category, category)
+        if category not in _UPLOAD_CATEGORIES:
+            raise ValueError(
+                f"Check #{idx + 1}: invalid category '{category_raw}'. "
+                f"Allowed: {', '.join(sorted(_UPLOAD_CATEGORIES))}."
+            )
+
+        sanitized.append({
+            "id": uuid_mod.uuid4().hex,  # server-synthesized; client id ignored
+            "name": name,
+            "description": description,
+            "category": category,
+        })
+    return sanitized
+
+
+async def import_validation_plan(workflow_id: str, raw_checks, user: User) -> list[dict]:
+    """Validate, sanitize, and persist a user-uploaded validation plan.
+
+    Requires manage rights on the workflow. Raises ValueError (-> 400) with a
+    user-facing message when the uploaded plan is malformed or unsafe.
+    """
+    wf = await get_authorized_workflow(workflow_id, user, manage=True)
+    if not wf:
+        raise ValueError("Workflow not found")
+    checks = _sanitize_uploaded_checks(raw_checks)
     wf.validation_plan = checks
     wf.updated_at = datetime.datetime.now(tz=datetime.timezone.utc)
     await wf.save()

--- a/backend/tests/test_workflow_service.py
+++ b/backend/tests/test_workflow_service.py
@@ -814,3 +814,76 @@ class TestParseJsonArray:
         from app.services.workflow_service import _parse_json_array
         result = _parse_json_array("[]")
         assert result == []
+
+
+class TestSanitizeUploadedChecks:
+    """_sanitize_uploaded_checks hardens an untrusted uploaded validation plan:
+    caps count/length, restricts category, drops unknown keys, synthesizes ids,
+    strips control chars, and raises friendly ValueErrors on bad input.
+    """
+
+    def _valid(self):
+        return [{"name": "Sections present", "description": "All sections appear", "category": "completeness"}]
+
+    def test_valid_plan_passes_and_synthesizes_ids(self):
+        from app.services.workflow_service import _sanitize_uploaded_checks
+        out = _sanitize_uploaded_checks(self._valid())
+        assert len(out) == 1
+        assert set(out[0].keys()) == {"id", "name", "description", "category"}
+        assert out[0]["id"]  # server-synthesized, non-empty
+
+    def test_client_id_is_ignored(self):
+        from app.services.workflow_service import _sanitize_uploaded_checks
+        out = _sanitize_uploaded_checks([{"id": "attacker-id", "name": "n", "description": "d", "category": "content"}])
+        assert out[0]["id"] != "attacker-id"
+
+    def test_unknown_keys_are_dropped(self):
+        from app.services.workflow_service import _sanitize_uploaded_checks
+        out = _sanitize_uploaded_checks([{
+            "name": "n", "description": "d", "category": "content",
+            "evil": "<script>alert(1)</script>", "weight": 999, "__proto__": "x",
+        }])
+        assert set(out[0].keys()) == {"id", "name", "description", "category"}
+
+    def test_category_alias_and_invalid(self):
+        from app.services.workflow_service import _sanitize_uploaded_checks
+        out = _sanitize_uploaded_checks([{"name": "n", "description": "d", "category": "format"}])
+        assert out[0]["category"] == "formatting"
+        with pytest.raises(ValueError):
+            _sanitize_uploaded_checks([{"name": "n", "description": "d", "category": "totally-bogus"}])
+
+    def test_control_chars_stripped(self):
+        from app.services.workflow_service import _sanitize_uploaded_checks
+        out = _sanitize_uploaded_checks([{"name": "a\x00\x1bb", "description": "x\ny\tz", "category": "content"}])
+        assert "\x00" not in out[0]["name"] and "\x1b" not in out[0]["name"]
+        assert "\n" not in out[0]["description"] and "\t" not in out[0]["description"]
+
+    def test_rejects_non_list(self):
+        from app.services.workflow_service import _sanitize_uploaded_checks
+        for bad in ({"checks": []}, "string", 42, None):
+            with pytest.raises(ValueError):
+                _sanitize_uploaded_checks(bad)
+
+    def test_rejects_empty_and_oversize_count(self):
+        from app.services.workflow_service import _sanitize_uploaded_checks, _UPLOAD_MAX_CHECKS
+        with pytest.raises(ValueError):
+            _sanitize_uploaded_checks([])
+        too_many = [{"name": "n", "description": "d", "category": "content"}] * (_UPLOAD_MAX_CHECKS + 1)
+        with pytest.raises(ValueError):
+            _sanitize_uploaded_checks(too_many)
+
+    def test_rejects_missing_or_nonstring_fields(self):
+        from app.services.workflow_service import _sanitize_uploaded_checks
+        with pytest.raises(ValueError):
+            _sanitize_uploaded_checks([{"description": "d", "category": "content"}])  # no name
+        with pytest.raises(ValueError):
+            _sanitize_uploaded_checks([{"name": "n", "category": "content"}])  # no description
+        with pytest.raises(ValueError):
+            _sanitize_uploaded_checks([{"name": 123, "description": "d", "category": "content"}])
+        with pytest.raises(ValueError):
+            _sanitize_uploaded_checks(["not a dict"])
+
+    def test_rejects_oversize_strings(self):
+        from app.services.workflow_service import _sanitize_uploaded_checks, _UPLOAD_DESC_MAX
+        with pytest.raises(ValueError):
+            _sanitize_uploaded_checks([{"name": "n", "description": "x" * (_UPLOAD_DESC_MAX + 1), "category": "content"}])

--- a/frontend/src/api/workflows.ts
+++ b/frontend/src/api/workflows.ts
@@ -321,6 +321,16 @@ export function generateValidationPlan(workflowId: string) {
   })
 }
 
+// Upload a user-supplied validation plan. The server strictly validates and
+// sanitizes the checks before persisting; `checks` is sent as-is from the
+// parsed file (untyped on purpose — the backend is the source of truth).
+export function importValidationPlan(workflowId: string, checks: unknown[]) {
+  return apiFetch<ValidationPlanResponse>(`/api/workflows/${workflowId}/validation-plan/import`, {
+    method: 'POST',
+    body: JSON.stringify({ checks }),
+  })
+}
+
 // Validation Inputs
 
 export interface ValidationInputDefinition {

--- a/frontend/src/components/workspace/WorkflowEditorPanel.tsx
+++ b/frontend/src/components/workspace/WorkflowEditorPanel.tsx
@@ -19,7 +19,7 @@ import {
   updateWorkflow, updateStep, downloadResults, testStep, getTestStepStatus,
   reorderSteps, validateWorkflow, runWorkflow, streamWorkflowStatus, createTempDocuments,
   getWorkflowQualityHistory, getWorkflowImprovementSuggestions, getWorkflowQualityStatus,
-  getValidationPlan, updateValidationPlan, generateValidationPlan,
+  getValidationPlan, updateValidationPlan, generateValidationPlan, importValidationPlan,
   getValidationInputs, updateValidationInputs,
   exportWorkflowUrl, importIntoWorkflow, getWorkflowHistory, duplicateWorkflow,
   improvePrompt,
@@ -5372,6 +5372,8 @@ function ValidateTab({
   const [planChecks, setPlanChecks] = useState<ValidationCheckDefinition[]>([])
   const [planLoading, setPlanLoading] = useState(false)
   const [generating, setGenerating] = useState(false)
+  const [importing, setImporting] = useState(false)
+  const uploadInputRef = useRef<HTMLInputElement>(null)
 
   // Plan editing state
   const [editingIdx, setEditingIdx] = useState<number | null>(null)
@@ -5494,6 +5496,56 @@ function ValidateTab({
       setError(err instanceof Error ? err.message : 'Failed to generate plan')
     } finally {
       setGenerating(false)
+    }
+  }
+
+  const handleUploadClick = () => {
+    setError(null)
+    uploadInputRef.current?.click()
+  }
+
+  const handleFileSelected = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    // Reset so re-selecting the same file fires onChange again.
+    e.target.value = ''
+    if (!file || !workflowId) return
+
+    const MAX_BYTES = 256 * 1024
+    if (file.size > MAX_BYTES) {
+      const msg = 'Validation plan file is too large (max 256 KB).'
+      setError(msg)
+      toast(msg, 'error')
+      return
+    }
+
+    setImporting(true)
+    setError(null)
+    try {
+      const text = await file.text()
+      let parsed: unknown
+      try {
+        parsed = JSON.parse(text)
+      } catch {
+        throw new Error('File is not valid JSON.')
+      }
+      // Accept a bare array of checks or a { "checks": [...] } wrapper.
+      const checks: unknown[] | null = Array.isArray(parsed)
+        ? parsed
+        : parsed && typeof parsed === 'object' && Array.isArray((parsed as { checks?: unknown }).checks)
+          ? (parsed as { checks: unknown[] }).checks
+          : null
+      if (!checks) {
+        throw new Error('Expected a JSON array of checks, or a { "checks": [...] } object.')
+      }
+      const res = await importValidationPlan(workflowId, checks)
+      setPlanChecks(res.checks)
+      toast(`Imported ${res.checks.length} validation check${res.checks.length === 1 ? '' : 's'}.`, 'success')
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Failed to import validation plan'
+      setError(msg)
+      toast(msg, 'error')
+    } finally {
+      setImporting(false)
     }
   }
 
@@ -5894,21 +5946,47 @@ function ValidateTab({
               </div>
             </div>
             {planChecks.length > 0 && (
-              <button
-                onClick={handleGenerate}
-                disabled={generating}
-                style={{
-                  display: 'inline-flex', alignItems: 'center', gap: 4,
-                  padding: '4px 10px', fontSize: 11, fontWeight: 600, fontFamily: 'inherit',
-                  borderRadius: 5, border: '1px solid #d1d5db', backgroundColor: '#fff',
-                  color: '#6b7280', cursor: generating ? 'not-allowed' : 'pointer',
-                  opacity: generating ? 0.6 : 1,
-                }}
-              >
-                <RefreshCw style={{ width: 11, height: 11 }} /> Regenerate
-              </button>
+              <div style={{ display: 'inline-flex', alignItems: 'center', gap: 6 }}>
+                <button
+                  onClick={handleUploadClick}
+                  disabled={importing}
+                  title="Upload a validation plan JSON file"
+                  style={{
+                    display: 'inline-flex', alignItems: 'center', gap: 4,
+                    padding: '4px 10px', fontSize: 11, fontWeight: 600, fontFamily: 'inherit',
+                    borderRadius: 5, border: '1px solid #d1d5db', backgroundColor: '#fff',
+                    color: '#6b7280', cursor: importing ? 'not-allowed' : 'pointer',
+                    opacity: importing ? 0.6 : 1,
+                  }}
+                >
+                  <Upload style={{ width: 11, height: 11 }} /> Upload
+                </button>
+                <button
+                  onClick={handleGenerate}
+                  disabled={generating}
+                  style={{
+                    display: 'inline-flex', alignItems: 'center', gap: 4,
+                    padding: '4px 10px', fontSize: 11, fontWeight: 600, fontFamily: 'inherit',
+                    borderRadius: 5, border: '1px solid #d1d5db', backgroundColor: '#fff',
+                    color: '#6b7280', cursor: generating ? 'not-allowed' : 'pointer',
+                    opacity: generating ? 0.6 : 1,
+                  }}
+                >
+                  <RefreshCw style={{ width: 11, height: 11 }} /> Regenerate
+                </button>
+              </div>
             )}
           </div>
+
+          {/* Hidden file input for "Upload" — server strictly validates the
+              uploaded plan (see import_validation_plan). */}
+          <input
+            ref={uploadInputRef}
+            type="file"
+            accept="application/json,.json"
+            style={{ display: 'none' }}
+            onChange={handleFileSelected}
+          />
 
           {planLoading ? (
             <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: 16, justifyContent: 'center' }}>
@@ -5936,6 +6014,20 @@ function ValidateTab({
                 }}
               >
                 <Sparkles style={{ width: 14, height: 14 }} /> Generate Plan
+              </button>
+              <button
+                onClick={handleUploadClick}
+                disabled={importing}
+                title="Upload a validation plan JSON file"
+                style={{
+                  padding: '6px 14px', fontSize: 12, fontWeight: 600, fontFamily: 'inherit',
+                  border: '1px solid #d1d5db', borderRadius: 6,
+                  cursor: importing ? 'not-allowed' : 'pointer', backgroundColor: '#fff',
+                  color: '#6b7280', display: 'flex', alignItems: 'center', gap: 6,
+                  opacity: importing ? 0.6 : 1,
+                }}
+              >
+                <Upload style={{ width: 12, height: 12 }} /> Upload a plan
               </button>
             </div>
           ) : generating ? (


### PR DESCRIPTION
## What

Adds an **Upload** button to the workflow editor's **Validation Plan** section so users can import their own validation plan from a JSON file, with **strict server-side validation/sanitization**.

Closes #481.

## Why

Today a plan is either LLM-**Regenerated** (non-deterministic; only sees ~2k chars of each prompt) or hand-edited check-by-check. Teams want version-controlled, reviewable, reusable plans authored offline (e.g. in the AI4RA prompt-library) and applied consistently. See #481.

## Backend — treats the upload as untrusted input

- **New endpoint** `POST /workflows/{id}/validation-plan/import` — requires **manage** rights, **rate-limited** `10/min`.
- **`_sanitize_uploaded_checks()`** (`workflow_service.py`):
  - requires a **non-empty JSON array** within a hard **count cap (50)**;
  - keeps **only** `{id, name, description, category}` — **unknown keys are dropped** (never stored or evaluated);
  - **synthesizes `id` server-side** and **ignores any client id** (no id collision/forgery);
  - restricts `category` to the enum `{completeness, accuracy, content, formatting}` (with a small alias map, e.g. `format`→`formatting`);
  - **strips C0/DEL control characters** (defuses terminal/log-injection and prompt-injection framing) and **caps** `name` (120) / `description` (2000);
  - raises friendly **per-check** `ValueError`s → `400` (e.g. "Check #3: invalid category 'foo'").
- `import_validation_plan()` persists the sanitized plan.
- `ImportValidationPlanRequest` accepts raw objects so the service can return friendly errors instead of opaque 422s.
- **No file is written to disk** — JSON is parsed in memory (no path-traversal / multipart-file surface). Output is rendered as **text** in the UI (no stored XSS; no `dangerouslySetInnerHTML`).

## Frontend

- `importValidationPlan()` API client.
- **Upload** button beside **Regenerate** and in the empty state; a hidden file input; a client-side **256 KB** size guard + `JSON.parse`; accepts a bare array or `{ "checks": [...] }`; success/error toasts. The server remains authoritative.

## Tests

`TestSanitizeUploadedChecks` (9 cases): valid passthrough, id synthesis, **client-id ignored**, **unknown-key drop**, category alias + invalid rejection, **control-char stripping**, non-list/empty/oversize-count rejection, missing/non-string-field rejection, oversize-string rejection.

```
cd backend && uv run pytest tests/test_workflow_service.py -q -k SanitizeUploadedChecks
```

## Security summary

Server-authoritative validation; auth + rate limit; count/length caps; enum-restricted category; unknown keys dropped; server-synthesized ids; control-char stripping; text-only rendering; no disk writes. **Residual (documented):** a check `description` is, by design, fed into the LLM judge prompt at Validate time (true of any plan); caps + stripping reduce framing, and the judge only emits PASS/FAIL/detail and executes nothing.

> Note: CI runs the typecheck/test suites. The backend changes were `py_compile`-checked and the sanitizer logic unit-verified locally; the frontend mirrors existing editor patterns (couldn't run `tsc`/`pytest` in the authoring env — no `uv`/`node_modules`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
