### PR TITLE
Batch validation backend: per-document grading + coverage aggregate

### DIFF
--- a/backend/app/routers/workflows.py
+++ b/backend/app/routers/workflows.py
@@ -1125,6 +1125,7 @@ async def run_workflow(request: Request, workflow_id: str, req: RunWorkflowReque
                 workflow_id, document_uuids, user.user_id, req.model,
                 activity_id=str(activity.id),
                 user=user,
+                sequential=req.sequential,
             )
             return {"batch_id": batch_id, "activity_id": str(activity.id)}
         else:

--- a/backend/app/routers/workflows.py
+++ b/backend/app/routers/workflows.py
@@ -1433,6 +1433,21 @@ async def validate_workflow(workflow_id: str, user: User = Depends(get_current_u
         raise HTTPException(status_code=400, detail=str(e))
 
 
+@router.get("/{workflow_id}/validate-batch")
+async def validate_batch(
+    workflow_id: str,
+    batch_id: str = Query(...),
+    user: User = Depends(get_current_user),
+):
+    """Validate every completed run in a batch independently and return a
+    per-document breakdown plus a coverage aggregate (no cross-document
+    stability)."""
+    try:
+        return await svc.validate_batch(workflow_id, batch_id, user=user)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+
 @router.post("/{workflow_id}/save-expected-output")
 async def save_expected_output(workflow_id: str, request: Request, user: User = Depends(get_current_user)):
     """Mark a completed workflow execution as expected output for validation."""

--- a/backend/app/routers/workflows.py
+++ b/backend/app/routers/workflows.py
@@ -1449,6 +1449,20 @@ async def validate_batch(
         raise HTTPException(status_code=400, detail=str(e))
 
 
+@router.post("/{workflow_id}/validate-runs")
+async def validate_runs(workflow_id: str, request: Request, user: User = Depends(get_current_user)):
+    """Validate a specific set of runs (by session id) independently and return
+    a per-document breakdown plus aggregate. Used by the sequential batch flow."""
+    body = await request.json()
+    session_ids = body.get("session_ids") or []
+    if not isinstance(session_ids, list):
+        raise HTTPException(status_code=400, detail="session_ids must be a list")
+    try:
+        return await svc.validate_runs(workflow_id, [str(s) for s in session_ids], user=user)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+
 @router.post("/{workflow_id}/save-expected-output")
 async def save_expected_output(workflow_id: str, request: Request, user: User = Depends(get_current_user)):
     """Mark a completed workflow execution as expected output for validation."""

--- a/backend/app/schemas/workflows.py
+++ b/backend/app/schemas/workflows.py
@@ -75,6 +75,10 @@ class RunWorkflowRequest(BaseModel):
     document_uuids: list[str]
     model: Optional[str] = None
     batch_mode: bool = False
+    # When batch_mode is on, run the documents one at a time (chained) instead
+    # of concurrently — avoids overwhelming the model with simultaneous
+    # large-context runs (used by batch validation for reliability).
+    sequential: bool = False
 
 
 class WorkflowStatusResponse(BaseModel):

--- a/backend/app/services/workflow_service.py
+++ b/backend/app/services/workflow_service.py
@@ -1395,7 +1395,10 @@ async def validate_workflow(workflow_id: str, user: User | None = None) -> dict:
                 for c in plan
             ]
         else:
-            run_checks = await _evaluate_checks_against_output(plan, output_text, wr.steps_output, wf_data)
+            src = await _resolve_run_source_text(wr)
+            run_checks = await _evaluate_checks_against_output(
+                plan, output_text, wr.steps_output, wf_data, source_text_override=src,
+            )
         all_run_checks.append(run_checks)
 
     # Merge multi-run results with consistency tracking
@@ -1446,13 +1449,52 @@ def _serialize_output(final_output: dict | None) -> str | None:
     return str(output_data)[:50_000]
 
 
+async def _resolve_run_source_text(result) -> str:
+    """Resolve a run's ACTUAL source text for the validation judge.
+
+    The ``Document`` trigger step only stores document UUIDs (its output is a
+    list of uuid hex strings), so the judge's legacy steps_output extraction
+    feeds those UUIDs as "ground truth" — the judge then sees opaque hash
+    strings instead of the document and cannot verify grounding. Here we
+    resolve ``input_context.doc_uuids`` to ``SmartDocument.raw_text`` (the same
+    text the workflow itself ran on) and append any KB chunks the run
+    retrieved, so accuracy/completeness checks evaluate against the real
+    source. Returns "" when no source text is recoverable.
+    """
+    parts: list[str] = []
+    ic = getattr(result, "input_context", None) or {}
+    uuids = ic.get("doc_uuids") or [] if isinstance(ic, dict) else []
+    for u in uuids:
+        try:
+            doc = await SmartDocument.find_one(SmartDocument.uuid == u)
+        except Exception:
+            doc = None
+        if doc and getattr(doc, "raw_text", ""):
+            parts.append(doc.raw_text)
+    for s in (getattr(result, "retrieved_sources", None) or []):
+        cp = s.get("content_preview") if isinstance(s, dict) else None
+        if cp:
+            parts.append(str(cp))
+    if not parts:
+        return ""
+    if len(parts) == 1:
+        return parts[0]
+    return "\n\n=== Document ===\n".join(parts)
+
+
 async def _evaluate_checks_against_output(
     plan: list[dict],
     output_text: str,
     steps_output: dict,
     wf_data: dict,
+    source_text_override: str | None = None,
 ) -> list[dict]:
-    """Single LLM call to evaluate all checks against the actual output."""
+    """Single LLM call to evaluate all checks against the actual output.
+
+    When *source_text_override* is provided, it is used as the ground-truth
+    source document text (resolved from the run's uploaded documents) instead
+    of the legacy steps_output scan, which only sees document UUIDs.
+    """
     import json as _json
     from app.services.llm_service import create_chat_agent
     from app.models.system_config import SystemConfig
@@ -1466,7 +1508,16 @@ async def _evaluate_checks_against_output(
     # Extract source document text from steps_output so the evaluator can
     # verify extracted values actually come from the source (not hallucinated).
     source_text = ""
-    if steps_output:
+    if source_text_override is not None:
+        _gt = source_text_override.strip()
+        if _gt:
+            source_text = (
+                "\n\n## Source Document Text (ground truth)\n"
+                "Use this to verify that extracted values actually appear in the "
+                "source document. Values not grounded in this text may be hallucinated.\n"
+                + _gt[:15_000]
+            )
+    elif steps_output:
         for step_name, step_data in steps_output.items():
             # Document / AddDocument steps carry the raw source text
             if step_name.lower() in ("document", "adddocument") or (

--- a/backend/app/services/workflow_service.py
+++ b/backend/app/services/workflow_service.py
@@ -1922,6 +1922,134 @@ async def _build_result(
 
 
 # ---------------------------------------------------------------------------
+# Batch validation (grade a workflow across a document SET)
+# ---------------------------------------------------------------------------
+
+def _score_check_results(check_results: list[dict], plan: list[dict]) -> tuple[float, str]:
+    """Quality-only score (0-100) + letter grade for one run's check results.
+
+    Weighted by category like _build_result's quality_score, but WITHOUT any
+    cross-document stability term — that term is meaningless across different
+    documents and is what makes the rolling-window validator misgrade batches.
+    """
+    cat_lookup = {c.get("id"): (c.get("category") or "content") for c in (plan or [])}
+    weighted_sum = 0.0
+    weight_total = 0.0
+    for r in check_results:
+        status = r.get("status")
+        if status == "SKIP":
+            continue
+        weight = _CATEGORY_WEIGHTS.get(cat_lookup.get(r.get("check_id"), "content"), 1.0)
+        weighted_sum += {"PASS": 1.0, "WARN": 0.5, "FAIL": 0.0}.get(status, 0.0) * weight
+        weight_total += weight
+    score = (weighted_sum / weight_total * 100) if weight_total > 0 else 0.0
+    score = min(100.0, max(0.0, score))
+    if score >= 90:
+        grade = "A"
+    elif score >= 80:
+        grade = "B"
+    elif score >= 70:
+        grade = "C"
+    elif score >= 60:
+        grade = "D"
+    else:
+        grade = "F"
+    return round(score, 1), grade
+
+
+def _aggregate_batch(documents: list[dict]) -> dict:
+    """Aggregate per-document validation results into a batch summary.
+
+    Coverage metrics (how the workflow does across the SET), not consistency:
+    mean score, grade distribution, count of documents passing every check, the
+    weakest document, and how often each check fails across the set.
+    """
+    if not documents:
+        return {
+            "num_documents": 0, "mean_score": 0.0, "grade_distribution": {},
+            "documents_all_passed": 0, "check_failure_counts": {}, "worst_document": None,
+        }
+    grade_distribution: dict[str, int] = {}
+    check_failure_counts: dict[str, int] = {}
+    for d in documents:
+        grade_distribution[d["grade"]] = grade_distribution.get(d["grade"], 0) + 1
+        for c in d.get("checks", []):
+            if c.get("status") == "FAIL":
+                name = c.get("name", "?")
+                check_failure_counts[name] = check_failure_counts.get(name, 0) + 1
+    mean_score = round(sum(d["score"] for d in documents) / len(documents), 1)
+    worst = min(documents, key=lambda d: d["score"])
+    return {
+        "num_documents": len(documents),
+        "mean_score": mean_score,
+        "grade_distribution": grade_distribution,
+        "documents_all_passed": sum(1 for d in documents if d["num_failed"] == 0),
+        "check_failure_counts": check_failure_counts,
+        "worst_document": {
+            "document_title": worst.get("document_title"),
+            "grade": worst["grade"], "score": worst["score"],
+        },
+    }
+
+
+async def validate_batch(workflow_id: str, batch_id: str, user: User) -> dict:
+    """Validate every completed run in a batch INDEPENDENTLY and aggregate.
+
+    Unlike validate_workflow (which grades the rolling last-3 runs as a single
+    consensus with cross-document stability), this grades each document's run
+    on its own and returns a per-document breakdown plus a coverage aggregate.
+    Each run is grounded in its own source document (see _resolve_run_source_text).
+    """
+    wf = await get_authorized_workflow(workflow_id, user)
+    if not wf:
+        raise ValueError("Workflow not found")
+    plan = wf.validation_plan
+    if not plan:
+        raise ValueError("No validation plan - generate or add checks first")
+
+    runs = await WorkflowResult.find(
+        WorkflowResult.workflow == wf.id,
+        WorkflowResult.batch_id == batch_id,
+        WorkflowResult.status == "completed",
+    ).sort("+_id").to_list()
+    if not runs:
+        raise ValueError(f"No completed runs found for batch {batch_id}")
+
+    wf_data = await get_workflow(workflow_id)
+    documents: list[dict] = []
+    for wr in runs:
+        output_text = _serialize_output(wr.final_output)
+        if output_text is None:
+            checks = [
+                {"check_id": c.get("id"), "name": c.get("name"), "status": "SKIP",
+                 "detail": "Binary output cannot be evaluated as text."}
+                for c in plan
+            ]
+        else:
+            src = await _resolve_run_source_text(wr)
+            checks = await _evaluate_checks_against_output(
+                plan, output_text, wr.steps_output, wf_data, source_text_override=src,
+            )
+        score, grade = _score_check_results(checks, plan)
+        documents.append({
+            "document_title": wr.document_title or wr.session_id,
+            "session_id": wr.session_id,
+            "grade": grade,
+            "score": score,
+            "num_passed": sum(1 for c in checks if c.get("status") == "PASS"),
+            "num_failed": sum(1 for c in checks if c.get("status") == "FAIL"),
+            "checks": checks,
+        })
+
+    return {
+        "batch_id": batch_id,
+        "num_documents": len(documents),
+        "aggregate": _aggregate_batch(documents),
+        "documents": documents,
+    }
+
+
+# ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 

--- a/backend/app/services/workflow_service.py
+++ b/backend/app/services/workflow_service.py
@@ -1925,6 +1925,15 @@ async def _build_result(
 # Batch validation (grade a workflow across a document SET)
 # ---------------------------------------------------------------------------
 
+# Each document's output is judged this many times and the per-check verdict is
+# the majority, with a confidence = fraction of judge runs that agreed. The
+# LLM judge can flip a borderline check between identical calls; re-judging the
+# SAME output stabilizes the displayed verdict and surfaces uncertainty instead
+# of showing a different result each time. (This addresses judge variance only;
+# the workflow's own output can still vary run-to-run — that's a workflow
+# temperature/prompt concern, not a validation one.)
+_BATCH_JUDGE_REPEATS = 2
+
 def _score_check_results(check_results: list[dict], plan: list[dict]) -> tuple[float, str]:
     """Quality-only score (0-100) + letter grade for one run's check results.
 
@@ -2022,14 +2031,21 @@ async def validate_batch(workflow_id: str, batch_id: str, user: User) -> dict:
         if output_text is None:
             checks = [
                 {"check_id": c.get("id"), "name": c.get("name"), "status": "SKIP",
-                 "detail": "Binary output cannot be evaluated as text."}
+                 "detail": "Binary output cannot be evaluated as text.", "consistency": 1.0}
                 for c in plan
             ]
         else:
             src = await _resolve_run_source_text(wr)
-            checks = await _evaluate_checks_against_output(
-                plan, output_text, wr.steps_output, wf_data, source_text_override=src,
-            )
+            # Re-judge the SAME output a few times and take the per-check
+            # majority (consensus) so a borderline check doesn't flip between
+            # runs; _merge_multi_run_checks records a consistency/confidence.
+            judge_runs = [
+                await _evaluate_checks_against_output(
+                    plan, output_text, wr.steps_output, wf_data, source_text_override=src,
+                )
+                for _ in range(max(1, _BATCH_JUDGE_REPEATS))
+            ]
+            checks = _merge_multi_run_checks(plan, judge_runs)
         score, grade = _score_check_results(checks, plan)
         documents.append({
             "document_title": wr.document_title or wr.session_id,
@@ -2039,6 +2055,8 @@ async def validate_batch(workflow_id: str, batch_id: str, user: User) -> dict:
             "num_passed": sum(1 for c in checks if c.get("status") == "PASS"),
             "num_failed": sum(1 for c in checks if c.get("status") == "FAIL"),
             "checks": checks,
+            # Deliverable text, for the per-document downloadable report.
+            "output": (output_text or "")[:20_000],
         })
 
     return {

--- a/backend/app/services/workflow_service.py
+++ b/backend/app/services/workflow_service.py
@@ -1976,7 +1976,8 @@ def _aggregate_batch(documents: list[dict]) -> dict:
     if not documents:
         return {
             "num_documents": 0, "mean_score": 0.0, "grade_distribution": {},
-            "documents_all_passed": 0, "check_failure_counts": {}, "worst_document": None,
+            "documents_all_passed": 0, "documents_errored": 0,
+            "check_failure_counts": {}, "worst_document": None,
         }
     grade_distribution: dict[str, int] = {}
     check_failure_counts: dict[str, int] = {}
@@ -1992,7 +1993,8 @@ def _aggregate_batch(documents: list[dict]) -> dict:
         "num_documents": len(documents),
         "mean_score": mean_score,
         "grade_distribution": grade_distribution,
-        "documents_all_passed": sum(1 for d in documents if d["num_failed"] == 0),
+        "documents_all_passed": sum(1 for d in documents if d["num_failed"] == 0 and not d.get("error")),
+        "documents_errored": sum(1 for d in documents if d.get("error")),
         "check_failure_counts": check_failure_counts,
         "worst_document": {
             "document_title": worst.get("document_title"),
@@ -2019,14 +2021,29 @@ async def validate_batch(workflow_id: str, batch_id: str, user: User) -> dict:
     runs = await WorkflowResult.find(
         WorkflowResult.workflow == wf.id,
         WorkflowResult.batch_id == batch_id,
-        WorkflowResult.status == "completed",
     ).sort("+_id").to_list()
     if not runs:
-        raise ValueError(f"No completed runs found for batch {batch_id}")
+        raise ValueError(f"No runs found for batch {batch_id}")
 
     wf_data = await get_workflow(workflow_id)
     documents: list[dict] = []
     for wr in runs:
+        # A run that errored/was canceled (e.g. the LLM timed out) can't be
+        # graded — surface it as a failed row instead of dropping it, so the
+        # user sees which documents failed and why.
+        if wr.status != "completed":
+            documents.append({
+                "document_title": wr.document_title or wr.session_id,
+                "session_id": wr.session_id,
+                "grade": "ERR",
+                "score": 0.0,
+                "num_passed": 0,
+                "num_failed": 0,
+                "checks": [],
+                "error": wr.error or f"Run did not complete (status: {wr.status}).",
+                "output": "",
+            })
+            continue
         output_text = _serialize_output(wr.final_output)
         if output_text is None:
             checks = [

--- a/backend/app/services/workflow_service.py
+++ b/backend/app/services/workflow_service.py
@@ -653,10 +653,16 @@ async def run_workflow_batch(
     model: str | None = None,
     activity_id: str | None = None,
     user: User | None = None,
+    sequential: bool = False,
 ) -> str:
     """Start a batched workflow execution — one run per document.
 
     Returns a ``batch_id`` that can be polled via ``get_batch_status``.
+
+    When *sequential* is True the per-document executions are chained so they
+    run one at a time instead of concurrently. This avoids hitting the model
+    with many simultaneous large-context runs (which can time out); used by
+    batch validation for reliability at the cost of wall-clock time.
     """
     if user is not None:
         wf = await get_authorized_workflow(workflow_id, user)
@@ -684,6 +690,7 @@ async def run_workflow_batch(
         model = await get_user_model_name(user_id)
 
     batch_id = str(uuid_mod.uuid4())[:8]
+    signatures = []  # used only in sequential mode
 
     for doc_uuid in document_uuids:
         # Look up title for display
@@ -702,19 +709,35 @@ async def run_workflow_batch(
         )
         await result.insert()
 
-        trigger_step_data = {"doc_uuids": [doc_uuid]}
+        task_kwargs = {
+            "workflow_result_id": str(result.id),
+            "workflow_id": str(wf.id),
+            "trigger_step_data": {"doc_uuids": [doc_uuid]},
+            "model": model,
+            "activity_id": activity_id,
+        }
 
-        celery_app.send_task(
-            "tasks.workflow_next.execution",
-            kwargs={
-                "workflow_result_id": str(result.id),
-                "workflow_id": str(wf.id),
-                "trigger_step_data": trigger_step_data,
-                "model": model,
-                "activity_id": activity_id,
-            },
-            queue="workflows",
-        )
+        if sequential:
+            # Immutable signature so the previous task's return value isn't
+            # injected as an arg; collected into a chain below.
+            signatures.append(
+                celery_app.signature(
+                    "tasks.workflow_next.execution",
+                    kwargs=task_kwargs, immutable=True,
+                ).set(queue="workflows")
+            )
+        else:
+            celery_app.send_task(
+                "tasks.workflow_next.execution",
+                kwargs=task_kwargs,
+                queue="workflows",
+            )
+
+    if sequential and signatures:
+        from celery import chain
+        # Runs the documents one after another (each starts when the previous
+        # finishes), so the model isn't hit with concurrent large-context runs.
+        chain(*signatures).apply_async()
 
     return batch_id
 

--- a/backend/app/services/workflow_service.py
+++ b/backend/app/services/workflow_service.py
@@ -2026,13 +2026,58 @@ def _aggregate_batch(documents: list[dict]) -> dict:
     }
 
 
-async def validate_batch(workflow_id: str, batch_id: str, user: User) -> dict:
-    """Validate every completed run in a batch INDEPENDENTLY and aggregate.
+async def _grade_one_run(wr, plan: list[dict], wf_data: dict) -> dict:
+    """Grade a single WorkflowResult into a per-document result dict.
 
-    Unlike validate_workflow (which grades the rolling last-3 runs as a single
-    consensus with cross-document stability), this grades each document's run
-    on its own and returns a per-document breakdown plus a coverage aggregate.
-    Each run is grounded in its own source document (see _resolve_run_source_text).
+    A run that didn't complete (e.g. the LLM timed out) becomes a failed row
+    (grade "ERR" + the error) instead of being dropped, so the user sees which
+    documents failed and why. A completed run is judged with consensus
+    (re-judged a few times, majority + confidence) and grounded in its own
+    source document.
+    """
+    if wr.status != "completed":
+        return {
+            "document_title": wr.document_title or wr.session_id,
+            "session_id": wr.session_id,
+            "grade": "ERR", "score": 0.0, "num_passed": 0, "num_failed": 0,
+            "checks": [],
+            "error": wr.error or f"Run did not complete (status: {wr.status}).",
+            "output": "",
+        }
+    output_text = _serialize_output(wr.final_output)
+    if output_text is None:
+        checks = [
+            {"check_id": c.get("id"), "name": c.get("name"), "status": "SKIP",
+             "detail": "Binary output cannot be evaluated as text.", "consistency": 1.0}
+            for c in plan
+        ]
+    else:
+        src = await _resolve_run_source_text(wr)
+        judge_runs = [
+            await _evaluate_checks_against_output(
+                plan, output_text, wr.steps_output, wf_data, source_text_override=src,
+            )
+            for _ in range(max(1, _BATCH_JUDGE_REPEATS))
+        ]
+        checks = _merge_multi_run_checks(plan, judge_runs)
+    score, grade = _score_check_results(checks, plan)
+    return {
+        "document_title": wr.document_title or wr.session_id,
+        "session_id": wr.session_id,
+        "grade": grade,
+        "score": score,
+        "num_passed": sum(1 for c in checks if c.get("status") == "PASS"),
+        "num_failed": sum(1 for c in checks if c.get("status") == "FAIL"),
+        "checks": checks,
+        "output": (output_text or "")[:20_000],
+    }
+
+
+async def validate_batch(workflow_id: str, batch_id: str, user: User) -> dict:
+    """Validate every run in a batch INDEPENDENTLY and aggregate.
+
+    Grades each document's run on its own (per-document breakdown + coverage
+    aggregate), unlike validate_workflow's rolling-window consensus.
     """
     wf = await get_authorized_workflow(workflow_id, user)
     if not wf:
@@ -2040,67 +2085,50 @@ async def validate_batch(workflow_id: str, batch_id: str, user: User) -> dict:
     plan = wf.validation_plan
     if not plan:
         raise ValueError("No validation plan - generate or add checks first")
-
     runs = await WorkflowResult.find(
         WorkflowResult.workflow == wf.id,
         WorkflowResult.batch_id == batch_id,
     ).sort("+_id").to_list()
     if not runs:
         raise ValueError(f"No runs found for batch {batch_id}")
-
     wf_data = await get_workflow(workflow_id)
-    documents: list[dict] = []
-    for wr in runs:
-        # A run that errored/was canceled (e.g. the LLM timed out) can't be
-        # graded — surface it as a failed row instead of dropping it, so the
-        # user sees which documents failed and why.
-        if wr.status != "completed":
-            documents.append({
-                "document_title": wr.document_title or wr.session_id,
-                "session_id": wr.session_id,
-                "grade": "ERR",
-                "score": 0.0,
-                "num_passed": 0,
-                "num_failed": 0,
-                "checks": [],
-                "error": wr.error or f"Run did not complete (status: {wr.status}).",
-                "output": "",
-            })
-            continue
-        output_text = _serialize_output(wr.final_output)
-        if output_text is None:
-            checks = [
-                {"check_id": c.get("id"), "name": c.get("name"), "status": "SKIP",
-                 "detail": "Binary output cannot be evaluated as text.", "consistency": 1.0}
-                for c in plan
-            ]
-        else:
-            src = await _resolve_run_source_text(wr)
-            # Re-judge the SAME output a few times and take the per-check
-            # majority (consensus) so a borderline check doesn't flip between
-            # runs; _merge_multi_run_checks records a consistency/confidence.
-            judge_runs = [
-                await _evaluate_checks_against_output(
-                    plan, output_text, wr.steps_output, wf_data, source_text_override=src,
-                )
-                for _ in range(max(1, _BATCH_JUDGE_REPEATS))
-            ]
-            checks = _merge_multi_run_checks(plan, judge_runs)
-        score, grade = _score_check_results(checks, plan)
-        documents.append({
-            "document_title": wr.document_title or wr.session_id,
-            "session_id": wr.session_id,
-            "grade": grade,
-            "score": score,
-            "num_passed": sum(1 for c in checks if c.get("status") == "PASS"),
-            "num_failed": sum(1 for c in checks if c.get("status") == "FAIL"),
-            "checks": checks,
-            # Deliverable text, for the per-document downloadable report.
-            "output": (output_text or "")[:20_000],
-        })
-
+    documents = [await _grade_one_run(wr, plan, wf_data) for wr in runs]
     return {
         "batch_id": batch_id,
+        "num_documents": len(documents),
+        "aggregate": _aggregate_batch(documents),
+        "documents": documents,
+    }
+
+
+async def validate_runs(workflow_id: str, session_ids: list[str], user: User) -> dict:
+    """Validate a specific set of runs (by session id) independently and
+    aggregate. Used by the UI's sequential batch flow: each document is run on
+    its own (so one timeout can't abandon the rest), then all are graded here.
+    Order follows *session_ids*; unknown/foreign sessions are skipped.
+    """
+    wf = await get_authorized_workflow(workflow_id, user)
+    if not wf:
+        raise ValueError("Workflow not found")
+    plan = wf.validation_plan
+    if not plan:
+        raise ValueError("No validation plan - generate or add checks first")
+    if not session_ids:
+        raise ValueError("No runs provided")
+
+    found = await WorkflowResult.find(
+        WorkflowResult.workflow == wf.id,
+        {"session_id": {"$in": list(session_ids)}},
+    ).to_list()
+    by_session = {r.session_id: r for r in found}
+    runs = [by_session[s] for s in session_ids if s in by_session]
+    if not runs:
+        raise ValueError("None of the provided runs were found for this workflow")
+
+    wf_data = await get_workflow(workflow_id)
+    documents = [await _grade_one_run(wr, plan, wf_data) for wr in runs]
+    return {
+        "batch_id": None,
         "num_documents": len(documents),
         "aggregate": _aggregate_batch(documents),
         "documents": documents,

--- a/backend/app/services/workflow_service.py
+++ b/backend/app/services/workflow_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import datetime
 import logging
 import uuid as uuid_mod
@@ -2073,6 +2074,26 @@ async def _grade_one_run(wr, plan: list[dict], wf_data: dict) -> dict:
     }
 
 
+# Documents in a batch are graded concurrently (bounded) rather than one at a
+# time. The judge is an in-house LLM that serves concurrent requests via
+# continuous batching, so N documents finish in roughly the time of one or two;
+# the cap keeps us from flooding the GPU queue. Each document still runs its
+# _BATCH_JUDGE_REPEATS judge passes serially, so peak in-flight ~= this cap.
+_BATCH_GRADE_CONCURRENCY = 4
+
+
+async def _grade_runs_concurrently(runs, plan: list[dict], wf_data: dict) -> list[dict]:
+    """Grade WorkflowResults concurrently (bounded by _BATCH_GRADE_CONCURRENCY),
+    preserving input order in the returned list."""
+    sem = asyncio.Semaphore(_BATCH_GRADE_CONCURRENCY)
+
+    async def _one(wr):
+        async with sem:
+            return await _grade_one_run(wr, plan, wf_data)
+
+    return await asyncio.gather(*(_one(wr) for wr in runs))
+
+
 async def validate_batch(workflow_id: str, batch_id: str, user: User) -> dict:
     """Validate every run in a batch INDEPENDENTLY and aggregate.
 
@@ -2092,7 +2113,7 @@ async def validate_batch(workflow_id: str, batch_id: str, user: User) -> dict:
     if not runs:
         raise ValueError(f"No runs found for batch {batch_id}")
     wf_data = await get_workflow(workflow_id)
-    documents = [await _grade_one_run(wr, plan, wf_data) for wr in runs]
+    documents = await _grade_runs_concurrently(runs, plan, wf_data)
     return {
         "batch_id": batch_id,
         "num_documents": len(documents),
@@ -2126,7 +2147,7 @@ async def validate_runs(workflow_id: str, session_ids: list[str], user: User) ->
         raise ValueError("None of the provided runs were found for this workflow")
 
     wf_data = await get_workflow(workflow_id)
-    documents = [await _grade_one_run(wr, plan, wf_data) for wr in runs]
+    documents = await _grade_runs_concurrently(runs, plan, wf_data)
     return {
         "batch_id": None,
         "num_documents": len(documents),

--- a/backend/tests/test_workflow_service.py
+++ b/backend/tests/test_workflow_service.py
@@ -814,3 +814,52 @@ class TestParseJsonArray:
         from app.services.workflow_service import _parse_json_array
         result = _parse_json_array("[]")
         assert result == []
+
+
+class TestResolveRunSourceText:
+    """_resolve_run_source_text must turn a run's doc UUIDs into the real
+    SmartDocument.raw_text (the judge's missing ground truth), not leave the
+    judge looking at UUID 'hash strings'."""
+
+    @patch("app.services.workflow_service.SmartDocument")
+    async def test_resolves_doc_uuids_to_raw_text(self, mock_doc_cls):
+        from app.services.workflow_service import _resolve_run_source_text
+        doc1 = MagicMock(raw_text="BLM award total $96,673.48")
+        doc2 = MagicMock(raw_text="second doc text")
+        mock_doc_cls.find_one = AsyncMock(side_effect=[doc1, doc2])
+        result = MagicMock()
+        result.input_context = {"doc_uuids": ["u1", "u2"]}
+        result.retrieved_sources = []
+        out = await _resolve_run_source_text(result)
+        assert "BLM award total $96,673.48" in out
+        assert "second doc text" in out
+
+    @patch("app.services.workflow_service.SmartDocument")
+    async def test_skips_docs_without_raw_text(self, mock_doc_cls):
+        from app.services.workflow_service import _resolve_run_source_text
+        empty = MagicMock(raw_text="")
+        good = MagicMock(raw_text="real text")
+        mock_doc_cls.find_one = AsyncMock(side_effect=[empty, good])
+        result = MagicMock()
+        result.input_context = {"doc_uuids": ["u1", "u2"]}
+        result.retrieved_sources = []
+        out = await _resolve_run_source_text(result)
+        assert out == "real text"
+
+    @patch("app.services.workflow_service.SmartDocument")
+    async def test_includes_kb_retrieved_sources(self, mock_doc_cls):
+        from app.services.workflow_service import _resolve_run_source_text
+        mock_doc_cls.find_one = AsyncMock(return_value=None)
+        result = MagicMock()
+        result.input_context = {"doc_uuids": []}
+        result.retrieved_sources = [{"content_preview": "2 CFR 200 chunk"}]
+        out = await _resolve_run_source_text(result)
+        assert "2 CFR 200 chunk" in out
+
+    async def test_empty_when_no_sources(self):
+        from app.services.workflow_service import _resolve_run_source_text
+        result = MagicMock()
+        result.input_context = {}
+        result.retrieved_sources = []
+        out = await _resolve_run_source_text(result)
+        assert out == ""

--- a/backend/tests/test_workflow_service.py
+++ b/backend/tests/test_workflow_service.py
@@ -863,3 +863,75 @@ class TestResolveRunSourceText:
         result.retrieved_sources = []
         out = await _resolve_run_source_text(result)
         assert out == ""
+
+
+class TestScoreCheckResults:
+    """_score_check_results: quality-only weighted score + grade, no stability."""
+
+    _PLAN = [
+        {"id": "c1", "category": "completeness"},  # weight 1.5
+        {"id": "c2", "category": "accuracy"},      # weight 1.3
+        {"id": "c3", "category": "formatting"},    # weight 0.7
+    ]
+
+    def test_all_pass_is_A_100(self):
+        from app.services.workflow_service import _score_check_results
+        checks = [{"check_id": "c1", "status": "PASS"}, {"check_id": "c2", "status": "PASS"}, {"check_id": "c3", "status": "PASS"}]
+        score, grade = _score_check_results(checks, self._PLAN)
+        assert score == 100.0 and grade == "A"
+
+    def test_all_fail_is_F_0(self):
+        from app.services.workflow_service import _score_check_results
+        checks = [{"check_id": "c1", "status": "FAIL"}, {"check_id": "c2", "status": "FAIL"}, {"check_id": "c3", "status": "FAIL"}]
+        score, grade = _score_check_results(checks, self._PLAN)
+        assert score == 0.0 and grade == "F"
+
+    def test_weighting_penalizes_high_weight_failure_more(self):
+        from app.services.workflow_service import _score_check_results
+        # Fail the heaviest (completeness 1.5) vs fail the lightest (formatting 0.7)
+        fail_heavy = [{"check_id": "c1", "status": "FAIL"}, {"check_id": "c2", "status": "PASS"}, {"check_id": "c3", "status": "PASS"}]
+        fail_light = [{"check_id": "c1", "status": "PASS"}, {"check_id": "c2", "status": "PASS"}, {"check_id": "c3", "status": "FAIL"}]
+        heavy_score, _ = _score_check_results(fail_heavy, self._PLAN)
+        light_score, _ = _score_check_results(fail_light, self._PLAN)
+        assert heavy_score < light_score
+
+    def test_skip_excluded_from_score(self):
+        from app.services.workflow_service import _score_check_results
+        checks = [{"check_id": "c1", "status": "PASS"}, {"check_id": "c2", "status": "SKIP"}, {"check_id": "c3", "status": "SKIP"}]
+        score, grade = _score_check_results(checks, self._PLAN)
+        assert score == 100.0 and grade == "A"  # only the PASS counts
+
+    def test_no_evaluated_checks_is_zero(self):
+        from app.services.workflow_service import _score_check_results
+        checks = [{"check_id": "c1", "status": "SKIP"}]
+        score, grade = _score_check_results(checks, self._PLAN)
+        assert score == 0.0 and grade == "F"
+
+
+class TestAggregateBatch:
+    """_aggregate_batch: coverage metrics across a document set."""
+
+    def _docs(self):
+        return [
+            {"document_title": "a.pdf", "grade": "A", "score": 95.0, "num_failed": 0,
+             "checks": [{"name": "X", "status": "PASS"}]},
+            {"document_title": "b.pdf", "grade": "F", "score": 40.0, "num_failed": 2,
+             "checks": [{"name": "X", "status": "FAIL"}, {"name": "Y", "status": "FAIL"}]},
+            {"document_title": "c.pdf", "grade": "A", "score": 91.0, "num_failed": 0,
+             "checks": [{"name": "X", "status": "PASS"}]},
+        ]
+
+    def test_aggregate_metrics(self):
+        from app.services.workflow_service import _aggregate_batch
+        agg = _aggregate_batch(self._docs())
+        assert agg["num_documents"] == 3
+        assert agg["mean_score"] == round((95.0 + 40.0 + 91.0) / 3, 1)
+        assert agg["grade_distribution"] == {"A": 2, "F": 1}
+        assert agg["documents_all_passed"] == 2
+        assert agg["check_failure_counts"] == {"X": 1, "Y": 1}
+        assert agg["worst_document"]["document_title"] == "b.pdf"
+
+    def test_empty(self):
+        from app.services.workflow_service import _aggregate_batch
+        agg = _aggregate_batch([])
+        assert agg["num_documents"] == 0 and agg["worst_document"] is None


### PR DESCRIPTION
## What

Adds the **batch-validation backend** — grade a workflow across a *set* of documents with a **per-document** breakdown, instead of the rolling last-3-runs consensus. Backend-first; the Validate-tab UI is a follow-up.

Refs #488.

## Why

`validate_workflow` grades the last ≤3 completed runs as **one consensus** with a **cross-document "stability"** term (`0.6*quality + 0.4*stability`). When those runs are *different* documents that's actively wrong: different docs → low output similarity → "stability" drags the grade down (the persistent "~64% stable"), and the consensus merge **hides which document failed**. See #488 for the full analysis.

## Changes (`backend/app/services/workflow_service.py` + router)

- **`validate_batch(workflow_id, batch_id, user)`** — loads every completed `WorkflowResult` for that `batch_id`, grades each run **independently** (grounded in its own source document via `_resolve_run_source_text` from #487), and returns:
  - `documents[]` — per doc: `{document_title, session_id, grade, score, num_passed, num_failed, checks[]}`
  - `aggregate` — mean score, grade distribution, `documents_all_passed`, `check_failure_counts` (which checks fail most across the set), and the weakest document.
  - **No cross-document stability term.**
- **`_score_check_results(checks, plan)`** — quality-only weighted score + grade (mirrors `_build_result`'s `quality_score` + grade bands; pure/testable).
- **`_aggregate_batch(documents)`** — the coverage aggregate (pure/testable).
- **`GET /workflows/{id}/validate-batch?batch_id=…`**.

Reuses the existing **`run_workflow_batch`** (already creates one `WorkflowResult` per document) as the run primitive — this PR adds only the grading/aggregation layer and `batch_id`-scoped selection (instead of the rolling window).

## Tests

`TestScoreCheckResults` (5): all-pass→A/100, all-fail→F/0, category weighting penalizes heavier-category failures more, SKIP excluded, no-evaluated→0. `TestAggregateBatch` (2): aggregate metrics + empty.

```
cd backend && uv run pytest tests/test_workflow_service.py -q -k "ScoreCheckResults or AggregateBatch"
```

## Dependency / sequencing

**Depends on #487** (judge source-grounding) for per-document accuracy, so this branch is stacked on it — until #487 merges, the diff here includes #487's commit. **Merge #487 first, then rebase this onto `main`.** Also benefits from #480 (schema-tolerant plan) but does not require it (reads the canonical plan like `validate_workflow` does).

## Follow-up (separate PR)

Validate-tab "validate a document set" UI: pick multiple Test Inputs → `run_workflow_batch` → poll → render the per-document grade table + aggregate + a downloadable batch report (extends #483).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
