### PR TITLE
Ground the validation judge in real document text, not UUIDs

### DIFF
--- a/backend/app/services/workflow_service.py
+++ b/backend/app/services/workflow_service.py
@@ -1395,7 +1395,10 @@ async def validate_workflow(workflow_id: str, user: User | None = None) -> dict:
                 for c in plan
             ]
         else:
-            run_checks = await _evaluate_checks_against_output(plan, output_text, wr.steps_output, wf_data)
+            src = await _resolve_run_source_text(wr)
+            run_checks = await _evaluate_checks_against_output(
+                plan, output_text, wr.steps_output, wf_data, source_text_override=src,
+            )
         all_run_checks.append(run_checks)
 
     # Merge multi-run results with consistency tracking
@@ -1446,13 +1449,52 @@ def _serialize_output(final_output: dict | None) -> str | None:
     return str(output_data)[:50_000]
 
 
+async def _resolve_run_source_text(result) -> str:
+    """Resolve a run's ACTUAL source text for the validation judge.
+
+    The ``Document`` trigger step only stores document UUIDs (its output is a
+    list of uuid hex strings), so the judge's legacy steps_output extraction
+    feeds those UUIDs as "ground truth" — the judge then sees opaque hash
+    strings instead of the document and cannot verify grounding. Here we
+    resolve ``input_context.doc_uuids`` to ``SmartDocument.raw_text`` (the same
+    text the workflow itself ran on) and append any KB chunks the run
+    retrieved, so accuracy/completeness checks evaluate against the real
+    source. Returns "" when no source text is recoverable.
+    """
+    parts: list[str] = []
+    ic = getattr(result, "input_context", None) or {}
+    uuids = ic.get("doc_uuids") or [] if isinstance(ic, dict) else []
+    for u in uuids:
+        try:
+            doc = await SmartDocument.find_one(SmartDocument.uuid == u)
+        except Exception:
+            doc = None
+        if doc and getattr(doc, "raw_text", ""):
+            parts.append(doc.raw_text)
+    for s in (getattr(result, "retrieved_sources", None) or []):
+        cp = s.get("content_preview") if isinstance(s, dict) else None
+        if cp:
+            parts.append(str(cp))
+    if not parts:
+        return ""
+    if len(parts) == 1:
+        return parts[0]
+    return "\n\n=== Document ===\n".join(parts)
+
+
 async def _evaluate_checks_against_output(
     plan: list[dict],
     output_text: str,
     steps_output: dict,
     wf_data: dict,
+    source_text_override: str | None = None,
 ) -> list[dict]:
-    """Single LLM call to evaluate all checks against the actual output."""
+    """Single LLM call to evaluate all checks against the actual output.
+
+    When *source_text_override* is provided, it is used as the ground-truth
+    source document text (resolved from the run's uploaded documents) instead
+    of the legacy steps_output scan, which only sees document UUIDs.
+    """
     import json as _json
     from app.services.llm_service import create_chat_agent
     from app.models.system_config import SystemConfig
@@ -1466,7 +1508,16 @@ async def _evaluate_checks_against_output(
     # Extract source document text from steps_output so the evaluator can
     # verify extracted values actually come from the source (not hallucinated).
     source_text = ""
-    if steps_output:
+    if source_text_override is not None:
+        _gt = source_text_override.strip()
+        if _gt:
+            source_text = (
+                "\n\n## Source Document Text (ground truth)\n"
+                "Use this to verify that extracted values actually appear in the "
+                "source document. Values not grounded in this text may be hallucinated.\n"
+                + _gt[:15_000]
+            )
+    elif steps_output:
         for step_name, step_data in steps_output.items():
             # Document / AddDocument steps carry the raw source text
             if step_name.lower() in ("document", "adddocument") or (

--- a/backend/tests/test_workflow_service.py
+++ b/backend/tests/test_workflow_service.py
@@ -814,3 +814,52 @@ class TestParseJsonArray:
         from app.services.workflow_service import _parse_json_array
         result = _parse_json_array("[]")
         assert result == []
+
+
+class TestResolveRunSourceText:
+    """_resolve_run_source_text must turn a run's doc UUIDs into the real
+    SmartDocument.raw_text (the judge's missing ground truth), not leave the
+    judge looking at UUID 'hash strings'."""
+
+    @patch("app.services.workflow_service.SmartDocument")
+    async def test_resolves_doc_uuids_to_raw_text(self, mock_doc_cls):
+        from app.services.workflow_service import _resolve_run_source_text
+        doc1 = MagicMock(raw_text="BLM award total $96,673.48")
+        doc2 = MagicMock(raw_text="second doc text")
+        mock_doc_cls.find_one = AsyncMock(side_effect=[doc1, doc2])
+        result = MagicMock()
+        result.input_context = {"doc_uuids": ["u1", "u2"]}
+        result.retrieved_sources = []
+        out = await _resolve_run_source_text(result)
+        assert "BLM award total $96,673.48" in out
+        assert "second doc text" in out
+
+    @patch("app.services.workflow_service.SmartDocument")
+    async def test_skips_docs_without_raw_text(self, mock_doc_cls):
+        from app.services.workflow_service import _resolve_run_source_text
+        empty = MagicMock(raw_text="")
+        good = MagicMock(raw_text="real text")
+        mock_doc_cls.find_one = AsyncMock(side_effect=[empty, good])
+        result = MagicMock()
+        result.input_context = {"doc_uuids": ["u1", "u2"]}
+        result.retrieved_sources = []
+        out = await _resolve_run_source_text(result)
+        assert out == "real text"
+
+    @patch("app.services.workflow_service.SmartDocument")
+    async def test_includes_kb_retrieved_sources(self, mock_doc_cls):
+        from app.services.workflow_service import _resolve_run_source_text
+        mock_doc_cls.find_one = AsyncMock(return_value=None)
+        result = MagicMock()
+        result.input_context = {"doc_uuids": []}
+        result.retrieved_sources = [{"content_preview": "2 CFR 200 chunk"}]
+        out = await _resolve_run_source_text(result)
+        assert "2 CFR 200 chunk" in out
+
+    async def test_empty_when_no_sources(self):
+        from app.services.workflow_service import _resolve_run_source_text
+        result = MagicMock()
+        result.input_context = {}
+        result.retrieved_sources = []
+        out = await _resolve_run_source_text(result)
+        assert out == ""


### PR DESCRIPTION
## What

Makes the workflow-validation judge evaluate against the **real document text**, not the document **UUIDs**. Fixes accuracy/completeness checks being graded blind for document-driven workflows.

Closes #486.

## Why

`_evaluate_checks_against_output` built its "Source Document Text (ground truth)" by scanning `steps_output` for a `Document`/`AddDocument` step. That step's `output` is a **list of document UUIDs**, so the judge was handed UUID hex strings as the "source" and reported it as *"hash strings"* — then failed every accuracy/grounding and completeness check because the extracted values "don't appear in the source." The two highest-weighted dimensions were effectively noise for all document-driven workflows. See #486 for the live trace.

## Changes (`backend/app/services/workflow_service.py`)

- **`_resolve_run_source_text(result)`** — resolves the run's `input_context.doc_uuids` to `SmartDocument.raw_text` (the same text the workflow ran on; same resolver the engine uses at `workflow_tasks.py:304`) and appends any KB `retrieved_sources` chunk previews. Returns `""` when nothing is recoverable.
- **`_evaluate_checks_against_output(..., source_text_override=None)`** — when an override is provided, it's used as the ground-truth source (capped 15k) instead of the UUID-stringifying `steps_output` scan. The legacy scan remains as a fallback for runs that genuinely carry document text in a step.
- **`validate_workflow`** — resolves per-run source text and passes it via `source_text_override`.

## Verification

Confirmed against a real run's data: its 4 document UUIDs resolve to **75,862 / 22,363 / 6,994 / 5,870** chars of real text the judge previously never saw (it only saw the 4 UUIDs).

## Tests

`TestResolveRunSourceText` (4 cases): UUID→`raw_text` resolution, skipping docs without `raw_text`, including KB `retrieved_sources`, and empty-when-no-sources.

```
cd backend && uv run pytest tests/test_workflow_service.py -q -k ResolveRunSourceText
```

## Notes

- Independent of #480 / #482 / #484 (branched from `main`).
- 15k source cap matches existing behavior; for very long single documents an early value past 15k could still be truncated — a smarter (section-targeted) extraction is a reasonable follow-up.
- This makes the judge reliable; it does not change what a workflow extracts. (E.g., feeding several *different* awards to one run still mixes them — that's a separate test-setup / batch-validation concern.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
