### PR TITLE
feat(catalog): retire dropped items on upgrade + in-app admin upgrade

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -79,6 +79,14 @@ async def lifespan(app: FastAPI):  # type: ignore[no-untyped-def]
         from app.services.feedback_prompt_service import seed_default_prompts
         await seed_default_prompts()
 
+    # One-time bell notification to admins when the bundled catalog is newer
+    # than what's applied. Best-effort — never block startup on it.
+    try:
+        from app.services.catalog_service import notify_admins_of_catalog_update_if_new
+        await notify_admins_of_catalog_update_if_new()
+    except Exception:
+        logger.warning("Catalog update check failed during startup", exc_info=True)
+
     yield
     logger.info("Shutting down Vandalizer backend")
 

--- a/backend/app/models/knowledge.py
+++ b/backend/app/models/knowledge.py
@@ -86,6 +86,7 @@ class KnowledgeBase(Document):
     sources_failed: int = 0
     total_chunks: int = 0
     collection_name: Optional[str] = None
+    resource_config: dict = Field(default_factory=dict)  # provenance markers (e.g. {"seed_id": ...})
     created_at: datetime.datetime = Field(default_factory=lambda: datetime.datetime.now(tz=datetime.timezone.utc))
     updated_at: datetime.datetime = Field(default_factory=lambda: datetime.datetime.now(tz=datetime.timezone.utc))
 

--- a/backend/app/models/system_config.py
+++ b/backend/app/models/system_config.py
@@ -178,6 +178,14 @@ class SystemConfig(Document):
     # compare without execing into the API container.
     catalog_version: Optional[str] = None
     catalog_version_applied_at: Optional[datetime.datetime] = None
+    # In-app catalog upgrade job status (set by the admin-triggered Celery task).
+    # Shape: {"state": running|completed|failed, "target_version": str,
+    #         "started_at": iso, "finished_at": iso, "by": user_id,
+    #         "prune": bool, "summary": {...}, "message": str}
+    catalog_upgrade: Optional[dict] = None
+    # Highest bundled catalog version we have already notified admins about, so
+    # the startup "update available" bell fires once per new version, not per boot.
+    catalog_upgrade_notified_version: Optional[str] = None
 
     # Metadata
     updated_at: Optional[datetime.datetime] = None

--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -2329,6 +2329,92 @@ async def get_system_version(user: User = Depends(get_current_user)) -> dict:
 
 
 # ---------------------------------------------------------------------------
+# Verified-catalog upgrade (in-app, admin-triggered)
+# ---------------------------------------------------------------------------
+
+
+class CatalogUpgradeRequest(BaseModel):
+    # Whether to also retire (soft-archive) items dropped from the catalog.
+    prune: bool = True
+
+
+@router.get("/catalog/status")
+async def get_catalog_status(user: User = Depends(get_current_user)) -> dict:
+    """Cheap version + job-state check for the banner: applied vs. bundled
+    catalog version, whether an upgrade is available, and any in-flight job."""
+    await _require_admin(user)
+    from scripts.seed_catalog import _read_seed_version, _version_newer
+
+    cfg = await SystemConfig.get_config()
+    bundled = _read_seed_version()
+    return {
+        "applied_version": cfg.catalog_version,
+        "bundled_version": bundled,
+        "update_available": _version_newer(bundled, cfg.catalog_version),
+        "job": cfg.catalog_upgrade,
+    }
+
+
+@router.get("/catalog/preview")
+async def preview_catalog_upgrade(user: User = Depends(get_current_user)) -> dict:
+    """Full diff for the Catalog tab: which items would be added, refreshed, and
+    retired by applying the bundled catalog. Read-only — mutates nothing."""
+    await _require_admin(user)
+    from scripts.seed_catalog import compute_catalog_diff
+
+    diff = await compute_catalog_diff()
+    cfg = await SystemConfig.get_config()
+    diff["job"] = cfg.catalog_upgrade
+    return diff
+
+
+@router.post("/catalog/upgrade")
+async def start_catalog_upgrade(
+    body: CatalogUpgradeRequest,
+    user: User = Depends(get_current_user),
+) -> dict:
+    """Kick off a background catalog upgrade to the bundled version. Refuses if a
+    job is already running or the catalog is already current."""
+    await _require_admin(user)
+    from app.celery_app import celery_app
+    from scripts.seed_catalog import _read_seed_version, _version_newer
+
+    cfg = await SystemConfig.get_config()
+    if cfg.catalog_upgrade and cfg.catalog_upgrade.get("state") == "running":
+        raise HTTPException(status_code=409, detail="A catalog upgrade is already running.")
+
+    bundled = _read_seed_version()
+    if not _version_newer(bundled, cfg.catalog_version):
+        raise HTTPException(
+            status_code=400,
+            detail=f"Catalog is already at {cfg.catalog_version or bundled}; nothing to upgrade.",
+        )
+
+    now = datetime.datetime.now(datetime.timezone.utc)
+    cfg.catalog_upgrade = {
+        "state": "running",
+        "target_version": bundled,
+        "started_at": now.isoformat(),
+        "by": user.user_id,
+        "prune": body.prune,
+    }
+    await cfg.save()
+
+    celery_app.send_task(
+        "tasks.catalog.upgrade",
+        args=[bundled, body.prune, user.user_id],
+        queue="default",
+    )
+    await _audit(
+        user,
+        "upgrade_catalog",
+        f"Started catalog upgrade to {bundled} (prune={body.prune})",
+        {"target_version": bundled, "prune": body.prune},
+    )
+    return {"status": "started", "target_version": bundled, "prune": body.prune}
+
+
+# ---------------------------------------------------------------------------
 # Email analytics — deliverability monitoring
 # ---------------------------------------------------------------------------
 

--- a/backend/app/services/catalog_service.py
+++ b/backend/app/services/catalog_service.py
@@ -1,0 +1,57 @@
+"""Verified-catalog version helpers used by the in-app upgrade feature."""
+
+import logging
+
+from app.models.system_config import SystemConfig
+from app.models.user import User
+from app.services import notification_service
+
+logger = logging.getLogger(__name__)
+
+
+async def notify_admins_of_catalog_update_if_new() -> None:
+    """If the bundled catalog is newer than what's applied, drop a one-time
+    'update available' notification to every admin/staff user.
+
+    Called on startup. Uses an atomic compare-and-set on the notified-version
+    marker so that, with multiple API workers each running this on boot, only
+    one worker actually sends the notifications (and only once per new version).
+    """
+    # Imported here to avoid a circular import at module load.
+    from scripts.seed_catalog import _read_seed_version, _version_newer
+
+    try:
+        bundled = _read_seed_version()
+    except Exception:
+        logger.warning("Could not read bundled catalog version; skipping update check")
+        return
+
+    cfg = await SystemConfig.get_config()
+    if not _version_newer(bundled, cfg.catalog_version):
+        return  # already current (or ahead) — nothing to announce
+    if cfg.catalog_upgrade_notified_version == bundled:
+        return  # already announced this version
+
+    # Atomic claim: only the worker that flips the marker proceeds to notify.
+    coll = SystemConfig.get_motor_collection()
+    res = await coll.update_one(
+        {"_id": cfg.id, "catalog_upgrade_notified_version": {"$ne": bundled}},
+        {"$set": {"catalog_upgrade_notified_version": bundled}},
+    )
+    if res.modified_count == 0:
+        return  # another worker already claimed this announcement
+
+    admins = await User.find({"$or": [{"is_admin": True}, {"is_staff": True}]}).to_list()
+    applied = cfg.catalog_version or "none"
+    for admin in admins:
+        try:
+            await notification_service.create_notification(
+                user_id=admin.user_id,
+                kind="catalog_upgrade_available",
+                title=f"Catalog update available: {bundled}",
+                body=f"Your verified catalog is at {applied}. Review and apply the update from Admin → Catalog.",
+                link="/admin?tab=catalog",
+            )
+        except Exception:
+            logger.warning("catalog-available notify failed for %s", getattr(admin, "user_id", "?"))
+    logger.info("Notified %d admin(s) of catalog update %s", len(admins), bundled)

--- a/backend/app/tasks/catalog_tasks.py
+++ b/backend/app/tasks/catalog_tasks.py
@@ -1,0 +1,128 @@
+"""Admin-triggered verified-catalog upgrade Celery task.
+
+Runs the seed pass (and, optionally, the prune/retire pass) against the
+bundled seed files, records progress on the SystemConfig singleton so the admin
+UI can poll it, and notifies admins on completion or failure.
+"""
+
+import asyncio
+import datetime
+import logging
+
+from app.celery_app import celery
+
+logger = logging.getLogger(__name__)
+
+
+def _run_async(coro):
+    """Run an async coroutine from sync Celery task context."""
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+def _now_iso() -> str:
+    return datetime.datetime.now(datetime.timezone.utc).isoformat()
+
+
+@celery.task(bind=True, name="tasks.catalog.upgrade")
+def upgrade_catalog_task(self, target_version: str, prune: bool, user_id: str):
+    """Apply the bundled catalog: seed (add/refresh) then optionally retire
+    items dropped from the catalog. State is mirrored to
+    SystemConfig.catalog_upgrade throughout for the admin UI to poll."""
+    started = _now_iso()
+
+    async def _run():
+        from app.config import Settings
+        from app.database import init_db
+        from app.models.system_config import SystemConfig
+        from app.models.user import User
+        from app.services import notification_service
+        from scripts.seed_catalog import ALL_TYPES, prune_stale_seeded_items, seed_catalog
+
+        await init_db(Settings())
+
+        async def _notify_admins(kind: str, title: str, body: str) -> None:
+            admins = await User.find(
+                {"$or": [{"is_admin": True}, {"is_staff": True}]}
+            ).to_list()
+            for admin in admins:
+                try:
+                    await notification_service.create_notification(
+                        user_id=admin.user_id,
+                        kind=kind,
+                        title=title,
+                        body=body,
+                        link="/admin?tab=catalog",
+                    )
+                except Exception:  # one bad recipient shouldn't abort the rest
+                    logger.warning("catalog notify failed for %s", getattr(admin, "user_id", "?"))
+
+        # Mark running (router also sets this; refresh started_at defensively).
+        cfg = await SystemConfig.get_config()
+        cfg.catalog_upgrade = {
+            "state": "running",
+            "target_version": target_version,
+            "started_at": started,
+            "by": user_id,
+            "prune": prune,
+        }
+        await cfg.save()
+
+        try:
+            seed_summary = await seed_catalog(types=set(ALL_TYPES))
+            retired = []
+            if prune:
+                retired = await prune_stale_seeded_items(set(ALL_TYPES), dry_run=False)
+
+            summary = {
+                "created": seed_summary.get("created", 0),
+                "updated": seed_summary.get("updated", 0),
+                "retired": len(retired),
+                "retired_items": retired,
+            }
+            message = (
+                f"Upgraded to {target_version}: {summary['created']} added, "
+                f"{summary['updated']} refreshed, {summary['retired']} retired."
+            )
+            cfg = await SystemConfig.get_config()
+            cfg.catalog_upgrade = {
+                "state": "completed",
+                "target_version": target_version,
+                "started_at": started,
+                "finished_at": _now_iso(),
+                "by": user_id,
+                "prune": prune,
+                "summary": summary,
+                "message": message,
+            }
+            await cfg.save()
+            await _notify_admins(
+                "catalog_upgrade_complete",
+                f"Catalog upgraded to {target_version}",
+                message,
+            )
+            return summary
+        except Exception as e:
+            logger.exception("Catalog upgrade to %s failed", target_version)
+            cfg = await SystemConfig.get_config()
+            cfg.catalog_upgrade = {
+                "state": "failed",
+                "target_version": target_version,
+                "started_at": started,
+                "finished_at": _now_iso(),
+                "by": user_id,
+                "prune": prune,
+                "message": f"Upgrade to {target_version} failed: {e}",
+            }
+            await cfg.save()
+            await _notify_admins(
+                "catalog_upgrade_failed",
+                f"Catalog upgrade to {target_version} failed",
+                str(e),
+            )
+            raise
+
+    return _run_async(_run())

--- a/backend/celery_worker.py
+++ b/backend/celery_worker.py
@@ -27,3 +27,4 @@ from app.tasks import passive_tasks  # noqa: F401  — tasks.passive.process_*, 
 from app.tasks import classification_tasks  # noqa: F401  — tasks.document.classify
 from app.tasks import demo_tasks  # noqa: F401  — tasks.demo.*
 from app.tasks import approval_tasks  # noqa: F401  — tasks.approvals.*
+from app.tasks import catalog_tasks  # noqa: F401  — tasks.catalog.upgrade

--- a/backend/scripts/seed_catalog.py
+++ b/backend/scripts/seed_catalog.py
@@ -12,6 +12,8 @@ Usage:
     python -m scripts.seed_catalog --only extractions,knowledge-bases
     python -m scripts.seed_catalog --only kbs                   # alias for knowledge-bases
     python -m scripts.seed_catalog --reset                      # wipe catalog metadata, then re-seed
+    python -m scripts.seed_catalog --prune                      # seed, then retire items dropped from the catalog
+    python -m scripts.seed_catalog --prune --dry-run            # preview what --prune would retire (no changes)
 
 The --reset flag clears the catalog "metadata layer" (VerifiedCollection,
 VerifiedItemMetadata, verified LibraryItem records, and the verified Library
@@ -19,6 +21,16 @@ container) before re-seeding. The underlying Workflow / SearchSet /
 KnowledgeBase documents (and any user-added LibraryItem bookmarks pointing
 at them) are NOT deleted — the seed pass re-attaches existing entities to
 fresh metadata via their stored seed_id markers.
+
+The --prune flag handles the inverse: catalog UPGRADES that *remove* items.
+Every seeded entity carries a seed_id (workflows/KBs in resource_config,
+search sets in extraction_config). After seeding, prune compares the seed_ids
+live in the seed files against the verified rows in the database and
+soft-archives any verified item whose seed_id is gone — flipping it to
+verified=False and detaching it from the explore catalog (LibraryItem,
+VerifiedItemMetadata, collection membership) while preserving the underlying
+row so the change is reversible. Items without a seed_id are never touched.
+Pair with --dry-run to preview the retirement list before applying it.
 """
 
 import argparse
@@ -629,16 +641,25 @@ async def seed_knowledge_base(
     data: dict, meta: dict, verified_lib: Library, slug_to_collection: dict[str, VerifiedCollection],
 ) -> SeedResult:
     """Seed a single knowledge base. Returns "created", "updated", or "skipped"."""
+    seed_id = meta["seed_id"]
     item = data["items"][0]
 
-    existing = await KnowledgeBase.find_one(
-        KnowledgeBase.title == item["title"],
-        KnowledgeBase.verified == True,  # noqa: E712
-    )
+    # Match on seed_id (provenance) first; fall back to title for legacy KBs
+    # seeded before seed_id tracking existed, then stamp them so future runs
+    # (and the prune pass) can identify them by seed_id.
+    existing = await KnowledgeBase.find_one({"resource_config.seed_id": seed_id})
+    if not existing:
+        existing = await KnowledgeBase.find_one(
+            KnowledgeBase.title == item["title"],
+            KnowledgeBase.verified == True,  # noqa: E712
+        )
     if existing:
         from app.services.knowledge_service import _ingest_url_source
 
         changed = False
+        if existing.resource_config.get("seed_id") != seed_id:
+            existing.resource_config = {**existing.resource_config, "seed_id": seed_id}
+            changed = True
         new_desc = item.get("description")
         if new_desc is not None and existing.description != new_desc:
             existing.description = new_desc
@@ -700,6 +721,7 @@ async def seed_knowledge_base(
         space="global",
         verified=True,
         status="ready",
+        resource_config={"seed_id": seed_id},
         created_at=now,
         updated_at=now,
     )
@@ -748,6 +770,180 @@ async def seed_knowledge_base(
 
 
 # ---------------------------------------------------------------------------
+# Prune (retire stale seeded items)
+# ---------------------------------------------------------------------------
+
+# Per-type wiring for prune: how to find the seed_id on a live document, the
+# seed directory to scan, the LibraryItemKind, and the metadata item_kind string.
+_PRUNE_SPEC = {
+    TYPE_WORKFLOWS: {
+        "model": Workflow,
+        "dir": "workflows",
+        "cfg_field": "resource_config",
+        "title_key": "name",  # field in seed items[0] holding the entity title
+        "library_kind": LibraryItemKind.WORKFLOW,
+        "meta_kind": "workflow",
+        "label": "workflow",
+        # Workflows have carried a seed_id in resource_config since their first
+        # seed, so seed_id alone is a reliable identity — no title fallback.
+        "title_fallback": False,
+    },
+    TYPE_EXTRACTIONS: {
+        "model": SearchSet,
+        "dir": "search_sets",
+        "cfg_field": "extraction_config",
+        "title_key": "title",
+        "library_kind": LibraryItemKind.SEARCH_SET,
+        "meta_kind": "search_set",
+        "label": "search set",
+        "title_fallback": False,
+    },
+    TYPE_KNOWLEDGE_BASES: {
+        "model": KnowledgeBase,
+        "dir": "knowledge_bases",
+        "cfg_field": "resource_config",
+        "title_key": "title",
+        "library_kind": LibraryItemKind.KNOWLEDGE_BASE,
+        "meta_kind": "knowledge_base",
+        "label": "knowledge base",
+        # KBs only gained seed_id tracking recently, so legacy rows have none.
+        # Fall back to matching system-seeded KBs by title against the manifest.
+        "title_fallback": True,
+    },
+}
+
+
+def _collect_live_manifest(selected: set[str]) -> dict[str, dict[str, set[str]]]:
+    """Scan the seed files for the selected types and return, per type, the
+    seed_ids and entity titles the catalog currently ships. The prune pass diffs
+    live items against this: a verified item whose seed_id (or, for legacy rows
+    without one, whose title) is absent here was dropped from the catalog."""
+    live: dict[str, dict[str, set[str]]] = {}
+    for type_name in selected:
+        spec = _PRUNE_SPEC[type_name]
+        type_dir = SEEDS_DIR / spec["dir"]
+        ids: set[str] = set()
+        titles: set[str] = set()
+        if type_dir.exists():
+            for seed_file in sorted(type_dir.glob("*.json")):
+                data = json.loads(seed_file.read_text())
+                seed_id = data.get("_seed_meta", {}).get("seed_id")
+                if seed_id:
+                    ids.add(seed_id)
+                items = data.get("items") or []
+                if items:
+                    title = items[0].get(spec["title_key"])
+                    if title:
+                        titles.add(title)
+        live[type_name] = {"ids": ids, "titles": titles}
+    return live
+
+
+async def _retire_item(type_name: str, doc, verified_lib: Library, dry_run: bool) -> None:
+    """Soft-archive a single seeded item: flip the underlying row to
+    verified=False and strip every catalog attachment (verified LibraryItem,
+    VerifiedItemMetadata, collection membership). The underlying
+    Workflow/SearchSet/KnowledgeBase row is preserved so the change is
+    reversible. A no-op when dry_run is True."""
+    if dry_run:
+        return
+    spec = _PRUNE_SPEC[type_name]
+    item_id_str = str(doc.id)
+
+    # Detach the verified LibraryItem(s) and pull them from the verified library.
+    lib_items = await LibraryItem.find(
+        LibraryItem.item_id == doc.id,
+        LibraryItem.kind == spec["library_kind"],
+        LibraryItem.verified == True,  # noqa: E712
+    ).to_list()
+    for li in lib_items:
+        if li.id in verified_lib.items:
+            verified_lib.items.remove(li.id)
+        await li.delete()
+
+    # Drop the verified metadata record.
+    await VerifiedItemMetadata.find(
+        VerifiedItemMetadata.item_kind == spec["meta_kind"],
+        VerifiedItemMetadata.item_id == item_id_str,
+    ).delete()
+
+    # Remove the item from any collection that references it.
+    async for col in VerifiedCollection.find(VerifiedCollection.item_ids == item_id_str):
+        col.item_ids = [i for i in col.item_ids if i != item_id_str]
+        col.updated_at = datetime.datetime.now(datetime.timezone.utc)
+        await col.save()
+
+    # Finally, unverify the underlying row (kept for reversibility).
+    doc.verified = False
+    if hasattr(doc, "updated_at"):
+        doc.updated_at = datetime.datetime.now(datetime.timezone.utc)
+    await doc.save()
+
+
+async def prune_stale_seeded_items(
+    selected: set[str], dry_run: bool = False,
+) -> list[dict]:
+    """Retire verified items whose seed_id is no longer present in the seed
+    files for their type. Only types in ``selected`` are considered, so a
+    partial run (e.g. --only workflows) never touches other types.
+
+    Items without a seed_id are ignored unless the type opts into a title
+    fallback (knowledge bases, whose legacy rows predate seed_id tracking) and
+    the row is system-seeded — this avoids retiring user-created entities or
+    internal artifacts (e.g. a workflow's inline-extraction SearchSet).
+    Returns a list of retired-item descriptors.
+    """
+    live = _collect_live_manifest(selected)
+    verified_lib = await get_or_create_verified_library()
+    retired: list[dict] = []
+
+    for type_name in sorted(selected):
+        spec = _PRUNE_SPEC[type_name]
+        model = spec["model"]
+        cfg_field = spec["cfg_field"]
+        live_ids = live[type_name]["ids"]
+        live_titles = live[type_name]["titles"]
+
+        # Verified rows that either carry a seed_id marker or — for types with a
+        # title fallback — are system-seeded (so legacy unstamped rows are seen).
+        query: dict = {"verified": True}
+        if spec["title_fallback"]:
+            query["$or"] = [
+                {f"{cfg_field}.seed_id": {"$exists": True, "$ne": None}},
+                {"user_id": SYSTEM_USER},
+            ]
+        else:
+            query[f"{cfg_field}.seed_id"] = {"$exists": True, "$ne": None}
+        candidates = await model.find(query).to_list()
+
+        for doc in candidates:
+            seed_id = (getattr(doc, cfg_field, {}) or {}).get("seed_id")
+            if seed_id:
+                stale = seed_id not in live_ids
+            elif spec["title_fallback"] and getattr(doc, "user_id", None) == SYSTEM_USER:
+                # Legacy system-seeded row with no seed_id: match by title. After
+                # a seed pass, a kept item is always stamped, so this only flags
+                # genuinely-dropped items; in --dry-run it relies on the title.
+                stale = getattr(doc, "title", None) not in live_titles
+            else:
+                continue
+            if not stale:
+                continue
+            await _retire_item(type_name, doc, verified_lib, dry_run)
+            retired.append({
+                "type": type_name,
+                "label": spec["label"],
+                "seed_id": seed_id or "(legacy/no seed_id)",
+                "name": getattr(doc, "name", None) or getattr(doc, "title", None) or str(doc.id),
+                "id": str(doc.id),
+            })
+
+    if not dry_run and retired:
+        await verified_lib.save()
+    return retired
+
+
+# ---------------------------------------------------------------------------
 # Reset
 # ---------------------------------------------------------------------------
 
@@ -776,6 +972,124 @@ async def reset_verified_catalog() -> dict[str, int]:
     deleted["libraries"] = getattr(res, "deleted_count", 0) or 0
 
     return deleted
+
+
+# ---------------------------------------------------------------------------
+# Diff / preview (powers the in-app "catalog update available" feature)
+# ---------------------------------------------------------------------------
+
+def _version_newer(candidate: str | None, current: str | None) -> bool:
+    """True if dotted-numeric ``candidate`` is a higher version than ``current``.
+    An absent current version means anything is newer. Non-numeric versions fall
+    back to a simple inequality so we still surface a change."""
+    if not candidate:
+        return False
+    if not current:
+        return True
+
+    def _parts(v: str):
+        try:
+            return tuple(int(x) for x in v.strip().split("."))
+        except ValueError:
+            return None
+
+    cp, kp = _parts(candidate), _parts(current)
+    if cp is None or kp is None:
+        return candidate != current
+    return cp > kp
+
+
+def _scan_seed_entries(type_name: str) -> list[dict]:
+    """Read the seed files for a type and return one entry per item:
+    {seed_id, name, title}. ``name`` is the human display label, ``title`` the
+    underlying entity title used for legacy (seed_id-less) matching."""
+    spec = _PRUNE_SPEC[type_name]
+    type_dir = SEEDS_DIR / spec["dir"]
+    entries: list[dict] = []
+    if not type_dir.exists():
+        return entries
+    for seed_file in sorted(type_dir.glob("*.json")):
+        data = json.loads(seed_file.read_text())
+        meta = data.get("_seed_meta", {})
+        seed_id = meta.get("seed_id")
+        if not seed_id:
+            continue
+        items = data.get("items") or []
+        title = items[0].get(spec["title_key"]) if items else None
+        entries.append({
+            "seed_id": seed_id,
+            "title": title,
+            "name": meta.get("display_name") or title or seed_id,
+        })
+    return entries
+
+
+async def _db_identity(type_name: str) -> tuple[set[str], set[str]]:
+    """Return (seed_ids, titles) for the verified rows of a type already in the
+    DB — the 'what's installed' side of the diff."""
+    spec = _PRUNE_SPEC[type_name]
+    model = spec["model"]
+    cfg_field = spec["cfg_field"]
+    rows = await model.find({"verified": True}).to_list()
+    ids: set[str] = set()
+    titles: set[str] = set()
+    for row in rows:
+        sid = (getattr(row, cfg_field, {}) or {}).get("seed_id")
+        if sid:
+            ids.add(sid)
+        title = getattr(row, "title", None) or getattr(row, "name", None)
+        if title and getattr(row, "user_id", None) == SYSTEM_USER:
+            titles.add(title)
+    return ids, titles
+
+
+async def compute_catalog_diff(types: set[str] | None = None) -> dict:
+    """Compute what a catalog upgrade would change, without mutating anything.
+
+    Returns the applied vs. bundled version, whether an upgrade is available,
+    and the lists of items that would be added and retired plus a refreshed
+    count. Powers the admin "catalog update available" banner and preview.
+    """
+    selected = set(types) if types else set(ALL_TYPES)
+    bundled = _read_seed_version()
+
+    from app.models.system_config import SystemConfig
+    cfg = await SystemConfig.get_config()
+    applied = cfg.catalog_version
+
+    new_items: list[dict] = []
+    refreshed = 0
+    for type_name in sorted(selected):
+        spec = _PRUNE_SPEC[type_name]
+        db_ids, db_titles = await _db_identity(type_name)
+        for entry in _scan_seed_entries(type_name):
+            known = entry["seed_id"] in db_ids or (
+                spec["title_fallback"] and entry.get("title") in db_titles
+            )
+            if known:
+                refreshed += 1
+            else:
+                new_items.append({
+                    "type": type_name,
+                    "label": spec["label"],
+                    "seed_id": entry["seed_id"],
+                    "name": entry["name"],
+                })
+
+    retiring = await prune_stale_seeded_items(selected, dry_run=True)
+
+    return {
+        "applied_version": applied,
+        "bundled_version": bundled,
+        "update_available": _version_newer(bundled, applied),
+        "counts": {
+            "new": len(new_items),
+            "refreshed": refreshed,
+            "retiring": len(retiring),
+        },
+        "new": new_items,
+        "retiring": retiring,
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -822,6 +1136,7 @@ async def seed_catalog(types: set[str] | None = None):
             print(f"  = {name} (skipped)")
 
     summary: list[str] = []
+    counts_by_type: dict[str, dict[str, int]] = {}
 
     # --- Phase 2: Workflows ---
     if TYPE_WORKFLOWS in selected:
@@ -841,6 +1156,7 @@ async def seed_catalog(types: set[str] | None = None):
             f"{wf_counts.get('updated', 0)} updated, "
             f"{wf_counts.get('skipped', 0)} skipped"
         )
+        counts_by_type[TYPE_WORKFLOWS] = wf_counts
 
     # --- Phase 3: Search Sets (extractions) ---
     if TYPE_EXTRACTIONS in selected:
@@ -860,6 +1176,7 @@ async def seed_catalog(types: set[str] | None = None):
             f"{ss_counts.get('updated', 0)} updated, "
             f"{ss_counts.get('skipped', 0)} skipped"
         )
+        counts_by_type[TYPE_EXTRACTIONS] = ss_counts
 
     # --- Phase 4: Knowledge Bases ---
     if TYPE_KNOWLEDGE_BASES in selected:
@@ -880,6 +1197,7 @@ async def seed_catalog(types: set[str] | None = None):
             f"{kb_counts.get('updated', 0)} updated, "
             f"{kb_counts.get('skipped', 0)} skipped"
         )
+        counts_by_type[TYPE_KNOWLEDGE_BASES] = kb_counts
 
     # --- Save verified library ---
     await verified_lib.save()
@@ -897,6 +1215,17 @@ async def seed_catalog(types: set[str] | None = None):
 
     # --- Summary ---
     print("\nDone! " + " | ".join(summary))
+
+    def _totals(key: str) -> int:
+        return sum(c.get(key, 0) for c in counts_by_type.values())
+
+    return {
+        "version": seed_version,
+        "by_type": counts_by_type,
+        "created": _totals("created"),
+        "updated": _totals("updated"),
+        "skipped": _totals("skipped"),
+    }
 
 
 async def main():
@@ -933,11 +1262,36 @@ async def main():
             "Workflow/SearchSet/KnowledgeBase rows are preserved."
         ),
     )
+    parser.add_argument(
+        "--prune",
+        action="store_true",
+        help=(
+            "After seeding, retire verified items whose seed_id is no longer in "
+            "the seed files (soft-archive: verified=False, removed from the "
+            "explore catalog, underlying row kept). Use to drop items dropped "
+            "from the catalog on an upgrade."
+        ),
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help=(
+            "Preview the prune pass only: list the items that --prune would "
+            "retire, without seeding or modifying anything. Implies --prune."
+        ),
+    )
     args = parser.parse_args()
     types = _parse_types(args.only)
 
     settings = Settings()
     await init_db(settings)
+
+    # Dry run: preview retirements only — no seeding, no mutations.
+    if args.dry_run:
+        stale = await prune_stale_seeded_items(types, dry_run=True)
+        _print_prune_summary(stale, dry_run=True)
+        return
+
     if args.reset:
         print("Resetting verified catalog metadata...")
         deleted = await reset_verified_catalog()
@@ -948,6 +1302,24 @@ async def main():
             f"{deleted['libraries']} verified library container(s)."
         )
     await seed_catalog(types=types)
+
+    if args.prune:
+        retired = await prune_stale_seeded_items(types, dry_run=False)
+        _print_prune_summary(retired, dry_run=False)
+
+
+def _print_prune_summary(items: list[dict], dry_run: bool) -> None:
+    """Render the prune result. The 'Retiring N item(s)' line is machine-readable
+    — setup.sh greps it to decide whether to prompt for confirmation."""
+    verb = "Would retire" if dry_run else "Retired"
+    print(f"\n--- Prune ({'dry run' if dry_run else 'applied'}) ---")
+    print(f"Retiring {len(items)} item(s) no longer in the catalog.")
+    for it in items:
+        print(f"  - [{it['label']}] {it['name']}  (seed_id={it['seed_id']})")
+    if not items:
+        print("  (nothing to retire — every verified seeded item is still in the seed files)")
+    else:
+        print(f"{verb} {len(items)} stale catalog item(s).")
 
 
 if __name__ == "__main__":

--- a/frontend/src/api/admin.ts
+++ b/frontend/src/api/admin.ts
@@ -15,6 +15,60 @@ export function getVersionStatus() {
   return apiFetch<VersionStatus>('/api/admin/system/version')
 }
 
+// Verified-catalog upgrade
+
+export interface CatalogJob {
+  state: 'running' | 'completed' | 'failed'
+  target_version: string
+  started_at?: string
+  finished_at?: string
+  by?: string
+  prune?: boolean
+  message?: string
+  summary?: {
+    created: number
+    updated: number
+    retired: number
+    retired_items?: CatalogItem[]
+  }
+}
+
+export interface CatalogStatus {
+  applied_version: string | null
+  bundled_version: string
+  update_available: boolean
+  job: CatalogJob | null
+}
+
+export interface CatalogItem {
+  type: string
+  label: string
+  seed_id: string
+  name: string
+  id?: string
+}
+
+export interface CatalogPreview extends CatalogStatus {
+  counts: { new: number; refreshed: number; retiring: number }
+  new: CatalogItem[]
+  retiring: CatalogItem[]
+}
+
+export function getCatalogStatus() {
+  return apiFetch<CatalogStatus>('/api/admin/catalog/status')
+}
+
+export function getCatalogPreview() {
+  return apiFetch<CatalogPreview>('/api/admin/catalog/preview')
+}
+
+export function applyCatalogUpgrade(prune: boolean) {
+  return apiFetch<{ status: string; target_version: string; prune: boolean }>(
+    '/api/admin/catalog/upgrade',
+    { method: 'POST', body: JSON.stringify({ prune }) },
+  )
+}
+
 // Usage
 
 export interface UsageStats {

--- a/frontend/src/components/admin/CatalogTab.tsx
+++ b/frontend/src/components/admin/CatalogTab.tsx
@@ -1,0 +1,196 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import {
+  PackageOpen, CheckCircle2, AlertTriangle, Loader2, ArrowUpCircle, Trash2,
+} from 'lucide-react'
+import {
+  getCatalogPreview, getCatalogStatus, applyCatalogUpgrade,
+  type CatalogPreview, type CatalogJob,
+} from '../../api/admin'
+
+function VersionPill({ label, value, accent }: { label: string; value: string; accent?: boolean }) {
+  return (
+    <div className="flex flex-col">
+      <span className="text-xs uppercase tracking-wide text-gray-500">{label}</span>
+      <span className={`font-mono text-lg ${accent ? 'text-amber-700 font-semibold' : 'text-gray-900'}`}>
+        {value}
+      </span>
+    </div>
+  )
+}
+
+export function CatalogTab() {
+  const [preview, setPreview] = useState<CatalogPreview | null>(null)
+  const [job, setJob] = useState<CatalogJob | null>(null)
+  const [prune, setPrune] = useState(true)
+  const [loading, setLoading] = useState(true)
+  const [applying, setApplying] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null)
+
+  const stopPolling = useCallback(() => {
+    if (pollRef.current) { clearInterval(pollRef.current); pollRef.current = null }
+  }, [])
+
+  const loadPreview = useCallback(async () => {
+    try {
+      const p = await getCatalogPreview()
+      setPreview(p)
+      setJob(p.job)
+      return p
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to load catalog status')
+      return null
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  const startPolling = useCallback(() => {
+    stopPolling()
+    pollRef.current = setInterval(async () => {
+      try {
+        const s = await getCatalogStatus()
+        setJob(s.job)
+        if (s.job && s.job.state !== 'running') {
+          stopPolling()
+          setApplying(false)
+          await loadPreview() // refresh counts/version after completion
+        }
+      } catch { /* keep polling */ }
+    }, 3000)
+  }, [stopPolling, loadPreview])
+
+  useEffect(() => {
+    loadPreview().then((p) => {
+      if (p?.job?.state === 'running') { setApplying(true); startPolling() }
+    })
+    return stopPolling
+  }, [loadPreview, startPolling, stopPolling])
+
+  const apply = async () => {
+    setError(null)
+    setApplying(true)
+    try {
+      await applyCatalogUpgrade(prune)
+      setJob({ state: 'running', target_version: preview?.bundled_version || '', prune })
+      startPolling()
+    } catch (e) {
+      setApplying(false)
+      setError(e instanceof Error ? e.message : 'Failed to start upgrade')
+    }
+  }
+
+  if (loading) {
+    return <div className="flex items-center gap-2 p-6 text-gray-500"><Loader2 className="h-4 w-4 animate-spin" /> Loading catalog status…</div>
+  }
+  if (!preview) {
+    return <div className="p-6 text-red-600">{error || 'Catalog status unavailable.'}</div>
+  }
+
+  const running = job?.state === 'running' || applying
+  const { counts } = preview
+
+  return (
+    <div className="max-w-3xl space-y-6 p-1">
+      <div className="flex items-center gap-2">
+        <PackageOpen className="h-5 w-5 text-gray-700" />
+        <h2 className="text-lg font-semibold text-gray-900">Verified Catalog</h2>
+      </div>
+
+      {/* Version summary */}
+      <div className="flex items-center gap-10 rounded-lg border border-gray-200 bg-white p-4">
+        <VersionPill label="Applied" value={preview.applied_version || 'none'} />
+        <ArrowUpCircle className="h-5 w-5 text-gray-400" />
+        <VersionPill label="Bundled (available)" value={preview.bundled_version} accent={preview.update_available} />
+      </div>
+
+      {error && (
+        <div className="flex items-start gap-2 rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+          <AlertTriangle className="mt-0.5 h-4 w-4 flex-shrink-0" /> {error}
+        </div>
+      )}
+
+      {/* Completed / failed banners */}
+      {job?.state === 'completed' && (
+        <div className="flex items-start gap-2 rounded-lg border border-emerald-200 bg-emerald-50 p-3 text-sm text-emerald-800">
+          <CheckCircle2 className="mt-0.5 h-4 w-4 flex-shrink-0" />
+          <span>{job.message || 'Catalog upgrade completed.'}</span>
+        </div>
+      )}
+      {job?.state === 'failed' && (
+        <div className="flex items-start gap-2 rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+          <AlertTriangle className="mt-0.5 h-4 w-4 flex-shrink-0" />
+          <span>{job.message || 'Catalog upgrade failed.'}</span>
+        </div>
+      )}
+
+      {running ? (
+        <div className="flex items-center gap-2 rounded-lg border border-amber-200 bg-amber-50 p-4 text-sm text-amber-800">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          Applying catalog {job?.target_version || preview.bundled_version}… You can leave this page; you'll get a notification when it finishes.
+        </div>
+      ) : !preview.update_available ? (
+        <div className="flex items-center gap-2 rounded-lg border border-gray-200 bg-gray-50 p-4 text-sm text-gray-600">
+          <CheckCircle2 className="h-4 w-4 text-emerald-500" />
+          Catalog is up to date ({preview.bundled_version}).
+        </div>
+      ) : (
+        <div className="space-y-4 rounded-lg border border-gray-200 bg-white p-4">
+          <div className="text-sm font-medium text-gray-900">
+            Applying {preview.bundled_version} will:
+          </div>
+          <div className="flex gap-6 text-sm">
+            <span className="text-emerald-700">+ {counts.new} new</span>
+            <span className="text-gray-600">~ {counts.refreshed} refreshed</span>
+            <span className="text-red-600">- {counts.retiring} retiring</span>
+          </div>
+
+          {/* New items */}
+          {preview.new.length > 0 && (
+            <details className="text-sm">
+              <summary className="cursor-pointer text-emerald-700">{preview.new.length} new item(s)</summary>
+              <ul className="mt-2 space-y-1 pl-4 text-gray-600">
+                {preview.new.map((it) => (
+                  <li key={`${it.type}:${it.seed_id}`}>[{it.label}] {it.name}</li>
+                ))}
+              </ul>
+            </details>
+          )}
+
+          {/* Retirement toggle + list */}
+          {counts.retiring > 0 && (
+            <div className="rounded-md border border-red-100 bg-red-50/50 p-3">
+              <label className="flex items-center gap-2 text-sm font-medium text-gray-800">
+                <input
+                  type="checkbox"
+                  checked={prune}
+                  onChange={(e) => setPrune(e.target.checked)}
+                  className="h-4 w-4 rounded border-gray-300"
+                />
+                <Trash2 className="h-4 w-4 text-red-500" />
+                Also retire {counts.retiring} dropped item(s)
+              </label>
+              <p className="mt-1 pl-6 text-xs text-gray-500">
+                Soft-archive: removed from Explore, underlying records kept (reversible). Uncheck to upgrade without removing them.
+              </p>
+              <ul className="mt-2 space-y-1 pl-6 text-sm text-gray-600">
+                {preview.retiring.map((it) => (
+                  <li key={`${it.type}:${it.seed_id}:${it.id}`}>[{it.label}] {it.name}</li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          <button
+            onClick={apply}
+            disabled={applying}
+            className="inline-flex items-center gap-2 rounded-lg bg-amber-600 px-4 py-2 text-sm font-medium text-white hover:bg-amber-700 disabled:opacity-50"
+          >
+            <ArrowUpCircle className="h-4 w-4" />
+            Apply catalog {preview.bundled_version}
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/admin/CatalogUpdateBanner.tsx
+++ b/frontend/src/components/admin/CatalogUpdateBanner.tsx
@@ -1,0 +1,69 @@
+import { useEffect, useState } from 'react'
+import { PackageOpen, X } from 'lucide-react'
+import { getCatalogStatus, type CatalogStatus } from '../../api/admin'
+
+const DISMISS_KEY_PREFIX = 'vandalizer:catalog-banner-dismissed:'
+
+/**
+ * Amber banner shown on the Admin page when the bundled verified catalog is
+ * newer than what's applied. Mirrors UpdateBanner, but the action is in-app:
+ * it points the admin at the Catalog tab to preview and apply.
+ */
+export function CatalogUpdateBanner({ onView }: { onView?: () => void }) {
+  const [status, setStatus] = useState<CatalogStatus | null>(null)
+  const [dismissed, setDismissed] = useState(false)
+
+  useEffect(() => {
+    let cancelled = false
+    getCatalogStatus()
+      .then((s) => { if (!cancelled) setStatus(s) })
+      .catch(() => { /* silent — banner is an optional signal */ })
+    return () => { cancelled = true }
+  }, [])
+
+  useEffect(() => {
+    if (!status?.bundled_version) return
+    const key = `${DISMISS_KEY_PREFIX}${status.bundled_version}`
+    setDismissed(localStorage.getItem(key) === '1')
+  }, [status?.bundled_version])
+
+  const running = status?.job?.state === 'running'
+  if (!status || !status.update_available || dismissed || running) {
+    return null
+  }
+
+  const dismiss = () => {
+    localStorage.setItem(`${DISMISS_KEY_PREFIX}${status.bundled_version}`, '1')
+    setDismissed(true)
+  }
+
+  return (
+    <div className="mb-4 flex items-start gap-3 rounded-lg border border-amber-300 bg-amber-50 p-4 text-amber-900">
+      <PackageOpen className="mt-0.5 h-5 w-5 flex-shrink-0" />
+      <div className="flex-1 text-sm">
+        <div className="font-medium">
+          Catalog update available: {status.bundled_version}
+        </div>
+        <div className="text-amber-800">
+          Your verified catalog is at {status.applied_version || 'none'}. Review what changes
+          (including any items that will be retired) and apply it from the Catalog tab.
+        </div>
+        {onView && (
+          <button
+            onClick={onView}
+            className="mt-1 inline-flex items-center gap-1 text-sm font-medium underline hover:no-underline"
+          >
+            Review &amp; apply
+          </button>
+        )}
+      </div>
+      <button
+        onClick={dismiss}
+        aria-label="Dismiss catalog update notice"
+        className="rounded p-1 text-amber-700 hover:bg-amber-100 hover:text-amber-900"
+      >
+        <X className="h-4 w-4" />
+      </button>
+    </div>
+  )
+}

--- a/frontend/src/pages/Admin.tsx
+++ b/frontend/src/pages/Admin.tsx
@@ -6,7 +6,7 @@ import {
   CheckCircle2, XCircle, Clock, Download, TrendingUp, TrendingDown,
   ChevronDown, ChevronUp, ArrowUpDown, Play, Minus, AlertCircle,
   ArrowLeft, FileText, FolderTree, X, Check,
-  Mail, Send, Link, UserPlus, Star, Award, Unlock, KeyRound,
+  Mail, Send, Link, UserPlus, Star, Award, Unlock, KeyRound, PackageOpen,
 } from 'lucide-react'
 import {
   AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer,
@@ -67,6 +67,8 @@ import * as auditApi from '../api/audit'
 import type { AuditLogEntry } from '../api/audit'
 import { getAuthConfig } from '../api/auth'
 import { UpdateBanner } from '../components/admin/UpdateBanner'
+import { CatalogUpdateBanner } from '../components/admin/CatalogUpdateBanner'
+import { CatalogTab } from '../components/admin/CatalogTab'
 import { ApiKeysTab } from '../components/admin/ApiKeysTab'
 import { ComplianceTab } from '../components/admin/ComplianceTab'
 
@@ -87,7 +89,7 @@ function readFileAsDataUrl(file: File): Promise<string> {
   })
 }
 
-type Tab = 'usage' | 'users' | 'teams' | 'organizations' | 'workflows' | 'quality' | 'compliance' | 'audit' | 'demo' | 'email' | 'certifications' | 'apikeys' | 'config'
+type Tab = 'usage' | 'users' | 'teams' | 'organizations' | 'workflows' | 'quality' | 'compliance' | 'audit' | 'demo' | 'email' | 'certifications' | 'apikeys' | 'catalog' | 'config'
 
 const TABS: { key: Tab; label: string; icon: typeof BarChart3 }[] = [
   { key: 'usage', label: 'Usage', icon: BarChart3 },
@@ -102,6 +104,7 @@ const TABS: { key: Tab; label: string; icon: typeof BarChart3 }[] = [
   { key: 'email', label: 'Email', icon: Mail },
   { key: 'certifications', label: 'Certifications', icon: Award },
   { key: 'apikeys', label: 'API Keys', icon: KeyRound },
+  { key: 'catalog', label: 'Catalog', icon: PackageOpen },
   { key: 'config', label: 'Config', icon: Settings },
 ]
 
@@ -7091,6 +7094,14 @@ export default function Admin() {
     getAuthConfig().then(c => setTrialEnabled(!!c.trial_system_enabled)).catch(() => {})
   }, [])
 
+  // Honor ?tab=<key> deep links (e.g. the catalog-update notification).
+  useEffect(() => {
+    const requested = new URLSearchParams(window.location.search).get('tab')
+    if (requested && TABS.some(t => t.key === requested)) {
+      setActiveTab(requested as Tab)
+    }
+  }, [])
+
   const isGlobalAdmin = !!user?.is_admin
   const isStaff = !!user?.is_staff
   const isTeamAdmin = currentTeam?.role === 'owner' || currentTeam?.role === 'admin'
@@ -7103,11 +7114,11 @@ export default function Admin() {
   // endpoints accept a team scope. Tabs whose backends require admin/staff (email,
   // plus everything in hiddenForNonAdmin) stay hidden so we never render a tab that
   // can only 403.
-  const hiddenForNonAdmin = ['config', 'quality', 'compliance', 'demo', 'organizations', 'approvals', 'audit', 'certifications', 'apikeys', 'email', 'teams']
+  const hiddenForNonAdmin = ['config', 'catalog', 'quality', 'compliance', 'demo', 'organizations', 'approvals', 'audit', 'certifications', 'apikeys', 'email', 'teams']
   let visibleTabs = isGlobalAdmin
     ? TABS
     : isStaff
-      ? TABS.filter(t => t.key !== 'config')
+      ? TABS.filter(t => t.key !== 'config' && t.key !== 'catalog')
       : TABS.filter(t => !hiddenForNonAdmin.includes(t.key))
 
   if (!trialEnabled) {
@@ -7176,6 +7187,7 @@ export default function Admin() {
         {/* Content */}
         <div style={{ flex: 1, padding: '20px 32px', minWidth: 0 }}>
           <UpdateBanner />
+          {isGlobalAdmin && <CatalogUpdateBanner onView={() => setActiveTab('catalog')} />}
           {activeTab === 'usage' && <UsageTab />}
           {activeTab === 'users' && <UsersTab />}
           {activeTab === 'teams' && <TeamsTab />}
@@ -7188,6 +7200,7 @@ export default function Admin() {
           {activeTab === 'email' && (isGlobalAdmin || isStaff) && <EmailAnalyticsTab />}
           {activeTab === 'certifications' && (isGlobalAdmin || isStaff) && <CertificationsTab />}
           {activeTab === 'apikeys' && (isGlobalAdmin || isStaff) && <ApiKeysTab />}
+          {activeTab === 'catalog' && isGlobalAdmin && <CatalogTab />}
           {activeTab === 'config' && isGlobalAdmin && <ConfigTab />}
         </div>
       </div>

--- a/setup.sh
+++ b/setup.sh
@@ -8,7 +8,7 @@
 #    ./setup.sh --repair       Diagnose and fix a broken deployment
 #    ./setup.sh --upgrade      Scan origin for new code & catalog, apply what's outdated
 #    ./setup.sh --redeploy     Rebuild and restart from current code (no git pull)
-#    ./setup.sh --seed         Update verified catalog (add new seed data)
+#    ./setup.sh --seed         Update verified catalog (add/refresh, retire dropped items with your OK)
 #    ./setup.sh --reset-catalog  Wipe catalog metadata and re-seed from current version
 #    ./setup.sh --reingest     Re-ingest all knowledge base content into ChromaDB
 #    ./setup.sh --reset-email  Reconfigure email provider (SMTP or Resend)
@@ -1819,7 +1819,8 @@ update_catalog() {
   section "S" "Update Verified Catalog"
 
   echo -e "  ${DIM}     Re-seeding verified workflows, extractions, and knowledge bases.${RESET}"
-  echo -e "  ${DIM}     Existing items are skipped — only new seed data is added.${RESET}"
+  echo -e "  ${DIM}     New items are added and existing ones refreshed. Items dropped from${RESET}"
+  echo -e "  ${DIM}     the catalog can be retired (removed from explore) with your OK.${RESET}"
   echo ""
 
   # Find the API container
@@ -1835,8 +1836,38 @@ update_catalog() {
   echo -e "  ${SYM_ARROW}  Using container: ${BOLD}${container_name}${RESET}"
   echo ""
 
+  # --- Step 1: preview retirements (items dropped from the catalog) ---
+  # Dry run makes no changes; it just lists verified items whose seed_id is gone.
+  local prune_flag=""
+  local preview
+  if preview=$(docker exec "$container_name" python -m scripts.seed_catalog --prune --dry-run 2>&1); then
+    local retire_count
+    retire_count=$(echo "$preview" | grep -E '^Retiring [0-9]+ item' | head -1 | sed -E 's/^Retiring ([0-9]+) item.*/\1/' || echo "0")
+    if [[ -n "$retire_count" && "$retire_count" -gt 0 ]]; then
+      echo -e "  ${SYM_WARN}  ${YELLOW}${BOLD}${retire_count} item(s) were dropped from the catalog and can be retired:${RESET}"
+      # Show the bullet list of items the prune pass identified.
+      echo "$preview" | grep -E '^  - \[' | while IFS= read -r line; do
+        echo -e "  ${DIM}    ${line}${RESET}"
+      done
+      echo ""
+      echo -e "  ${DIM}     Retiring soft-archives them (verified=False, removed from explore).${RESET}"
+      echo -e "  ${DIM}     The underlying rows are kept, so this is reversible.${RESET}"
+      echo ""
+      echo -ne "  ${SYM_ARROW}  Retire these ${retire_count} item(s) during the update? [y/N]: "
+      local confirm
+      read -r confirm
+      if [[ "$confirm" =~ ^[Yy] ]]; then
+        prune_flag="--prune"
+      else
+        echo -e "  ${DIM}     Keeping them — running an additive update only.${RESET}"
+      fi
+      echo ""
+    fi
+  fi
+
+  # --- Step 2: seed (with --prune only if the user confirmed retirements) ---
   local seed_output
-  if seed_output=$(docker exec "$container_name" python -m scripts.seed_catalog 2>&1); then
+  if seed_output=$(docker exec "$container_name" python -m scripts.seed_catalog $prune_flag 2>&1); then
     # Display the output with indentation
     while IFS= read -r line; do
       echo -e "  ${DIM}     ${line}${RESET}"


### PR DESCRIPTION
## Why

The catalog seeder was **upsert-only** — it could add and refresh verified items but never **remove** them. The upcoming "official v1 catalog" drops ~half the Explore-tab items, and there was no clean upgrade path. The only way to (re)seed at all was `setup.sh` on the server — no in-app trigger, and no way for admins to even know an upgrade exists.

## What

### 1. Prune-by-manifest (retire dropped items)
`scripts/seed_catalog.py` gains `--prune` (+ `--dry-run`). After seeding, it diffs the `seed_id`s/titles live in `backend/seeds/**` against verified DB rows and **soft-archives** anything dropped:
- `verified=False`, detach `LibraryItem` + `VerifiedItemMetadata` + collection membership
- **underlying Workflow/SearchSet/KB row kept** → reversible, no data loss
- `./setup.sh --seed` previews retirements (`--dry-run`), lists them, prompts **y/N** before applying; non-interactive/cron stays additive-only (never auto-retires)
- Identity: workflows = `resource_config.seed_id`, search sets = `extraction_config.seed_id`. KBs never stored one → added `KnowledgeBase.resource_config` (stamped on seed) with a title fallback for legacy rows.

### 2. In-app, version-aware admin upgrade
Compares **bundled `seeds/VERSION`** (in the image) vs **applied `SystemConfig.catalog_version`**:
- `compute_catalog_diff()` — read-only preview of new / refreshed / retiring
- Admin endpoints (gated `_require_admin`): `GET /catalog/status` (banner), `GET /catalog/preview` (full diff), `POST /catalog/upgrade {prune}` (guards already-running/already-current, audits)
- Celery `tasks.catalog.upgrade` — seed + optional prune, status on `SystemConfig.catalog_upgrade`, **admin notifications** on done/fail
- Startup hook notifies admins **once per new version** (atomic compare-and-set dedup across workers)
- Frontend: amber `CatalogUpdateBanner` + **Catalog** admin tab (version display, preview, **default-on "Also retire N dropped items" toggle**, apply + 3s status polling); `?tab=catalog` deep-link honored

## Boundary

Covers upgrades **already in the deployed image** (bundled vs applied). A catalog newer on GitHub but not yet deployed still needs a code/image deploy first (`setup.sh`) — the app cannot pull new seed files itself. In practice catalog versions ship inside releases, so after deploying the banner/bell light up automatically.

## Testing

- `py_compile` + `ruff` (clean) + `tsc --noEmit` (exit 0)
- Live, against a running stack, through the **real Celery pipeline** using a self-contained canary item:
  - **Create path** (→1.0.1): job completed, `1 added / 29 refreshed / 0 retired`, canary became a verified catalog item (metadata + library item), admin completion notification fired
  - **Retire path** (→1.0.2, prune on): job completed, `retired: 1`, canary soft-archived (`verified=False`, metadata + library item removed, row preserved)
  - System restored to a clean baseline afterward
- Not exercised: the thin HTTP layer through an authenticated browser session (endpoints are import/route-verified). Worktree changes were copied into containers for the live run; the canonical change is this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
