### PR TITLE
Replace trial lockout with friendly end-of-trial screen + self-serve …

### DIFF
--- a/backend/app/models/demo.py
+++ b/backend/app/models/demo.py
@@ -29,6 +29,9 @@ class DemoApplication(Document):
     recapture_step: int = 0  # 0=not started, 1-3=sent step N
     recapture_next_at: Optional[datetime.datetime] = None  # when to send next recapture email
 
+    # Self-serve renewals taken from the end-of-trial screen (capped)
+    trial_extensions_used: int = 0
+
     class Settings:
         name = "demo_application"
 

--- a/backend/app/routers/demo.py
+++ b/backend/app/routers/demo.py
@@ -13,6 +13,9 @@ from app.schemas.demo import (
     PostExperienceRequest,
     PostExperienceResponseSchema,
     DemoAdminStatsResponse,
+    TrialEndInfoResponse,
+    TrialExtensionRequest,
+    TrialExtensionResponse,
 )
 from app.services import demo_service
 
@@ -105,6 +108,43 @@ async def submit_feedback(token: str, body: PostExperienceRequest):
         )
     return PostExperienceResponseSchema(
         message="Thank you for your feedback!"
+    )
+
+
+@router.get("/trial-end/{token}", response_model=TrialEndInfoResponse)
+async def trial_end_info(token: str):
+    """Return the data the end-of-trial screen needs (engagement + renewal state)."""
+    info = await demo_service.get_trial_end_info(token)
+    if not info:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Invalid trial token"
+        )
+    return TrialEndInfoResponse(**info)
+
+
+@router.post("/trial-end/{token}/extend", response_model=TrialExtensionResponse)
+async def extend_trial(
+    token: str,
+    body: TrialExtensionRequest,
+    settings: Settings = Depends(get_settings),
+):
+    """Self-serve trial renewal from the end-of-trial screen (+14 days)."""
+    result = await demo_service.self_extend_trial(token, body.notes, settings)
+    if not result.get("ok"):
+        reason = result.get("reason")
+        if reason == "cap_reached":
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="You've reached the self-serve renewal limit. "
+                "Get in touch and we'll keep your access going.",
+            )
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Invalid trial token"
+        )
+    return TrialExtensionResponse(
+        ok=True,
+        message="Your trial has been extended. Welcome back!",
+        expires_at=result.get("expires_at"),
     )
 
 

--- a/backend/app/schemas/demo.py
+++ b/backend/app/schemas/demo.py
@@ -31,6 +31,26 @@ class PostExperienceResponseSchema(BaseModel):
     message: str
 
 
+class TrialEndInfoResponse(BaseModel):
+    name: str
+    organization: str
+    engagement: str  # "low" | "engaged"
+    extensions_used: int
+    max_extensions: int
+    can_self_extend: bool
+    already_extended: bool
+
+
+class TrialExtensionRequest(BaseModel):
+    notes: Optional[dict] = None
+
+
+class TrialExtensionResponse(BaseModel):
+    ok: bool
+    message: str
+    expires_at: Optional[str] = None
+
+
 class DemoApplicationResponse(BaseModel):
     uuid: str
     name: str

--- a/backend/app/services/demo_service.py
+++ b/backend/app/services/demo_service.py
@@ -7,10 +7,13 @@ from typing import Optional
 
 
 from app.config import Settings
+from app.models.chat import ChatConversation
 from app.models.demo import DemoApplication, PostExperienceResponse
+from app.models.document import SmartDocument
 from app.models.email_log import EmailLog
 from app.models.team import Team, TeamMembership
 from app.models.user import User
+from app.models.workflow import Workflow, WorkflowResult
 from app.services.email_service import (
     send_email,
     test_email,
@@ -18,6 +21,7 @@ from app.services.email_service import (
     activation_email,
     expiry_warning_email,
     trial_expired_email,
+    trial_extended_email,
     recapture_email,
 )
 from app.utils.security import hash_password
@@ -28,6 +32,13 @@ logger = logging.getLogger(__name__)
 MAX_ACTIVE_DEMOS = 50
 MAX_PER_ORGANIZATION = 5
 TRIAL_DAYS = 14
+
+# Self-serve renewal from the end-of-trial screen
+MAX_SELF_EXTENSIONS = 2
+# A trial user who logged in but produced fewer than this many meaningful
+# artifacts (documents + workflow runs + chats) "didn't really get a chance to
+# try it" — the end screen offers them a frictionless one-click extension.
+LOW_ENGAGEMENT_MAX_ARTIFACTS = 3
 
 MAGIC_LINK_TTL_SECONDS = 48 * 60 * 60
 
@@ -290,9 +301,9 @@ async def check_expirations(settings: Settings | None = None) -> int:
                 user.demo_status = "locked"
                 await user.save()
 
-        # Send feedback email
-        feedback_url = f"{settings.frontend_url}/demo/feedback?token={app.post_questionnaire_token}"
-        subject, html = trial_expired_email(app.name, feedback_url)
+        # Send the friendly end-of-trial email pointing at the renew/feedback screen
+        trial_end_url = f"{settings.frontend_url}/demo/trial-end?token={app.post_questionnaire_token}"
+        subject, html = trial_expired_email(app.name, trial_end_url)
         await send_email(app.email, subject, html, settings, email_type="trial_expired")
         count += 1
 
@@ -467,6 +478,8 @@ async def admin_restart_trial(demo_uuid: str) -> bool:
     app.expired_at = None
     app.recapture_step = 0
     app.recapture_next_at = now + datetime.timedelta(days=_RECAPTURE_SCHEDULE_DAYS[0])
+    # Admin restart restores a fresh self-serve renewal runway.
+    app.trial_extensions_used = 0
     await app.save()
 
     if app.user_id:
@@ -477,6 +490,119 @@ async def admin_restart_trial(demo_uuid: str) -> bool:
             await user.save()
 
     return True
+
+
+async def compute_trial_engagement(user_id: str | None) -> str:
+    """Classify how much a trial user actually used the product.
+
+    Returns "low" if they never logged in or produced fewer than
+    LOW_ENGAGEMENT_MAX_ARTIFACTS meaningful artifacts (documents + workflow runs
+    + chats with messages), else "engaged".
+    """
+    if not user_id:
+        return "low"
+
+    user = await User.find_one(User.user_id == user_id)
+    if not user or user.last_login_at is None:
+        return "low"
+
+    docs = await SmartDocument.find(SmartDocument.user_id == user_id).count()
+
+    workflows = await Workflow.find(Workflow.user_id == user_id).to_list()
+    workflow_ids = [w.id for w in workflows]
+    runs = (
+        await WorkflowResult.find({"workflow": {"$in": workflow_ids}}).count()
+        if workflow_ids
+        else 0
+    )
+
+    chats = await ChatConversation.find(
+        {"user_id": user_id, "messages": {"$ne": []}}
+    ).count()
+
+    total = docs + runs + chats
+    return "low" if total < LOW_ENGAGEMENT_MAX_ARTIFACTS else "engaged"
+
+
+async def get_trial_end_info(token: str) -> Optional[dict]:
+    """Validate an end-of-trial token and return the data the screen needs."""
+    app = await DemoApplication.find_one(
+        DemoApplication.post_questionnaire_token == token
+    )
+    if not app:
+        return None
+
+    engagement = await compute_trial_engagement(app.user_id)
+    return {
+        "name": app.name,
+        "organization": app.organization,
+        "engagement": engagement,
+        "extensions_used": app.trial_extensions_used,
+        "max_extensions": MAX_SELF_EXTENSIONS,
+        "can_self_extend": app.trial_extensions_used < MAX_SELF_EXTENSIONS,
+        "already_extended": app.trial_extensions_used > 0,
+    }
+
+
+async def self_extend_trial(
+    token: str, notes: dict | None = None, settings: Settings | None = None
+) -> dict:
+    """Self-serve trial renewal from the end-of-trial screen.
+
+    Extends the trial by TRIAL_DAYS and unlocks the account, up to
+    MAX_SELF_EXTENSIONS times. Optional post-trial notes are persisted as a
+    PostExperienceResponse. Returns {"ok": bool, ...}.
+    """
+    if settings is None:
+        settings = Settings()
+
+    app = await DemoApplication.find_one(
+        DemoApplication.post_questionnaire_token == token
+    )
+    if not app:
+        return {"ok": False, "reason": "invalid"}
+
+    if app.trial_extensions_used >= MAX_SELF_EXTENSIONS:
+        return {"ok": False, "reason": "cap_reached"}
+
+    # Persist any post-trial notes the user left (reuses the feedback model).
+    if notes:
+        await PostExperienceResponse(
+            uuid=secrets.token_urlsafe(12),
+            demo_application_id=app.id,
+            responses={"kind": "renewal_notes", **notes},
+            created_at=datetime.datetime.now(datetime.timezone.utc),
+        ).insert()
+
+    now = datetime.datetime.now(datetime.timezone.utc)
+    new_expires = now + datetime.timedelta(days=TRIAL_DAYS)
+
+    app.status = "active"
+    app.expires_at = new_expires
+    app.expired_at = None
+    app.trial_extensions_used += 1
+    app.recapture_step = 0
+    app.recapture_next_at = now + datetime.timedelta(days=_RECAPTURE_SCHEDULE_DAYS[0])
+    await app.save()
+
+    if app.user_id:
+        user = await User.find_one(User.user_id == app.user_id)
+        if user:
+            user.demo_status = "active"
+            user.demo_expires_at = new_expires
+            await user.save()
+
+    # Confirmation email
+    expires_str = new_expires.strftime("%B %d, %Y")
+    subject, html = trial_extended_email(app.name, expires_str, settings.frontend_url)
+    await send_email(app.email, subject, html, settings, email_type="trial_extended")
+
+    logger.info(
+        "Self-serve trial extension for %s (#%d)",
+        app.email,
+        app.trial_extensions_used,
+    )
+    return {"ok": True, "expires_at": new_expires.isoformat()}
 
 
 async def admin_add_demo_user(

--- a/backend/app/services/email_service.py
+++ b/backend/app/services/email_service.py
@@ -260,17 +260,43 @@ def expiry_warning_email(name: str, days_left: int, expires_at: str, frontend_ur
     return subject, html
 
 
-def trial_expired_email(name: str, feedback_url: str) -> tuple[str, str]:
-    """Returns (subject, html_body) for trial expired notification."""
-    subject = "Your Vandalizer Demo Has Ended"
+def trial_expired_email(name: str, trial_end_url: str) -> tuple[str, str]:
+    """Returns (subject, html_body) for the friendly end-of-trial notification.
+
+    Links to the end-of-trial screen, where the user can pick up where they left
+    off (self-serve renewal) or tell us what to build next.
+    """
+    subject = "Your Vandalizer trial — pick up where you left off"
     html = f"""<!DOCTYPE html><html><head>{_BASE_STYLE}</head><body>
     <div class="container"><div class="card">
       <div class="logo">Vandalizer</div>
-      <h1>Thank you for trying Vandalizer!</h1>
-      <p>Hi {name}, your 2-week demo trial has ended. We hope you found the platform valuable.</p>
-      <p>We'd love to hear about your experience. Please take a few minutes to fill out our feedback questionnaire:</p>
-      <p style="margin-top:24px"><a class="btn" href="{feedback_url}">Share Your Feedback</a></p>
-      <p>Your feedback helps us improve Vandalizer for future users and researchers.</p>
+      <h1>Your trial wrapped up — but you don't have to stop here</h1>
+      <p>Hi {name}, your two weeks with Vandalizer are up. Vandalizer is an
+         evolving beta built for research offices, and the feedback from trial
+         users like you is actively shaping where it goes next.</p>
+      <p>Want more time? You can pick up right where you left off, or tell us
+         what would make Vandalizer more useful for your office — either way,
+         we'll keep your access going.</p>
+      <p style="margin-top:24px"><a class="btn" href="{trial_end_url}">Keep going &amp; share your thoughts</a></p>
+      <p>Trial access continues as new releases come out. Thanks for helping
+         build it.</p>
+      <div class="footer">Vandalizer</div>
+    </div></div></body></html>"""
+    return subject, html
+
+
+def trial_extended_email(name: str, expires_at: str, frontend_url: str) -> tuple[str, str]:
+    """Returns (subject, html_body) confirming a self-serve trial renewal."""
+    subject = "Your Vandalizer trial is extended"
+    html = f"""<!DOCTYPE html><html><head>{_BASE_STYLE}</head><body>
+    <div class="container"><div class="card">
+      <div class="logo">Vandalizer</div>
+      <h1>You're back in — welcome!</h1>
+      <p>Hi {name}, your Vandalizer trial has been extended. You now have access
+         through <span class="highlight">{expires_at}</span>.</p>
+      <p>Thanks for helping shape the product. As new releases land, you'll see
+         them here first.</p>
+      <p style="margin-top:24px"><a class="btn" href="{frontend_url}/login">Back to Vandalizer</a></p>
       <div class="footer">Vandalizer</div>
     </div></div></body></html>"""
     return subject, html

--- a/backend/tests/integration/test_tier2_services.py
+++ b/backend/tests/integration/test_tier2_services.py
@@ -409,3 +409,155 @@ class TestAuthConfigRouteWithRealDB:
         data = resp.json()
         assert "auth_methods" in data
         assert "local" in data["auth_methods"]
+
+
+# ---------------------------------------------------------------------------
+# demo_service trial extension — engagement classification + self-serve renewal
+# (counts/queries across Beanie models; needs Tier 2).
+# ---------------------------------------------------------------------------
+
+class TestTrialExtensionWithRealDB:
+    async def _make_locked_trial(self, suffix: str, *, extensions_used: int = 0):
+        """Create a locked demo application + user, return (app, user)."""
+        from app.models.demo import DemoApplication
+        from app.models.user import User
+
+        uid = f"trial_{suffix}@example.com"
+        past = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=1)
+        user = User(
+            user_id=uid,
+            email=uid,
+            name=f"Trial {suffix}",
+            is_demo_user=True,
+            demo_status="locked",
+            demo_expires_at=past,
+        )
+        await user.insert()
+        app = DemoApplication(
+            uuid=f"app_{suffix}",
+            name=f"Trial {suffix}",
+            email=uid,
+            organization="Test Org",
+            status="expired",
+            user_id=uid,
+            expires_at=past,
+            expired_at=past,
+            post_questionnaire_token=f"tok_{suffix}",
+            trial_extensions_used=extensions_used,
+        )
+        await app.insert()
+        return app, user
+
+    async def test_engagement_low_when_never_logged_in(self, mongo_client):
+        from app.services.demo_service import compute_trial_engagement
+
+        _app, _user = await self._make_locked_trial("nologin")
+        # last_login_at defaults to None
+        assert await compute_trial_engagement("trial_nologin@example.com") == "low"
+
+    async def test_engagement_low_with_few_artifacts(self, mongo_client):
+        from app.models.document import SmartDocument
+        from app.models.user import User
+        from app.services.demo_service import compute_trial_engagement
+
+        _app, user = await self._make_locked_trial("fewdocs")
+        user.last_login_at = datetime.datetime.now(datetime.timezone.utc)
+        await user.save()
+        # 2 docs is below the LOW_ENGAGEMENT_MAX_ARTIFACTS=3 threshold
+        for i in range(2):
+            await SmartDocument(
+                path="p", downloadpath="d", title=f"doc{i}",
+                uuid=f"fewdocs_doc_{i}", user_id=user.user_id,
+            ).insert()
+        assert await compute_trial_engagement(user.user_id) == "low"
+
+    async def test_engagement_engaged_at_threshold(self, mongo_client):
+        from app.models.document import SmartDocument
+        from app.models.user import User
+        from app.services.demo_service import compute_trial_engagement
+
+        _app, user = await self._make_locked_trial("engaged")
+        user.last_login_at = datetime.datetime.now(datetime.timezone.utc)
+        await user.save()
+        for i in range(3):
+            await SmartDocument(
+                path="p", downloadpath="d", title=f"doc{i}",
+                uuid=f"engaged_doc_{i}", user_id=user.user_id,
+            ).insert()
+        assert await compute_trial_engagement(user.user_id) == "engaged"
+
+    async def test_self_extend_unlocks_and_extends(self, mongo_client):
+        from app.config import Settings
+        from app.models.demo import DemoApplication
+        from app.models.user import User
+        from app.services import demo_service
+
+        app, _user = await self._make_locked_trial("extend")
+        with patch.object(demo_service, "send_email", new_callable=AsyncMock):
+            result = await demo_service.self_extend_trial(
+                "tok_extend", None, Settings()
+            )
+
+        assert result["ok"] is True
+        refreshed_app = await DemoApplication.find_one(DemoApplication.uuid == app.uuid)
+        refreshed_user = await User.find_one(User.user_id == "trial_extend@example.com")
+        assert refreshed_app.status == "active"
+        assert refreshed_app.trial_extensions_used == 1
+        assert refreshed_user.demo_status == "active"
+        now = datetime.datetime.now(datetime.timezone.utc)
+        # New expiry is ~14 days out
+        assert refreshed_app.expires_at.replace(tzinfo=datetime.timezone.utc) > now + datetime.timedelta(days=13)
+
+    async def test_self_extend_blocked_at_cap(self, mongo_client):
+        from app.config import Settings
+        from app.models.user import User
+        from app.services import demo_service
+
+        await self._make_locked_trial("capped", extensions_used=2)
+        with patch.object(demo_service, "send_email", new_callable=AsyncMock):
+            result = await demo_service.self_extend_trial(
+                "tok_capped", None, Settings()
+            )
+
+        assert result["ok"] is False
+        assert result["reason"] == "cap_reached"
+        # User stays locked
+        refreshed_user = await User.find_one(User.user_id == "trial_capped@example.com")
+        assert refreshed_user.demo_status == "locked"
+
+    async def test_self_extend_persists_notes(self, mongo_client):
+        from app.config import Settings
+        from app.models.demo import DemoApplication, PostExperienceResponse
+        from app.services import demo_service
+
+        app, _user = await self._make_locked_trial("notes")
+        with patch.object(demo_service, "send_email", new_callable=AsyncMock):
+            await demo_service.self_extend_trial(
+                "tok_notes", {"using_for": "grants"}, Settings()
+            )
+
+        stored = await DemoApplication.find_one(DemoApplication.uuid == app.uuid)
+        responses = await PostExperienceResponse.find(
+            PostExperienceResponse.demo_application_id == stored.id
+        ).to_list()
+        assert len(responses) == 1
+        assert responses[0].responses["kind"] == "renewal_notes"
+        assert responses[0].responses["using_for"] == "grants"
+
+    async def test_get_trial_end_info(self, mongo_client):
+        from app.services.demo_service import get_trial_end_info
+
+        await self._make_locked_trial("info", extensions_used=1)
+        info = await get_trial_end_info("tok_info")
+        assert info is not None
+        assert info["name"] == "Trial info"
+        assert info["extensions_used"] == 1
+        assert info["max_extensions"] == 2
+        assert info["can_self_extend"] is True
+        assert info["already_extended"] is True
+        assert info["engagement"] == "low"
+
+    async def test_get_trial_end_info_invalid_token(self, mongo_client):
+        from app.services.demo_service import get_trial_end_info
+
+        assert await get_trial_end_info("does_not_exist") is None

--- a/frontend/src/api/demo.ts
+++ b/frontend/src/api/demo.ts
@@ -4,6 +4,8 @@ import type {
   DemoSignupResponse,
   WaitlistStatusResponse,
   FeedbackInfo,
+  TrialEndInfo,
+  TrialExtensionResult,
   DemoAdminStats,
   DemoApplication,
   PostExperienceResponseAdmin,
@@ -38,6 +40,17 @@ export function submitPostQuestionnaire(token: string, responses: Record<string,
   return apiFetch<{ message: string }>(`/api/demo/feedback/${token}`, {
     method: 'POST',
     body: JSON.stringify({ responses }),
+  })
+}
+
+export function getTrialEndInfo(token: string) {
+  return apiFetch<TrialEndInfo>(`/api/demo/trial-end/${token}`)
+}
+
+export function requestTrialExtension(token: string, notes?: Record<string, unknown>) {
+  return apiFetch<TrialExtensionResult>(`/api/demo/trial-end/${token}/extend`, {
+    method: 'POST',
+    body: JSON.stringify({ notes: notes ?? null }),
   })
 }
 

--- a/frontend/src/components/survey/renewalNotesFields.ts
+++ b/frontend/src/components/survey/renewalNotesFields.ts
@@ -1,0 +1,31 @@
+import type { SurveyField } from '../../types/demo'
+
+// Short, low-friction notes collected from engaged trial users in exchange for
+// another two weeks. Kept deliberately brief — the goal is a quick signal on
+// what to build next, not a full post-experience survey.
+export const RENEWAL_NOTES_FIELDS: SurveyField[] = [
+  {
+    key: 'using_for',
+    label: 'What are you using Vandalizer for?',
+    type: 'textarea',
+    required: true,
+    section: 'Quick notes',
+    placeholder: 'e.g. extracting deadlines and budgets from NIH grant announcements',
+  },
+  {
+    key: 'would_make_useful',
+    label: 'What would make Vandalizer more useful for your office?',
+    type: 'textarea',
+    required: true,
+    section: 'Quick notes',
+    placeholder: 'The one thing that would make this a no-brainer to keep using',
+  },
+  {
+    key: 'anything_blocking',
+    label: 'Anything getting in your way? (optional)',
+    type: 'textarea',
+    required: false,
+    section: 'Quick notes',
+    placeholder: 'Bugs, confusing bits, missing features…',
+  },
+]

--- a/frontend/src/pages/DemoTrialEnd.test.tsx
+++ b/frontend/src/pages/DemoTrialEnd.test.tsx
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import DemoTrialEnd from './DemoTrialEnd'
+import type { TrialEndInfo } from '../types/demo'
+
+const mockGetTrialEndInfo = vi.fn()
+const mockRequestTrialExtension = vi.fn()
+const mockRefreshUser = vi.fn()
+const mockNavigate = vi.fn()
+
+vi.mock('@tanstack/react-router', () => ({
+  useSearch: () => ({ token: 'tok123' }),
+  useNavigate: () => mockNavigate,
+  Link: ({ children, ...props }: { children: React.ReactNode; to?: string }) => <a {...props}>{children}</a>,
+}))
+
+vi.mock('../hooks/useAuth', () => ({
+  useAuth: () => ({ refreshUser: mockRefreshUser }),
+}))
+
+vi.mock('../api/demo', () => ({
+  getTrialEndInfo: (token: string) => mockGetTrialEndInfo(token),
+  requestTrialExtension: (token: string, notes?: Record<string, unknown>) =>
+    mockRequestTrialExtension(token, notes),
+}))
+
+vi.mock('../components/layout/Footer', () => ({ Footer: () => <footer /> }))
+
+function info(overrides: Partial<TrialEndInfo> = {}): TrialEndInfo {
+  return {
+    name: 'Sam',
+    organization: 'Test Org',
+    engagement: 'low',
+    extensions_used: 0,
+    max_extensions: 2,
+    can_self_extend: true,
+    already_extended: false,
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  mockGetTrialEndInfo.mockReset()
+  mockRequestTrialExtension.mockReset()
+  mockRefreshUser.mockReset()
+  mockNavigate.mockReset()
+})
+
+describe('DemoTrialEnd', () => {
+  it('low-engagement: shows one-click renewal and extends on click', async () => {
+    mockGetTrialEndInfo.mockResolvedValueOnce(info({ engagement: 'low' }))
+    mockRequestTrialExtension.mockResolvedValueOnce({ ok: true, message: 'ok', expires_at: null })
+
+    render(<DemoTrialEnd />)
+
+    const btn = await screen.findByRole('button', { name: /keep my trial going/i })
+    fireEvent.click(btn)
+
+    await waitFor(() => expect(mockRequestTrialExtension).toHaveBeenCalledWith('tok123', undefined))
+    expect(await screen.findByText(/you're back in/i)).toBeInTheDocument()
+  })
+
+  it('engaged: shows the notes form, not the one-click button', async () => {
+    mockGetTrialEndInfo.mockResolvedValueOnce(info({ engagement: 'engaged' }))
+
+    render(<DemoTrialEnd />)
+
+    expect(await screen.findByText(/tell us a little about how it's going/i)).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /keep my trial going/i })).not.toBeInTheDocument()
+  })
+
+  it('cap reached: shows the contact CTA instead of a renew option', async () => {
+    mockGetTrialEndInfo.mockResolvedValueOnce(
+      info({ can_self_extend: false, extensions_used: 2, already_extended: true }),
+    )
+
+    render(<DemoTrialEnd />)
+
+    expect(await screen.findByText(/let's keep this going/i)).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /get in touch/i })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /keep my trial going/i })).not.toBeInTheDocument()
+  })
+
+  it('invalid token: shows an error state', async () => {
+    mockGetTrialEndInfo.mockRejectedValueOnce(new Error('nope'))
+
+    render(<DemoTrialEnd />)
+
+    expect(await screen.findByText(/invalid link/i)).toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/DemoTrialEnd.tsx
+++ b/frontend/src/pages/DemoTrialEnd.tsx
@@ -1,0 +1,266 @@
+import { useState, useEffect } from 'react'
+import { Link, useSearch, useNavigate } from '@tanstack/react-router'
+import {
+  Sparkles,
+  CheckCircle,
+  Loader2,
+  ArrowLeft,
+  ArrowRight,
+  ExternalLink,
+  AlertCircle,
+  Mail,
+  Rocket,
+} from 'lucide-react'
+import { Footer } from '../components/layout/Footer'
+import { useAuth } from '../hooks/useAuth'
+import { getTrialEndInfo, requestTrialExtension } from '../api/demo'
+import { SurveyFieldRenderer } from '../components/survey/SurveyFieldRenderer'
+import { SurveyWizard } from '../components/survey/SurveyWizard'
+import { RENEWAL_NOTES_FIELDS } from '../components/survey/renewalNotesFields'
+import { groupBySection } from '../lib/survey'
+import type { TrialEndInfo } from '../types/demo'
+
+// ---------------------------------------------------------------------------
+// End-of-trial screen — friendly renewal + beta positioning. Replaces the hard
+// lockout dead-end. Token-authenticated (the lock token), no session required.
+// ---------------------------------------------------------------------------
+
+// Matches the Landing page's "Get in Touch" convention (no public support inbox).
+const CONTACT_URL = 'https://github.com/ui-insight/vandalizer/issues'
+
+export default function DemoTrialEnd() {
+  const search = useSearch({ strict: false }) as Record<string, string | undefined>
+  const token = search?.token || ''
+  const navigate = useNavigate()
+  const { refreshUser } = useAuth()
+
+  const [info, setInfo] = useState<TrialEndInfo | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+  const [extended, setExtended] = useState(false)
+  const [answers, setAnswers] = useState<Record<string, unknown>>({})
+
+  useEffect(() => {
+    if (!token) {
+      setError('No trial token provided.')
+      setLoading(false)
+      return
+    }
+    getTrialEndInfo(token)
+      .then(setInfo)
+      .catch(() => setError('This link is invalid or has expired.'))
+      .finally(() => setLoading(false))
+  }, [token])
+
+  function updateAnswer(key: string, value: unknown) {
+    setAnswers((prev) => ({ ...prev, [key]: value }))
+  }
+
+  async function handleExtend(notes?: Record<string, unknown>) {
+    setError('')
+    setSubmitting(true)
+    try {
+      await requestTrialExtension(token, notes)
+      setExtended(true)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Could not extend your trial.')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  async function enterApp() {
+    await refreshUser()
+    navigate({
+      to: '/',
+      search: {
+        mode: undefined,
+        tab: undefined,
+        workflow: undefined,
+        extraction: undefined,
+        automation: undefined,
+        kb: undefined,
+        workflow_share_token: undefined,
+      },
+    })
+  }
+
+  const sections = groupBySection(RENEWAL_NOTES_FIELDS)
+  const steps = sections.map((sec) => ({
+    title: sec.name,
+    content: (
+      <>
+        {sec.fields.map((field) => (
+          <div key={field.key}>
+            {field.type !== 'info' && (
+              <label className="block text-sm font-medium text-gray-300 mb-2">
+                {field.label}
+                {field.required ? ' *' : ''}
+              </label>
+            )}
+            <SurveyFieldRenderer field={field} value={answers[field.key]} onChange={updateAnswer} />
+          </div>
+        ))}
+      </>
+    ),
+  }))
+
+  return (
+    <div className="bg-[#0a0a0a] text-gray-200 antialiased min-h-screen">
+      {/* Nav */}
+      <nav className="fixed top-0 inset-x-0 z-50 bg-[#0a0a0a]/80 backdrop-blur-md border-b border-white/10">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex items-center justify-between h-16">
+          <Link
+            to="/landing"
+            search={{ error: undefined, invite_token: undefined, admin: undefined, next: undefined }}
+            className="flex items-center gap-2 text-gray-400 hover:text-white transition-colors"
+          >
+            <ArrowLeft className="w-4 h-4" />
+            <span className="text-xl font-bold text-white">Vandalizer</span>
+          </Link>
+          <a
+            href="https://github.com/ui-insight/vandalizer"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1.5 text-sm text-gray-400 hover:text-[#f1b300] transition-colors"
+          >
+            <ExternalLink className="w-4 h-4" />
+            GitHub
+          </a>
+        </div>
+      </nav>
+
+      <div className="relative z-10 pt-28 pb-16">
+        <div className="max-w-2xl mx-auto px-4 sm:px-6 lg:px-8">
+          {loading ? (
+            <div className="flex justify-center py-20">
+              <Loader2 className="w-8 h-8 animate-spin text-[#f1b300]" />
+            </div>
+          ) : error && !info ? (
+            <div className="text-center py-20">
+              <AlertCircle className="w-16 h-16 text-red-400 mx-auto mb-6" />
+              <h2 className="text-2xl font-bold text-white mb-4">Invalid Link</h2>
+              <p className="text-gray-400">{error}</p>
+              <Link
+                to="/landing"
+                search={{ error: undefined, invite_token: undefined, admin: undefined, next: undefined }}
+                className="inline-block mt-6 rounded-lg bg-white/10 px-6 py-3 font-bold text-white hover:bg-white/20 transition-colors"
+              >
+                Go to Homepage
+              </Link>
+            </div>
+          ) : extended ? (
+            // --- Renewal succeeded ---
+            <div className="text-center py-12">
+              <div className="p-8 rounded-2xl border border-green-500/20 bg-green-500/5">
+                <Rocket className="w-16 h-16 text-green-400 mx-auto mb-6" />
+                <h2 className="text-2xl font-bold text-white mb-4">You're back in!</h2>
+                <p className="text-gray-400 mb-6">
+                  Your trial has been extended by another two weeks. Pick up right where you left
+                  off — and thanks for helping shape Vandalizer.
+                </p>
+                <button
+                  onClick={enterApp}
+                  className="inline-flex items-center gap-2 rounded-lg bg-[#f1b300] px-6 py-3 font-bold text-black hover:bg-[#d49e00] transition-colors"
+                >
+                  Enter Vandalizer <ArrowRight className="w-5 h-5" />
+                </button>
+              </div>
+            </div>
+          ) : info && info.can_self_extend ? (
+            // --- Can still self-extend ---
+            <div className="p-8 rounded-2xl border border-white/10 bg-white/5">
+              <div className="text-center mb-8">
+                <Sparkles className="w-12 h-12 text-[#f1b300] mx-auto mb-4" />
+                <h2 className="text-2xl font-bold text-white mb-2">Your trial has wrapped up</h2>
+                <p className="text-gray-400">
+                  Hi {info.name} — Vandalizer is an evolving beta built for research offices, and
+                  feedback from trial users like you is actively shaping where it goes next. Trial
+                  access keeps going as new releases land.
+                </p>
+              </div>
+
+              {info.engagement === 'low' ? (
+                // Low engagement → frictionless one-click renewal
+                <div className="text-center">
+                  <p className="text-gray-300 mb-6">
+                    Looks like you were just getting started. No problem — grab another two weeks
+                    and take it for a proper spin.
+                  </p>
+                  {error && (
+                    <div className="mb-4 rounded-md bg-red-500/20 border border-red-500/30 p-3 text-sm text-red-300">
+                      {error}
+                    </div>
+                  )}
+                  <button
+                    onClick={() => handleExtend()}
+                    disabled={submitting}
+                    className="inline-flex items-center gap-2 rounded-lg bg-[#f1b300] px-8 py-4 text-lg font-bold text-black hover:bg-[#d49e00] transition-colors disabled:opacity-50"
+                  >
+                    {submitting ? (
+                      <>
+                        <Loader2 className="w-5 h-5 animate-spin" /> Extending…
+                      </>
+                    ) : (
+                      <>
+                        Keep my trial going <ArrowRight className="w-5 h-5" />
+                      </>
+                    )}
+                  </button>
+                  <p className="mt-3 text-xs text-gray-500">Adds 14 more days, instantly.</p>
+                </div>
+              ) : (
+                // Engaged → short notes in exchange for more time
+                <div>
+                  <p className="text-gray-300 mb-6">
+                    Want another two weeks? Tell us a little about how it's going — your notes go
+                    straight to the team, and you'll be back in the moment you submit.
+                  </p>
+                  <SurveyWizard
+                    steps={steps}
+                    onSubmit={() => handleExtend(answers)}
+                    submitting={submitting}
+                    submitLabel="Get 2 more weeks"
+                    submitIcon={Sparkles}
+                    error={error}
+                  />
+                </div>
+              )}
+            </div>
+          ) : (
+            // --- Cap reached → route to a human ---
+            <div className="p-8 rounded-2xl border border-white/10 bg-white/5 text-center">
+              <Mail className="w-12 h-12 text-[#f1b300] mx-auto mb-4" />
+              <h2 className="text-2xl font-bold text-white mb-2">Let's keep this going</h2>
+              <p className="text-gray-400 mb-6">
+                {info ? `Hi ${info.name} — you` : 'You'}'ve made the most of your trial extensions.
+                We'd love to talk about keeping Vandalizer in your office for good. Reach out and
+                we'll sort out continued access.
+              </p>
+              <div className="flex flex-col sm:flex-row gap-3 justify-center">
+                <a
+                  href={CONTACT_URL}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center justify-center gap-2 rounded-lg bg-[#f1b300] px-6 py-3 font-bold text-black hover:bg-[#d49e00] transition-colors"
+                >
+                  <Mail className="w-5 h-5" /> Get in touch
+                </a>
+                <Link
+                  to="/demo/feedback"
+                  search={{ token }}
+                  className="inline-flex items-center justify-center gap-2 rounded-lg bg-white/10 px-6 py-3 font-bold text-white hover:bg-white/20 transition-colors"
+                >
+                  <CheckCircle className="w-5 h-5" /> Share final feedback
+                </Link>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+
+      <Footer />
+    </div>
+  )
+}

--- a/frontend/src/pages/Landing.tsx
+++ b/frontend/src/pages/Landing.tsx
@@ -301,7 +301,7 @@ export default function Landing() {
 
   if (loading) return null
   if (user && demoExpired && demoFeedbackToken) {
-    return <Navigate to="/demo/feedback" search={{ token: demoFeedbackToken }} />
+    return <Navigate to="/demo/trial-end" search={{ token: demoFeedbackToken }} />
   }
   if (user && !demoExpired) {
     // If user arrived here with an invite token, redirect to accept it

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -23,6 +23,7 @@ const SupportCenter = lazy(() => import('./pages/SupportCenter'))
 const Docs = lazy(() => import('./pages/Docs'))
 const Demo = lazy(() => import('./pages/Demo'))
 const DemoFeedback = lazy(() => import('./pages/DemoFeedback'))
+const DemoTrialEnd = lazy(() => import('./pages/DemoTrialEnd'))
 const InviteAccept = lazy(() => import('./pages/InviteAccept'))
 const JoinLinkAccept = lazy(() => import('./pages/JoinLinkAccept'))
 const Organizations = lazy(() => import('./pages/Organizations'))
@@ -295,6 +296,15 @@ const demoFeedbackRoute = createRoute({
   component: DemoFeedback,
 })
 
+const demoTrialEndRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/demo/trial-end',
+  validateSearch: (search: Record<string, unknown>) => ({
+    token: (search.token as string) || undefined,
+  }),
+  component: DemoTrialEnd,
+})
+
 const certificationRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/certification',
@@ -404,6 +414,7 @@ const routeTree = rootRoute.addChildren([
   certificationRoute,
   demoRoute,
   demoFeedbackRoute,
+  demoTrialEndRoute,
   demoStatusRoute,
   organizationsRoute,
   credentialsRoute,

--- a/frontend/src/types/demo.ts
+++ b/frontend/src/types/demo.ts
@@ -42,6 +42,22 @@ export interface FeedbackInfo {
   already_completed: boolean
 }
 
+export interface TrialEndInfo {
+  name: string
+  organization: string
+  engagement: 'low' | 'engaged'
+  extensions_used: number
+  max_extensions: number
+  can_self_extend: boolean
+  already_extended: boolean
+}
+
+export interface TrialExtensionResult {
+  ok: boolean
+  message: string
+  expires_at: string | null
+}
+
 export interface DemoApplication {
   uuid: string
   name: string


### PR DESCRIPTION
…renewal

When a 14-day trial ended, users hit a hard 403 lockout and were redirected to a dead-end feedback survey, with no way to get more time short of an admin manually restarting the trial.

This turns that dead-end into a friendly, on-brand end-of-trial screen that positions Vandalizer as an evolving beta and lets users self-serve another two weeks (capped at 2):

- Low-engagement users (never logged in, or fewer than 3 documents + workflow runs + chats) get a frictionless one-click "Keep my trial going (+14d)".
- Engaged users leave short post-trial notes and are unlocked instantly on submit.
- After 2 self-serve extensions, the screen routes them to a contact CTA.

Because a locked demo user already holds a valid session cookie from login, flipping demo_status back to active unlocks them in place and drops them straight into the app.

Backend: trial_extensions_used on DemoApplication; compute_trial_engagement, get_trial_end_info, self_extend_trial services; counter reset in admin_restart_trial; reworded trial_expired_email + new trial_extended_email; expiry link points at /demo/trial-end; two public token-auth endpoints.

Frontend: new DemoTrialEnd page + renewal-notes fields, route, API client, types, and Landing redirect to the new screen.

Tests: 8 tier-2 backend tests (engagement boundaries, unlock+extend, cap enforcement, notes persistence) and 4 DemoTrialEnd render tests.

## Summary

Brief description of the changes in this PR.

## Changes

-

## Test Plan

- [ ] Shared checks pass (`make ci`)
- [ ] Release check passes if packaging or deployment changed (`make release-check`)
- [ ] Manually tested the affected feature(s)
- [ ] Updated `CHANGELOG.md` for user-facing or operator-facing changes
- [ ] Updated deploy/release docs (`README.md`, `DEPLOY.md`, `OPERATIONS.md`, or `RELEASE_CHECKLIST.md`) if the install or release path changed

## Related Issues

Closes #
