### PR TITLE
Meter every LLM call via central wrapper + usage ledger

### DIFF
--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -42,6 +42,7 @@ from app.models.feedback_prompt import FeedbackPrompt, FeedbackPromptResponse
 from app.models.email_log import EmailLog
 from app.models.api_key import ApiKey
 from app.models.credential import Credential
+from app.models.llm_usage import LlmUsageRecord
 
 ALL_MODELS = [
     User,
@@ -104,6 +105,7 @@ ALL_MODELS = [
     EmailLog,
     ApiKey,
     Credential,
+    LlmUsageRecord,
 ]
 
 

--- a/backend/app/models/llm_usage.py
+++ b/backend/app/models/llm_usage.py
@@ -1,0 +1,64 @@
+"""LLM usage ledger  - append-only record of token consumption per LLM call.
+
+Every LLM call in the app is metered at a single chokepoint (the MeteredModel
+wrapper in llm_service.py) and recorded here, attributed to a feature and, when
+available, a user/team/activity. This is the canonical source of truth for token
+usage; ActivityEvent token fields are a denormalized convenience updated
+alongside this ledger when a call belongs to an activity.
+"""
+
+import datetime
+from typing import Optional
+
+from beanie import Document
+from pydantic import Field
+
+
+def _utcnow() -> datetime.datetime:
+    return datetime.datetime.now(datetime.timezone.utc)
+
+
+# Sentinel feature used when an LLM call fires with no metering scope set. These
+# rows flag call sites that still need attribution wiring; they should be rare.
+UNATTRIBUTED_FEATURE = "unattributed"
+
+
+class LlmUsageRecord(Document):
+    timestamp: datetime.datetime = Field(default_factory=_utcnow)
+
+    # Which product surface made the call: "chat", "extraction", "workflow",
+    # "classification", "validation", "title_gen", etc. (see metering.py).
+    feature: str
+
+    user_id: Optional[str] = None
+    team_id: Optional[str] = None
+    space: Optional[str] = None
+
+    # Links back to an ActivityEvent (its str id) when the call is part of one.
+    activity_id: Optional[str] = None
+
+    model: Optional[str] = None
+
+    tokens_input: int = 0
+    tokens_output: int = 0
+    total_tokens: int = 0
+
+    # Number of underlying model HTTP requests aggregated into this row (a single
+    # logical operation may make several: retries, tool sub-calls, multi-step).
+    request_count: int = 1
+
+    # True when token counts were estimated locally because the provider/gateway
+    # returned no usage. Lets reporting separate exact from estimated totals.
+    estimated: bool = False
+
+    status: str = "ok"
+
+    class Settings:
+        name = "llm_usage"
+        indexes = [
+            "user_id",
+            "team_id",
+            "feature",
+            "timestamp",
+            [("user_id", 1), ("timestamp", -1)],
+        ]

--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -2245,7 +2245,9 @@ async def test_prompt(body: TestPromptRequest, user: User = Depends(get_current_
         model = get_agent_model(model_name, system_config_doc=cfg.model_dump())
         system = body.system_prompt.strip()
         agent = Agent(model, system_prompt=system) if system else Agent(model)
-        result = await agent.run(body.user_prompt)
+        from app.services.metering import metered_async
+        async with metered_async("diagnostics"):
+            result = await agent.run(body.user_prompt)
         elapsed_ms = int((_time.perf_counter() - started) * 1000)
         usage = result.usage()
         return {

--- a/backend/app/routers/chat.py
+++ b/backend/app/routers/chat.py
@@ -686,9 +686,15 @@ async def compact_context(
         system_prompt=COMPACT_SYSTEM_PROMPT,
         system_config_doc=sys_config_doc,
     )
-    result = await agent.run(
-        f"Summarize this conversation:\n\n{conversation_text}"
-    )
+    from app.services.metering import metered_async
+    async with metered_async(
+        "chat_summarize",
+        user_id=user.user_id,
+        team_id=str(user.current_team) if getattr(user, "current_team", None) else None,
+    ):
+        result = await agent.run(
+            f"Summarize this conversation:\n\n{conversation_text}"
+        )
 
     summary = result.output if hasattr(result, "output") else str(result.data)
     cutoff = len(conversation.messages)

--- a/backend/app/routers/extractions.py
+++ b/backend/app/routers/extractions.py
@@ -449,7 +449,13 @@ async def upload_pdf_template(
         "Return a JSON object with key 'mappings' mapping each field name to a human-readable "
         "extraction prompt."
     )
-    result = await agent.run(prompt, output_type=FieldMapping)
+    from app.services.metering import metered_async
+    async with metered_async(
+        "extraction_template",
+        user_id=user.user_id,
+        team_id=str(user.current_team) if user.current_team else None,
+    ):
+        result = await agent.run(prompt, output_type=FieldMapping)
     mappings: dict[str, str] = result.output.mappings
 
     # Replace all existing items with new ones from the mapping
@@ -719,14 +725,21 @@ async def run_extraction_sync(request: Request, req: RunExtractionSyncRequest, u
     assert activity.id is not None
 
     try:
-        results = await svc.run_extraction_sync(
-            search_set_uuid=req.search_set_uuid,
-            document_uuids=document_uuids,
+        from app.services.metering import metered_async
+        async with metered_async(
+            "extraction",
             user_id=user.user_id,
-            model=req.model,
-            extraction_config_override=req.extraction_config_override,
-            combined_context=req.combined_context,
-        )
+            team_id=str(user.current_team) if user.current_team else None,
+            activity_id=str(activity.id),
+        ):
+            results = await svc.run_extraction_sync(
+                search_set_uuid=req.search_set_uuid,
+                document_uuids=document_uuids,
+                user_id=user.user_id,
+                model=req.model,
+                extraction_config_override=req.extraction_config_override,
+                combined_context=req.combined_context,
+            )
         await activity_service.activity_finish(activity.id, ActivityStatus.COMPLETED)
         # Merge all result entities into a single normalized map so the
         # activity rail can restore results when the user reopens the run.

--- a/backend/app/services/browser_automation.py
+++ b/backend/app/services/browser_automation.py
@@ -303,8 +303,10 @@ class BrowserAutomationService:
         )
 
         try:
+            from app.services.metering import metered
             agent = create_chat_agent(model, system_prompt=system_prompt)
-            response = agent.run_sync(user_prompt)
+            with metered("browser_automation", user_id=getattr(self.get_session(session_id), "user_id", None)):
+                response = agent.run_sync(user_prompt)
             if response.output:
                 json_match = re.search(r"\{.*\}", response.output, re.DOTALL)
                 if json_match:
@@ -332,8 +334,10 @@ class BrowserAutomationService:
         try:
             from app.services.llm_service import create_chat_agent
 
+            from app.services.metering import metered
             agent = create_chat_agent(model, system_prompt=system_prompt)
-            response = agent.run_sync(user_prompt)
+            with metered("browser_automation", user_id=getattr(self.get_session(session_id), "user_id", None)):
+                response = agent.run_sync(user_prompt)
             json_match = re.search(r"\[.*\]", response.output, re.DOTALL)
             if json_match:
                 return json.loads(json_match.group(0))
@@ -376,8 +380,10 @@ class BrowserAutomationService:
             "--- END PAGE HTML ---"
         )
 
+        from app.services.metering import metered
         agent = create_chat_agent(model, system_prompt=system_prompt)
-        response = agent.run_sync(user_prompt)
+        with metered("browser_automation", user_id=getattr(self.get_session(session_id), "user_id", None)):
+            response = agent.run_sync(user_prompt)
 
         content = response.output.strip()
         if content.startswith("```json"):

--- a/backend/app/services/chat_service.py
+++ b/backend/app/services/chat_service.py
@@ -509,6 +509,17 @@ async def chat_stream(
     thinking_duration: float | None = None
     thinking_done_emitted = False
 
+    # Meter every token this chat consumes (see app/services/metering.py). Manual
+    # enter/exit avoids re-indenting the large streaming body; __aexit__ in the
+    # finally flushes whatever was accrued, even on cancellation mid-stream.
+    from app.services.metering import metered_async
+    _meter = metered_async(
+        "chat",
+        user_id=user_id,
+        team_id=getattr(conversation, "team_id", None),
+        activity_id=activity_id,
+    )
+    await _meter.__aenter__()
     try:
         think_parser = _ThinkTagParser()
 
@@ -630,6 +641,8 @@ async def chat_stream(
             )
         except Exception as save_err:
             logger.error("Failed to persist interrupted chat: %s", save_err)
+    finally:
+        await _meter.__aexit__(None, None, None)
 
 
 

--- a/backend/app/services/llm_service.py
+++ b/backend/app/services/llm_service.py
@@ -6,8 +6,10 @@ from dataclasses import dataclass
 from typing import Optional
 
 import httpx
+from contextlib import asynccontextmanager
 from pydantic_ai.agent import Agent
 from pydantic_ai.models.openai import OpenAIModel
+from pydantic_ai.models.wrapper import WrapperModel
 from pydantic_ai.profiles import ModelProfile
 from pydantic_ai.profiles.openai import (
     OpenAIJsonSchemaTransformer,
@@ -314,12 +316,92 @@ def build_thinking_model_settings(
     return settings
 
 
+class MeteredModel(WrapperModel):
+    """Transparent wrapper that records token usage on every model call.
+
+    This is the single chokepoint for LLM metering: every agent in the app is
+    built from a model produced by get_agent_model(), so wrapping here meters
+    100% of calls — including agentic-chat tool sub-calls, RAG's nested prompt
+    agent, and retries. Usage is reported to the active metering scope (see
+    app/services/metering.py); attribution (user/team/feature) is supplied by
+    the call site via metered()/metered_async().
+
+    When the provider/gateway returns no usage (some OpenAI-compatible gateways
+    omit it), tokens are estimated locally and flagged, so a real call never
+    records zero.
+    """
+
+    async def request(self, messages, model_settings, model_request_parameters):
+        resp = await self.wrapped.request(messages, model_settings, model_request_parameters)
+        self._record(messages, getattr(resp, "usage", None), getattr(resp, "parts", None))
+        return resp
+
+    @asynccontextmanager
+    async def request_stream(
+        self, messages, model_settings, model_request_parameters, run_context=None
+    ):
+        async with self.wrapped.request_stream(
+            messages, model_settings, model_request_parameters, run_context
+        ) as stream:
+            try:
+                yield stream
+            finally:
+                # Usage is final only after the consumer drains the stream, which
+                # happens inside the caller's `async with` block — i.e. before
+                # this finally runs.
+                usage = None
+                parts = None
+                try:
+                    usage = stream.usage()
+                except Exception:
+                    pass
+                try:
+                    parts = stream.get().parts
+                except Exception:
+                    pass
+                self._record(messages, usage, parts)
+
+    def _record(self, messages, usage, parts):
+        from app.services.metering import (
+            estimate_messages_tokens,
+            estimate_parts_tokens,
+            record_usage,
+        )
+
+        in_tok = int(getattr(usage, "input_tokens", 0) or 0)
+        out_tok = int(getattr(usage, "output_tokens", 0) or 0)
+        estimated = False
+        if in_tok + out_tok == 0:
+            in_tok = estimate_messages_tokens(messages)
+            out_tok = estimate_parts_tokens(parts)
+            estimated = True
+        try:
+            record_usage(self.model_name, in_tok, out_tok, estimated=estimated)
+        except Exception:
+            # Metering must never break an LLM call.
+            pass
+
+
 def get_agent_model(
     agent_model: str,
     thinking_override: Optional[bool] = None,
     system_config_doc: dict | None = None,
 ):
-    """Get the appropriate model instance. Sync  - safe for Celery workers."""
+    """Get the appropriate model instance, wrapped for token metering.
+
+    Sync  - safe for Celery workers. The returned MeteredModel is a drop-in
+    Model that Agent(...) accepts unchanged.
+    """
+    model = _build_agent_model(agent_model, thinking_override, system_config_doc)
+    return MeteredModel(model)
+
+
+def _build_agent_model(
+    agent_model: str,
+    thinking_override: Optional[bool] = None,
+    system_config_doc: dict | None = None,
+):
+    """Build the raw (unmetered) provider-specific model instance."""
     model_config = _get_model_config_sync(agent_model, system_config_doc)
 
     # Resolve per-model API key from system config (decrypt if encrypted)

--- a/backend/app/services/metering.py
+++ b/backend/app/services/metering.py
@@ -1,0 +1,279 @@
+"""Central LLM token metering.
+
+Every LLM call flows through the MeteredModel wrapper (llm_service.py), which
+calls record_usage() once per model HTTP request. record_usage() accrues into
+the metering scope set by the nearest enclosing `metered()` / `metered_async()`
+context manager, and on scope exit one LlmUsageRecord is written (plus the
+linked ActivityEvent's token fields, when an activity_id is set).
+
+Why a contextvar instead of threading a usage object through every call site:
+the chokepoint is deep in pydantic-ai (the Model), far below the call sites that
+know *who* and *which feature*. A contextvar lets the call site declare context
+once and have it picked up automatically by every (possibly nested) LLM call
+underneath — including RAG tool sub-calls and workflow nodes. Workflow nodes run
+on a ThreadPoolExecutor, which does not copy contextvars automatically; the
+engine is patched to run each node within a copied context so the scope
+propagates (see workflow_engine.process).
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+from contextvars import ContextVar
+from dataclasses import dataclass
+from typing import Any, AsyncIterator, Iterator, Optional
+
+# Sentinel feature for calls that fire with no scope set (see record_usage).
+from app.models.llm_usage import UNATTRIBUTED_FEATURE
+
+logger = logging.getLogger(__name__)
+
+_CHARS_PER_TOKEN_FALLBACK = 4
+
+
+# ---------------------------------------------------------------------------
+# Token estimation (used when the provider/gateway returns no usage)
+# ---------------------------------------------------------------------------
+_encoding: Any = None
+_encoding_failed = False
+
+
+def _get_encoding():
+    global _encoding, _encoding_failed
+    if _encoding is None and not _encoding_failed:
+        try:
+            import tiktoken
+
+            _encoding = tiktoken.get_encoding("cl100k_base")
+        except Exception as e:  # pragma: no cover - defensive
+            logger.warning("tiktoken unavailable, using char heuristic: %s", e)
+            _encoding_failed = True
+    return _encoding
+
+
+def estimate_tokens(text: str) -> int:
+    """Best-effort token count for a string. Never raises."""
+    if not text:
+        return 0
+    enc = _get_encoding()
+    if enc is not None:
+        try:
+            return len(enc.encode(text))
+        except Exception:  # pragma: no cover - defensive
+            pass
+    return max(1, len(text) // _CHARS_PER_TOKEN_FALLBACK)
+
+
+def _text_of(obj: Any) -> str:
+    """Pull display text out of a pydantic-ai message/part, best-effort."""
+    content = getattr(obj, "content", None)
+    if isinstance(content, str):
+        return content
+    if isinstance(content, (list, tuple)):
+        return " ".join(_text_of(c) for c in content)
+    # request parts hold their text under .content; tool parts under .args etc.
+    return content if isinstance(content, str) else ""
+
+
+def estimate_messages_tokens(messages: Any) -> int:
+    """Estimate input tokens from a list of pydantic-ai ModelMessages."""
+    total = 0
+    try:
+        for msg in messages or []:
+            for part in getattr(msg, "parts", []) or []:
+                total += estimate_tokens(_text_of(part))
+    except Exception:  # pragma: no cover - defensive
+        return 0
+    return total
+
+
+def estimate_parts_tokens(parts: Any) -> int:
+    """Estimate output tokens from a ModelResponse's parts."""
+    total = 0
+    try:
+        for part in parts or []:
+            total += estimate_tokens(_text_of(part))
+    except Exception:  # pragma: no cover - defensive
+        return 0
+    return total
+
+
+# ---------------------------------------------------------------------------
+# Metering scope
+# ---------------------------------------------------------------------------
+@dataclass
+class MeterScope:
+    feature: str
+    user_id: Optional[str] = None
+    team_id: Optional[str] = None
+    space: Optional[str] = None
+    activity_id: Optional[str] = None
+    model: Optional[str] = None
+    tokens_in: int = 0
+    tokens_out: int = 0
+    requests: int = 0
+    estimated: bool = False
+
+
+_current_scope: ContextVar[Optional[MeterScope]] = ContextVar(
+    "llm_meter_scope", default=None
+)
+
+
+def current_scope() -> Optional[MeterScope]:
+    return _current_scope.get()
+
+
+def record_usage(
+    model_name: Optional[str],
+    input_tokens: int,
+    output_tokens: int,
+    *,
+    estimated: bool = False,
+) -> None:
+    """Add one model request's usage to the active scope.
+
+    Called by MeteredModel after every request. If no scope is set (a call site
+    we haven't wired for attribution), the usage is still recorded under the
+    `unattributed` feature so nothing is lost, and a warning is logged so the
+    site can be found and wrapped.
+    """
+    scope = _current_scope.get()
+    if scope is None:
+        logger.warning(
+            "LLM call with no metering scope (model=%s, in=%s, out=%s) — recording as unattributed",
+            model_name, input_tokens, output_tokens,
+        )
+        backstop = MeterScope(
+            feature=UNATTRIBUTED_FEATURE,
+            model=model_name,
+            tokens_in=input_tokens or 0,
+            tokens_out=output_tokens or 0,
+            requests=1,
+            estimated=estimated,
+        )
+        flush_sync(backstop)
+        return
+    scope.tokens_in += input_tokens or 0
+    scope.tokens_out += output_tokens or 0
+    scope.requests += 1
+    if estimated:
+        scope.estimated = True
+    if model_name and not scope.model:
+        scope.model = model_name
+
+
+# ---------------------------------------------------------------------------
+# Context managers
+# ---------------------------------------------------------------------------
+@contextlib.contextmanager
+def metered(
+    feature: str,
+    *,
+    user_id: Optional[str] = None,
+    team_id: Optional[str] = None,
+    activity_id: Optional[str] = None,
+    space: Optional[str] = None,
+) -> Iterator[MeterScope]:
+    """Sync metering scope (Celery tasks, engine run_sync paths)."""
+    scope = MeterScope(
+        feature=feature, user_id=user_id, team_id=team_id,
+        activity_id=activity_id, space=space,
+    )
+    token = _current_scope.set(scope)
+    try:
+        yield scope
+    finally:
+        _current_scope.reset(token)
+        flush_sync(scope)
+
+
+@contextlib.asynccontextmanager
+async def metered_async(
+    feature: str,
+    *,
+    user_id: Optional[str] = None,
+    team_id: Optional[str] = None,
+    activity_id: Optional[str] = None,
+    space: Optional[str] = None,
+) -> AsyncIterator[MeterScope]:
+    """Async metering scope (FastAPI routes/services using `await agent.run`)."""
+    scope = MeterScope(
+        feature=feature, user_id=user_id, team_id=team_id,
+        activity_id=activity_id, space=space,
+    )
+    token = _current_scope.set(scope)
+    try:
+        yield scope
+    finally:
+        _current_scope.reset(token)
+        await flush_async(scope)
+
+
+# ---------------------------------------------------------------------------
+# Flush  - persist a finished scope to the ledger (+ linked ActivityEvent)
+# ---------------------------------------------------------------------------
+def _record_doc(scope: MeterScope) -> dict:
+    import datetime
+
+    return {
+        "timestamp": datetime.datetime.now(datetime.timezone.utc),
+        "feature": scope.feature,
+        "user_id": scope.user_id,
+        "team_id": scope.team_id,
+        "space": scope.space,
+        "activity_id": scope.activity_id,
+        "model": scope.model,
+        "tokens_input": scope.tokens_in,
+        "tokens_output": scope.tokens_out,
+        "total_tokens": scope.tokens_in + scope.tokens_out,
+        "request_count": scope.requests,
+        "estimated": scope.estimated,
+        "status": "ok",
+    }
+
+
+def flush_sync(scope: MeterScope) -> None:
+    """Write a usage row (and update the linked activity) from sync context."""
+    if scope.requests == 0:
+        return  # no LLM call happened under this scope
+    try:
+        from bson import ObjectId
+
+        from app.tasks import get_sync_db
+
+        db = get_sync_db()
+        db.llm_usage.insert_one(_record_doc(scope))
+        if scope.activity_id:
+            db.activity_event.update_one(
+                {"_id": ObjectId(scope.activity_id)},
+                {"$set": {
+                    "tokens_input": scope.tokens_in,
+                    "tokens_output": scope.tokens_out,
+                    "total_tokens": scope.tokens_in + scope.tokens_out,
+                }},
+            )
+    except Exception as e:  # never let metering break the request
+        logger.error("Failed to flush LLM usage (sync, feature=%s): %s", scope.feature, e)
+
+
+async def flush_async(scope: MeterScope) -> None:
+    """Write a usage row (and update the linked activity) from async context."""
+    if scope.requests == 0:
+        return
+    try:
+        from app.models.llm_usage import LlmUsageRecord
+
+        await LlmUsageRecord(**_record_doc(scope)).insert()
+        if scope.activity_id:
+            from app.models.activity import ActivityEvent
+
+            ev = await ActivityEvent.get(scope.activity_id)
+            if ev:
+                ev.tokens_input = scope.tokens_in
+                ev.tokens_output = scope.tokens_out
+                ev.total_tokens = scope.tokens_in + scope.tokens_out
+                await ev.save()
+    except Exception as e:
+        logger.error("Failed to flush LLM usage (async, feature=%s): %s", scope.feature, e)

--- a/backend/app/services/prompt_improvement_service.py
+++ b/backend/app/services/prompt_improvement_service.py
@@ -79,7 +79,9 @@ async def improve_prompt(
     model = get_agent_model(default_model, system_config_doc=sys_config_doc)
     agent = Agent(model, system_prompt=_SYSTEM_PROMPT, output_type=PromptImprovement)
 
-    result = await agent.run("\n".join(parts))
+    from app.services.metering import metered_async
+    async with metered_async("prompt_improve"):
+        result = await agent.run("\n".join(parts))
     return {
         "improved_prompt": result.output.improved_prompt,
         "rationale": result.output.rationale,

--- a/backend/app/services/quality_service.py
+++ b/backend/app/services/quality_service.py
@@ -463,7 +463,9 @@ async def generate_improvement_suggestions(
             ),
             system_config_doc=sys_config_doc,
         )
-        res = await agent.run(prompt)
+        from app.services.metering import metered_async
+        async with metered_async("quality_suggestion"):
+            res = await agent.run(prompt)
         return res.output
     except Exception as exc:
         logger.exception("Failed to generate improvement suggestions for %s %s", item_kind, item_id)

--- a/backend/app/services/search_set_service.py
+++ b/backend/app/services/search_set_service.py
@@ -327,7 +327,9 @@ async def suggest_fields_from_documents(
 
     prompt = BUILD_FROM_DOC_USER_PROMPT.format(doc_text=doc_text[:100000])
     try:
-        result = await agent.run(prompt)
+        from app.services.metering import metered_async
+        async with metered_async("kb_field_suggest", user_id=user_id):
+            result = await agent.run(prompt)
     except Exception as e:
         raise RuntimeError(f"LLM call failed: {e}") from e
     response_text = result.output

--- a/backend/app/services/system_diagnostics.py
+++ b/backend/app/services/system_diagnostics.py
@@ -178,7 +178,9 @@ async def diagnose_model(cfg: SystemConfig, index: int) -> dict[str, Any]:
 
         model = get_agent_model(model_name, system_config_doc=config_doc)
         agent = Agent(model, system_prompt="You are a connectivity probe. Reply with exactly: ok")
-        result = await agent.run("Say ok")
+        from app.services.metering import metered_async
+        async with metered_async("diagnostics"):
+            result = await agent.run("Say ok")
         elapsed_ms = int((time.perf_counter() - started) * 1000)
         reply = (result.output or "").strip()
         usage = result.usage()

--- a/backend/app/services/triage_agent.py
+++ b/backend/app/services/triage_agent.py
@@ -145,5 +145,11 @@ Attachments ({work_item_doc.get('attachment_count', 0)} files): {', '.join(attac
 {attachment_text_preview}
 """.strip()
 
-    result = agent.run_sync(context)
+    from app.services.metering import metered
+    with metered(
+        "m365_triage",
+        user_id=work_item_doc.get("user_id"),
+        team_id=work_item_doc.get("team_id"),
+    ):
+        result = agent.run_sync(context)
     return result.output

--- a/backend/app/services/workflow_engine.py
+++ b/backend/app/services/workflow_engine.py
@@ -383,12 +383,19 @@ class MultiTaskNode(Node):
         return task._apply_post_process(result)
 
     def process(self, inputs):
+        import contextvars
         from copy import deepcopy
 
         for task in self.tasks:
             task.inputs = deepcopy(inputs)
+        # Run each node within a copy of the current context so contextvars set
+        # by the caller (notably the LLM metering scope) propagate into the
+        # worker threads — ThreadPoolExecutor does not copy contextvars itself.
         with ThreadPoolExecutor(max_workers=self.max_workers) as executor:
-            task_futures = [executor.submit(self.process_task, task) for task in self.tasks]
+            task_futures = [
+                executor.submit(contextvars.copy_context().run, self.process_task, task)
+                for task in self.tasks
+            ]
             results = [future.result() for future in as_completed(task_futures)]
 
         collected = []

--- a/backend/app/services/workflow_service.py
+++ b/backend/app/services/workflow_service.py
@@ -1194,7 +1194,9 @@ async def generate_validation_plan(workflow_id: str, user: User) -> list[dict]:
     )
 
     try:
-        result = await agent.run(f"## Workflow\n{workflow_desc}")
+        from app.services.metering import metered_async
+        async with metered_async("validation", user_id=wf_data.get("user_id")):
+            result = await agent.run(f"## Workflow\n{workflow_desc}")
     except Exception:
         raise ValueError("LLM call failed - could not generate validation plan")
 
@@ -1553,7 +1555,9 @@ async def _evaluate_checks_against_output(
     )
 
     try:
-        result = await agent.run(user_prompt)
+        from app.services.metering import metered_async
+        async with metered_async("validation"):
+            result = await agent.run(user_prompt)
     except Exception:
         return [
             {"check_id": c["id"], "name": c["name"], "status": "SKIP", "detail": "LLM evaluation failed"}

--- a/backend/app/services/workflow_validator.py
+++ b/backend/app/services/workflow_validator.py
@@ -235,7 +235,9 @@ class PlanGenerator:
         model = get_agent_model(model_name)
 
         agent = Agent(model, system_prompt=PLAN_GENERATION_SYSTEM_PROMPT)
-        result = agent.run_sync(user_prompt)
+        from app.services.metering import metered
+        with metered("validation", user_id=user_id):
+            result = agent.run_sync(user_prompt)
         raw = _extract_json(result.output)
         checks = _parse_checks(raw)
 
@@ -397,12 +399,21 @@ class CheckRunner:
             check_results.append(self._run_deterministic_check(check, step_output))
 
         if llm_checks:
+            import contextvars
+
+            from app.services.metering import metered
             worker_count = min(len(llm_checks), self.MAX_LLM_WORKERS)
-            with ThreadPoolExecutor(max_workers=worker_count) as executor:
+            # One usage row for the whole evaluation run; copy_context so the
+            # metering scope reaches the check worker threads.
+            with metered("validation", user_id=user_id), \
+                    ThreadPoolExecutor(max_workers=worker_count) as executor:
                 futures = {}
                 for check in llm_checks:
                     step_output = self._resolve_step_output(check, step_outputs, final_output)
-                    future = executor.submit(self._run_llm_check, check, step_output, model_name)
+                    future = executor.submit(
+                        contextvars.copy_context().run,
+                        self._run_llm_check, check, step_output, model_name,
+                    )
                     futures[future] = check
 
                 for future in as_completed(futures):

--- a/backend/app/tasks/activity_tasks.py
+++ b/backend/app/tasks/activity_tasks.py
@@ -248,7 +248,13 @@ def generate_activity_description_task(
             thinking_override=False,
             system_config_doc=sys_cfg,
         )
-        result = chat_agent.run_sync(prompt)
+        # No activity_id: this runs after the activity is finalized, and flush
+        # $sets activity token totals — linking it would clobber the real
+        # workflow/chat/extraction total with the tiny title-gen count. The
+        # ledger still meters it (attributed to the user).
+        from app.services.metering import metered
+        with metered("title_gen", user_id=user_id, team_id=activity.get("team_id")):
+            result = chat_agent.run_sync(prompt)
         description = _clean_title(result.output)
 
         # Truncate to 8 words max; the UI clamps to 2 lines anyway.

--- a/backend/app/tasks/classification_tasks.py
+++ b/backend/app/tasks/classification_tasks.py
@@ -48,7 +48,11 @@ async def _classify(document_uuid: str):
             )
         return
 
-    result = await classify_document(doc)
+    from app.services.metering import metered_async
+    async with metered_async(
+        "classification", user_id=doc.user_id, team_id=doc.team_id
+    ):
+        result = await classify_document(doc)
     await apply_classification(
         doc,
         classification=result["classification"],

--- a/backend/app/tasks/extraction_tasks.py
+++ b/backend/app/tasks/extraction_tasks.py
@@ -143,12 +143,15 @@ def perform_extraction_task(
 
         # Perform extraction
         engine = ExtractionEngine(system_config_doc=sys_cfg)
-        results = engine.extract(
-            keys,
-            document_uuids,
-            model=model_name,
-            extraction_config_override=extraction_config_override,
-        )
+        from app.services.metering import metered
+        team_id = activity.get("team_id") if activity else None
+        with metered("extraction", user_id=user_id, team_id=team_id, activity_id=str(activity_id)):
+            results = engine.extract(
+                keys,
+                document_uuids,
+                model=model_name,
+                extraction_config_override=extraction_config_override,
+            )
         raw_results = deepcopy(results)
 
         result_count = (

--- a/backend/app/tasks/passive_tasks.py
+++ b/backend/app/tasks/passive_tasks.py
@@ -427,7 +427,9 @@ def execute_workflow_passive(self, trigger_event_id: str) -> dict:
             allow_code_execution=wf_is_admin,
         )
 
-        final_output, data = engine.execute()
+        from app.services.metering import metered
+        with metered("workflow_passive", user_id=wf_user_id, team_id=workflow.get("team_id")):
+            final_output, data = engine.execute()
 
         # Update result
         completed_at = datetime.now(timezone.utc)
@@ -908,12 +910,14 @@ def process_extraction_outputs(
                 continue
             try:
                 engine = ExtractionEngine(system_config_doc=sys_config, domain=domain)
-                doc_results = engine.extract(
-                    extract_keys=keys,
-                    full_text=doc["raw_text"],
-                    extraction_config_override=extraction_config,
-                    field_metadata=field_metadata,
-                )
+                from app.services.metering import metered
+                with metered("extraction_passive", user_id=user_id):
+                    doc_results = engine.extract(
+                        extract_keys=keys,
+                        full_text=doc["raw_text"],
+                        extraction_config_override=extraction_config,
+                        field_metadata=field_metadata,
+                    )
                 for entity in doc_results:
                     entity["document_id"] = doc_uuid
                     results.append(entity)

--- a/backend/app/tasks/upload_validation_tasks.py
+++ b/backend/app/tasks/upload_validation_tasks.py
@@ -101,7 +101,9 @@ def validate_chunk(
             f"Compliance Requirements:\n{compliance}\n"
             f"Document Text Chunk:\n{chunk_text}"
         )
-        result = agent.run_sync(prompt)
+        from app.services.metering import metered
+        with metered("upload_validation"):
+            result = agent.run_sync(prompt)
         output = result.output
 
         # Parse structured output or treat as text
@@ -157,14 +159,16 @@ def summarize_results(
     # Summarize via LLM
     try:
         agent = _get_secure_agent()
-        summary_result = agent.run_sync(
-            f"Analyze this validation feedback and return a structured response.\n"
-            f'Validation results: {"PASSED" if all_valid else "FAILED"}\n\n'
-            f"Validation feedback:\n{combined}\n\n"
-            f"Return:\n"
-            f"- valid: {str(all_valid).lower()}\n"
-            f'- feedback: {"Confirm all sections passed validation" if all_valid else "Concise summary of failures and required fixes"}'
-        )
+        from app.services.metering import metered
+        with metered("upload_validation"):
+            summary_result = agent.run_sync(
+                f"Analyze this validation feedback and return a structured response.\n"
+                f'Validation results: {"PASSED" if all_valid else "FAILED"}\n\n'
+                f"Validation feedback:\n{combined}\n\n"
+                f"Return:\n"
+                f"- valid: {str(all_valid).lower()}\n"
+                f'- feedback: {"Confirm all sections passed validation" if all_valid else "Concise summary of failures and required fixes"}'
+            )
         output = summary_result.output
 
         if hasattr(output, "model_dump"):

--- a/backend/app/tasks/workflow_tasks.py
+++ b/backend/app/tasks/workflow_tasks.py
@@ -482,10 +482,17 @@ def execute_workflow_task(self, workflow_result_id, workflow_id, trigger_step_da
             return False
 
     try:
-        final_output, data = engine.execute(
-            workflow_result_updater=update_progress,
-            should_cancel=should_cancel,
-        )
+        from app.services.metering import metered
+        with metered(
+            "workflow",
+            user_id=user_id,
+            team_id=workflow_doc.get("team_id"),
+            activity_id=activity_id,
+        ):
+            final_output, data = engine.execute(
+                workflow_result_updater=update_progress,
+                should_cancel=should_cancel,
+            )
     except WorkflowCancelled:
         logger.info(
             "Workflow %s canceled by user (result %s)", workflow_id, workflow_result_id,
@@ -873,11 +880,21 @@ def resume_workflow_after_approval(self, approval_uuid):
     )
 
     try:
-        final_output, data = engine.execute(
-            workflow_result_updater=update_progress,
-            start_index=step_index + 1,
-            initial_output=initial_output,
+        from app.services.metering import metered
+        _act = db.activity_event.find_one(
+            {"workflow_result": ObjectId(workflow_result_id)}, {"_id": 1}
         )
+        with metered(
+            "workflow",
+            user_id=user_id,
+            team_id=workflow_doc.get("team_id"),
+            activity_id=str(_act["_id"]) if _act else None,
+        ):
+            final_output, data = engine.execute(
+                workflow_result_updater=update_progress,
+                start_index=step_index + 1,
+                initial_output=initial_output,
+            )
     except Exception as e:
         logger.error("Workflow resume failed for %s: %s", workflow_id, e)
         db.workflow_result.update_one(

--- a/backend/tests/test_metering.py
+++ b/backend/tests/test_metering.py
@@ -1,0 +1,238 @@
+"""Unit tests for central LLM token metering (app/services/metering.py +
+MeteredModel in app/services/llm_service.py).
+
+These avoid MongoDB by stubbing the flush sinks and asserting on the in-memory
+MeterScope the wrapper/context-managers produce.
+"""
+
+import pytest
+
+from app.services import metering
+from app.services.llm_service import MeteredModel
+
+
+# ---------------------------------------------------------------------------
+# Fakes for the pydantic-ai Model surface the wrapper touches
+# ---------------------------------------------------------------------------
+class _Usage:
+    def __init__(self, i, o):
+        self.input_tokens = i
+        self.output_tokens = o
+
+
+class _Part:
+    def __init__(self, content):
+        self.content = content
+
+
+class _Resp:
+    def __init__(self, usage, parts):
+        self.usage = usage
+        self.parts = parts
+
+
+class _Msg:
+    def __init__(self, content):
+        self.parts = [_Part(content)]
+
+
+class _FakeModel:
+    """Minimal Model stand-in; MeteredModel delegates model_name/system here."""
+
+    def __init__(self, resp):
+        self._resp = resp
+
+    @property
+    def model_name(self):
+        return "fake-model"
+
+    @property
+    def system(self):
+        return "openai"
+
+    async def request(self, messages, model_settings, model_request_parameters):
+        return self._resp
+
+
+def _metered_model(resp):
+    mm = MeteredModel.__new__(MeteredModel)
+    mm.wrapped = _FakeModel(resp)
+    return mm
+
+
+@pytest.fixture(autouse=True)
+def _capture_flushes(monkeypatch):
+    """Capture flushed scopes instead of writing to Mongo."""
+    flushed = []
+    monkeypatch.setattr(metering, "flush_sync", lambda s: flushed.append(("sync", s)))
+
+    async def _afl(s):
+        flushed.append(("async", s))
+
+    monkeypatch.setattr(metering, "flush_async", _afl)
+    return flushed
+
+
+class _FakeStream:
+    def __init__(self, usage, parts):
+        self._usage = usage
+        self._parts = parts
+
+    def usage(self):
+        return self._usage
+
+    def get(self):
+        return _Resp(self._usage, self._parts)
+
+
+class _StreamingModel:
+    def __init__(self, stream):
+        self._stream = stream
+
+    @property
+    def model_name(self):
+        return "fake-model"
+
+    @property
+    def system(self):
+        return "openai"
+
+    def request_stream(self, messages, model_settings, model_request_parameters, run_context=None):
+        import contextlib
+
+        stream = self._stream
+
+        @contextlib.asynccontextmanager
+        async def _cm():
+            yield stream
+
+        return _cm()
+
+
+async def test_request_stream_records_usage_after_drain():
+    mm = MeteredModel.__new__(MeteredModel)
+    mm.wrapped = _StreamingModel(_FakeStream(_Usage(20, 8), []))
+    with metering.metered("chat") as scope:
+        async with mm.request_stream([], None, None) as s:
+            assert s.usage().input_tokens == 20  # consumer drains here
+    assert (scope.tokens_in, scope.tokens_out, scope.requests) == (20, 8, 1)
+    assert scope.estimated is False
+
+
+# ---------------------------------------------------------------------------
+# Wrapper: exact usage from provider
+# ---------------------------------------------------------------------------
+async def test_request_records_exact_usage():
+    mm = _metered_model(_Resp(_Usage(11, 7), []))
+    with metering.metered("unit") as scope:
+        await mm.request([], None, None)
+    assert (scope.tokens_in, scope.tokens_out, scope.requests) == (11, 7, 1)
+    assert scope.estimated is False
+    assert scope.model == "fake-model"
+
+
+# ---------------------------------------------------------------------------
+# Wrapper: estimate fallback when the provider returns no usage
+# ---------------------------------------------------------------------------
+async def test_request_estimates_when_usage_missing():
+    resp = _Resp(None, [_Part("some output text the model produced")])
+    mm = _metered_model(resp)
+    with metering.metered("unit") as scope:
+        await mm.request([_Msg("a reasonably long input prompt here")], None, None)
+    assert scope.estimated is True
+    assert scope.tokens_in > 0
+    assert scope.tokens_out > 0
+
+
+async def test_request_estimates_when_usage_zero():
+    mm = _metered_model(_Resp(_Usage(0, 0), [_Part("output")]))
+    with metering.metered("unit") as scope:
+        await mm.request([_Msg("input")], None, None)
+    assert scope.estimated is True
+    assert scope.tokens_in + scope.tokens_out > 0
+
+
+# ---------------------------------------------------------------------------
+# Context managers flush exactly once with the accrued totals
+# ---------------------------------------------------------------------------
+def test_metered_flushes_once(_capture_flushes):
+    with metering.metered("feat_a", user_id="u1", team_id="t1", activity_id="a1"):
+        metering.record_usage("m", 3, 4)
+        metering.record_usage("m", 1, 1)
+    assert len(_capture_flushes) == 1
+    kind, scope = _capture_flushes[0]
+    assert kind == "sync"
+    assert (scope.feature, scope.user_id, scope.activity_id) == ("feat_a", "u1", "a1")
+    assert (scope.tokens_in, scope.tokens_out, scope.requests) == (4, 5, 2)
+
+
+async def test_metered_async_flushes_once(_capture_flushes):
+    async with metering.metered_async("feat_b", user_id="u2"):
+        metering.record_usage("m", 10, 2)
+    assert len(_capture_flushes) == 1
+    kind, scope = _capture_flushes[0]
+    assert kind == "async"
+    assert scope.feature == "feat_b"
+    assert scope.tokens_in == 10 and scope.tokens_out == 2
+
+
+# ---------------------------------------------------------------------------
+# Nested scopes: usage accrues to the nearest scope, no double counting
+# ---------------------------------------------------------------------------
+def test_nested_scope_accrues_to_nearest(_capture_flushes):
+    with metering.metered("outer") as outer:
+        metering.record_usage("m", 5, 5)
+        with metering.metered("inner") as inner:
+            metering.record_usage("m", 1, 1)
+        # after inner closes, usage goes back to outer
+        metering.record_usage("m", 2, 2)
+    assert (inner.tokens_in, inner.tokens_out) == (1, 1)
+    assert (outer.tokens_in, outer.tokens_out) == (7, 7)
+    # inner flush, then outer flush
+    assert [k for k, _ in _capture_flushes] == ["sync", "sync"]
+    assert [s.feature for _, s in _capture_flushes] == ["inner", "outer"]
+
+
+# ---------------------------------------------------------------------------
+# Backstop: no scope set -> recorded as unattributed, never lost
+# ---------------------------------------------------------------------------
+def test_backstop_records_unattributed(_capture_flushes):
+    # Ensure no ambient scope
+    assert metering.current_scope() is None
+    metering.record_usage("m", 9, 9)
+    assert len(_capture_flushes) == 1
+    _, scope = _capture_flushes[0]
+    assert scope.feature == metering.UNATTRIBUTED_FEATURE
+    assert (scope.tokens_in, scope.tokens_out) == (9, 9)
+
+
+# ---------------------------------------------------------------------------
+# Estimation helpers
+# ---------------------------------------------------------------------------
+def test_estimate_tokens_nonzero_and_empty():
+    assert metering.estimate_tokens("") == 0
+    assert metering.estimate_tokens("hello world") > 0
+
+
+def test_estimate_messages_and_parts():
+    assert metering.estimate_messages_tokens([_Msg("a longer prompt string")]) > 0
+    assert metering.estimate_parts_tokens([_Part("output content")]) > 0
+    assert metering.estimate_messages_tokens([]) == 0
+
+
+# ---------------------------------------------------------------------------
+# Empty scope (no LLM call) should not flush a row
+# ---------------------------------------------------------------------------
+def test_real_flush_sync_skips_empty_scope(monkeypatch):
+    # Use the real flush_sync but assert it returns early (no DB access) when
+    # nothing was recorded. get_sync_db must NOT be called.
+    called = {"db": False}
+
+    def _boom():
+        called["db"] = True
+        raise AssertionError("should not touch DB for empty scope")
+
+    import app.tasks as tasks_mod
+    monkeypatch.setattr(tasks_mod, "get_sync_db", _boom)
+    metering.flush_sync(metering.MeterScope(feature="empty"))
+    assert called["db"] is False


### PR DESCRIPTION
## Context

Token usage was recorded ad-hoc at only **4 of ~16 LLM surfaces** (workflow runs, async extraction, passive workflows, and chat *only when the provider returned usage*). The other ~12 — UI extractions, classification, validation/evaluation, quality suggestions, chat summarization, upload/compliance validation, prompt rewriting, KB field suggestion, M365 triage, title generation, diagnostics, browser automation — consumed tokens with **zero record**. There was no central ledger and no cost tracking, so per-user usage exports substantially undercounted real cost (the "activity but 0 tokens" trial users).

## What this does

Captures token usage on **100% of LLM calls** at a single chokepoint, stores it in a dedicated append-only ledger attributed to user/team/feature, and never silently records 0 for a real call.

- **Single chokepoint** — every agent is built from `get_agent_model()`, so a `MeteredModel(WrapperModel)` wrapping its output meters everything, including agentic-chat tool sub-calls, RAG's nested prompt agent, and retries. When the gateway omits usage, tokens are estimated via tiktoken and flagged `estimated` — so a real call never records 0.
- **Usage ledger** — new append-only `llm_usage` collection (one row per operation: feature, user, team, model, tokens, `estimated`, linked `activity_id`).
- **Attribution via contextvar** — call sites declare `metered()` / `metered_async()` with a feature tag; usage accrues to the nearest scope and flushes once on exit, writing the ledger row **and** `$set`ting the linked ActivityEvent tokens (which fixes the original chat-streaming / extraction 0-token bug). Any unwrapped site hits an `unattributed` backstop so nothing is lost.
- **~16 call sites wired** with feature tags.

### Two subtleties handled
- **Thread propagation** — workflow and validation run nodes on `ThreadPoolExecutor`, which doesn't copy contextvars; both are patched to `contextvars.copy_context().run(...)` so the scope reaches node threads.
- **Title-gen trap** — it runs *after* its activity is finalized, and the flush does `$set`, so linking it would clobber the real total; it records to the ledger with `activity_id=None`.

## Files
- New: `backend/app/models/llm_usage.py`, `backend/app/services/metering.py`, `backend/tests/test_metering.py`
- `llm_service.py`: `MeteredModel` + `get_agent_model` wraps `_build_agent_model`
- 21 call-site / engine edits

## Out of scope (deferred)
Admin reporting endpoint over `llm_usage` + cost($) computation. The ledger is structured to support both.

## Testing
- `tests/test_metering.py` — 11 tests (exact usage, estimate fallback, streaming-after-drain, single flush, nested-scope no-double-count, unattributed backstop, empty-scope skip). All pass.
- 648 existing backend tests pass (no regressions); `ruff check app/` clean; CI bandit exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)