### PR TITLE
Fix recurring FD-exhaustion: leaked Redis pub/sub socket in browser-automation WebSocket

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -243,6 +243,38 @@ from prometheus_fastapi_instrumentator import Instrumentator  # noqa: E402
 Instrumentator().instrument(app).expose(app, endpoint="/api/metrics")
 
 
+def _fd_usage() -> dict[str, object]:
+    """Report this process's open file-descriptor count and soft limit.
+
+    A steadily climbing ``open_fds`` is the early signal of an fd leak — the
+    kind that has repeatedly surfaced only as a misleading Mongo
+    ``AutoReconnect`` once the table is already exhausted. Surfacing it here
+    lets monitoring alert on the rising line instead of the eventual crash.
+
+    ``open_fds`` is None on platforms without ``/proc`` (e.g. macOS dev); the
+    limit is still read via ``resource``. ``pct`` is the soft-limit usage so a
+    scrape/alert can threshold without re-deriving it.
+    """
+    import os
+    import resource
+
+    open_fds: int | None = None
+    try:
+        open_fds = len(os.listdir("/proc/self/fd"))
+    except OSError:
+        open_fds = None
+
+    limit: int | None = None
+    try:
+        soft, _hard = resource.getrlimit(resource.RLIMIT_NOFILE)
+        limit = soft if soft != resource.RLIM_INFINITY else None
+    except (ValueError, OSError):
+        limit = None
+
+    pct = round(100 * open_fds / limit, 1) if open_fds is not None and limit else None
+    return {"open_fds": open_fds, "fd_limit": limit, "fd_pct": pct}
+
+
 @app.get("/api/health")
 async def health() -> JSONResponse:
     """Health check that verifies all critical dependencies."""
@@ -286,5 +318,9 @@ async def health() -> JSONResponse:
     status_code = 200 if all_ok else 503
     return JSONResponse(
         status_code=status_code,
-        content={"status": "ok" if all_ok else "degraded", "checks": checks},
+        content={
+            "status": "ok" if all_ok else "degraded",
+            "checks": checks,
+            "resources": _fd_usage(),
+        },
     )

--- a/backend/app/routers/browser_automation.py
+++ b/backend/app/routers/browser_automation.py
@@ -4,6 +4,7 @@ Replaces Flask Socket.IO with FastAPI WebSockets.
 """
 
 import asyncio
+import contextlib
 import json
 import logging
 
@@ -165,6 +166,20 @@ async def browser_automation_ws(
     # Background task for forwarding Redis -> WebSocket
     forward_task: asyncio.Task | None = None
 
+    async def _stop_forwarder(task: asyncio.Task | None) -> None:
+        """Cancel the forwarder and wait for its finally-block cleanup to run.
+
+        Awaiting the cancelled task is essential: the task's own ``finally``
+        (pubsub.unsubscribe + r.aclose) is what releases the dedicated Redis
+        pub/sub socket. A bare ``cancel()`` returns before that cleanup runs,
+        leaking one file descriptor per orphaned forwarder.
+        """
+        if task is None:
+            return
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
     async def _forward_redis_to_ws(uid: str):
         """Subscribe to Redis channel and forward messages to WebSocket."""
         import redis.asyncio as aioredis
@@ -184,8 +199,13 @@ async def browser_automation_ws(
         except Exception as e:
             logger.debug("WebSocket pubsub listener ended: %s", e)
         finally:
-            await pubsub.unsubscribe(channel)
-            await r.aclose()
+            # Always release the dedicated pub/sub socket. Guard each await
+            # separately so that if cancellation interrupts the unsubscribe,
+            # the client (and its file descriptor) is still closed.
+            with contextlib.suppress(Exception):
+                await pubsub.aclose()
+            with contextlib.suppress(Exception):
+                await r.aclose()
 
     try:
         while True:
@@ -200,7 +220,10 @@ async def browser_automation_ws(
                 service.register_websocket(user_id, websocket)
                 await websocket.send_json({"type": "auth_ok"})
 
-                # Start background forwarder
+                # Start background forwarder. A client may re-send `auth` on the
+                # same connection; tear down any prior forwarder first so its
+                # Redis pub/sub socket is released instead of being orphaned.
+                await _stop_forwarder(forward_task)
                 forward_task = asyncio.create_task(_forward_redis_to_ws(user_id))
 
             elif msg_type == "response":
@@ -230,5 +253,7 @@ async def browser_automation_ws(
     finally:
         if user_id:
             service.unregister_websocket(user_id)
-        if forward_task:
-            forward_task.cancel()
+        # Await the forwarder's cleanup so its Redis socket is closed before the
+        # handler returns — a bare cancel() leaves the fd to a non-deterministic
+        # cleanup that may never run.
+        await _stop_forwarder(forward_task)

--- a/backend/app/services/extraction_engine.py
+++ b/backend/app/services/extraction_engine.py
@@ -279,20 +279,22 @@ class ExtractionEngine:
             try:
                 import fitz  # pymupdf
 
-                doc = fitz.open(file_path)
-                total_pages = len(doc)
-                render_pages = min(total_pages, MAX_PDF_PAGES_FOR_IMAGES)
-                if total_pages > MAX_PDF_PAGES_FOR_IMAGES:
-                    logger.warning(
-                        "PDF %s has %d pages, capping at %d for image rendering",
-                        file_path, total_pages, MAX_PDF_PAGES_FOR_IMAGES,
-                    )
-                pages: list[BinaryContent] = []
-                for page in doc[:render_pages]:
-                    # 144 DPI (2x zoom) balances quality and memory
-                    pix = page.get_pixmap(matrix=fitz.Matrix(2, 2))
-                    pages.append(BinaryContent(data=pix.tobytes("png"), media_type="image/png"))
-                doc.close()
+                # Context-managed so the document's file handle is released on
+                # every path, including if get_pixmap/tobytes raises mid-render
+                # (a bare close() after the loop leaks the fd on exceptions).
+                with fitz.open(file_path) as doc:
+                    total_pages = len(doc)
+                    render_pages = min(total_pages, MAX_PDF_PAGES_FOR_IMAGES)
+                    if total_pages > MAX_PDF_PAGES_FOR_IMAGES:
+                        logger.warning(
+                            "PDF %s has %d pages, capping at %d for image rendering",
+                            file_path, total_pages, MAX_PDF_PAGES_FOR_IMAGES,
+                        )
+                    pages: list[BinaryContent] = []
+                    for page in doc[:render_pages]:
+                        # 144 DPI (2x zoom) balances quality and memory
+                        pix = page.get_pixmap(matrix=fitz.Matrix(2, 2))
+                        pages.append(BinaryContent(data=pix.tobytes("png"), media_type="image/png"))
                 logger.info("Rendered %d/%d page(s) from %s", render_pages, total_pages, file_path)
                 return pages
             except Exception as e:

--- a/backend/app/services/version_service.py
+++ b/backend/app/services/version_service.py
@@ -133,12 +133,16 @@ async def get_update_status(settings: Settings) -> dict[str, Any]:
     if cached is None:
         cached = await _fetch_latest_release()
         if cached is not None:
+            redis = await _redis_client(settings)
             try:
-                redis = await _redis_client(settings)
                 await redis.set(CACHE_KEY, json.dumps(cached), ex=CACHE_TTL_SECONDS)
-                await redis.aclose()
             except aioredis.RedisError as exc:
                 logger.debug("Update-check cache write failed: %s", exc)
+            finally:
+                # aclose() must run even if set() raises, or the connection
+                # (and its fd) leaks on every RedisError — same leak class as
+                # the WS forwarder, just lower-frequency.
+                await redis.aclose()
 
     if cached is None:
         return {

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -32,6 +32,10 @@ async def test_health_endpoint(client):
     assert "status" in body
     assert body["status"] in ("ok", "degraded")
     assert "checks" in body
+    # fd-usage gauge — surfaces a climbing open-fd count before it crashes the
+    # process as a misleading Mongo AutoReconnect.
+    assert "resources" in body
+    assert set(body["resources"]) == {"open_fds", "fd_limit", "fd_pct"}
 
 
 @pytest.mark.asyncio

--- a/compose.yaml
+++ b/compose.yaml
@@ -79,8 +79,8 @@ services:
       - uploads:/app/static/uploads
     ulimits:
       nofile:
-        soft: 8192
-        hard: 8192
+        soft: 65536
+        hard: 65536
     restart: unless-stopped
     deploy:
       resources:
@@ -111,8 +111,8 @@ services:
       - uploads:/app/static/uploads
     ulimits:
       nofile:
-        soft: 8192
-        hard: 8192
+        soft: 65536
+        hard: 65536
     entrypoint: ["sh", "run_celery.sh", "start"]
     restart: unless-stopped
     deploy:


### PR DESCRIPTION
## Problem

Production keeps crashing with `[Errno 24] Too many open files`, surfacing as a misleading pymongo `AutoReconnect` / `ServerSelectionTimeoutError` on the **healthy** Motor singleton (the victim, not the cause). The same fd-exhaustion event produced **6 Sentry traces** across both deployments on 6/7–6/8, each on a different high-frequency poll that happened to need a Mongo connection once the fd table was full:

| Sentry issue | Box | Transaction |
|---|---|---|
| 7525303362 | `3a4ab738` (uidaho) | /api/feedback/prompts/pending |
| 7524586758 | `3a4ab738` (uidaho) | /api/auth/refresh |
| 7524274548 | `7504468b` (**nkn**) | /api/automations/active |
| 7524578547 | `3a4ab738` (uidaho) | /api/notifications/count |
| 7517108223 | `3a4ab738` (uidaho) | pymongo background monitor (handled log) |

This is the **third recurrence** of the same incident class. The prior two fixes (Mongo health-probe client → singleton; per-call LLM httpx → per-loop cache; per-call Redis → `aclose()`) were correct but addressed *different* leak sources. Sentry groups them all under umbrella issue 7517108223, which is why it keeps reappearing.

## Root cause

`/api/browser-automation/ws` spawns `_forward_redis_to_ws` via `asyncio.create_task`, which opens its **own dedicated** `aioredis` client + `pubsub` — a dedicated TCP socket (one fd), separate from any pool. Two leaks:

1. **Duplicate `auth` (unconditional, steady builder):** a client re-sending `auth` on a live connection reassigned `forward_task` **without cancelling the prior task**. The orphaned task blocks forever on `pubsub.listen()`, so its cleanup `finally` never runs and the socket is pinned until process exit. Chrome MV3 extension service workers recycle/re-auth frequently, so this accumulates over days.
2. **Cancel-without-await on disconnect:** the handler did a bare `forward_task.cancel()` with no `await`, so socket release was non-deterministic; and the cleanup ran `unsubscribe` before `aclose` in one block, so an interrupted `unsubscribe` skipped `aclose`.

Verified this is the **only** fire-and-forget socket-holding path in the web process: one `asyncio.create_task`, one `@router.websocket`, no `BackgroundTasks`, no lifespan polling loop. All per-request client paths were previously audited clean.

## Changes

- **`browser_automation.py`** — `_stop_forwarder()` cancels **and awaits** the task so its cleanup `finally` runs; called before re-creating the forwarder on duplicate `auth` and in the handler's `finally`. Forwarder `finally` now closes `pubsub` + client in **separate** `suppress` blocks so an interrupted close still releases the fd. *(the fix)*
- **`version_service.py`** — move `aclose()` into `finally` so the update-check cache-write doesn't leak a connection on `RedisError` (same leak class, lower frequency).
- **`extraction_engine.py`** — context-manage `fitz.open()` so the PDF handle is released on the render exception path.
- **`main.py` + `test_health.py`** — `/api/health` now reports `open_fds`/`fd_limit`/`fd_pct` so a climbing fd count is visible *before* it crashes the process (Linux containers also already expose `process_open_fds` on `/api/metrics`).
- **`compose.yaml`** — raise api/celery `nofile` 8192 → 65536 (defense-in-depth runway for any future leak; not a fix).

## Testing

- `ruff` clean; `py_compile` clean on all edited modules.
- `tests/test_health.py`, `tests/test_browser_automation_routes.py`, `tests/test_version_service.py` pass.

## Deploy / verify

Deploy to **both** `vandalizer.uidaho.edu` and `vandalizer.nkn.uidaho.edu` (the nkn crash proved the leak isn't box-specific). After deploy, watch `/api/health` → `resources.open_fds` on each box: flat/sawtooth = fixed; still climbing = a source not yet pinned (next suspect would surface on the fd-gauge trend).