### PR TITLE
feat(workflows): KB Query node - answer mode, templated queries, visible warnings

### DIFF
--- a/backend/app/services/document_manager.py
+++ b/backend/app/services/document_manager.py
@@ -357,11 +357,20 @@ class DocumentManager:
             dists_list = (results.get("distances") or [[]])[0]
             for i, doc in enumerate(results["documents"][0]):
                 metadata = results["metadatas"][0][i] if results.get("metadatas") else {}
+                dist = dists_list[i] if i < len(dists_list) else None
+                # Chroma returns squared-L2 distances and the default embedding
+                # function yields unit vectors, so d = 2(1 - cos); map back to
+                # cosine similarity clamped to [0, 1] for consumers that want a
+                # higher-is-better relevance signal.
+                similarity = None
+                if isinstance(dist, (int, float)):
+                    similarity = max(0.0, min(1.0, 1.0 - dist / 2.0))
                 output.append({
                     "content": doc,
                     "metadata": metadata,
                     "chunk_id": ids_list[i] if i < len(ids_list) else None,
-                    "score": dists_list[i] if i < len(dists_list) else None,
+                    "score": dist,
+                    "similarity": similarity,
                 })
         return output
 

--- a/backend/app/services/workflow_engine.py
+++ b/backend/app/services/workflow_engine.py
@@ -400,9 +400,19 @@ class MultiTaskNode(Node):
 
         collected = []
         task_step_name = self.name
+        merged_sources: list[dict] = []
+        warnings: list[str] = []
         for result in results:
             if result.get("_approval_pause"):
                 return result
+            # Citations and warnings must survive the wrapper even when a task
+            # produced no output (e.g. a failed KB lookup reports a warning).
+            sources = result.get("retrieved_sources")
+            if isinstance(sources, list):
+                merged_sources.extend(sources)
+            warning = result.get("warning")
+            if isinstance(warning, str) and warning:
+                warnings.append(warning)
             result_output = result.get("output")
             if result_output is None:
                 continue
@@ -417,7 +427,12 @@ class MultiTaskNode(Node):
         # Unwrap single-element lists for cleaner downstream data flow
         final_output = collected[0] if len(collected) == 1 else collected
 
-        return {"input": inputs.get("input"), "output": final_output, "step_name": task_step_name}
+        out = {"input": inputs.get("input"), "output": final_output, "step_name": task_step_name}
+        if merged_sources:
+            out["retrieved_sources"] = merged_sources
+        if warnings:
+            out["warning"] = " | ".join(warnings)
+        return out
 
 
 # ---------------------------------------------------------------------------
@@ -1239,33 +1254,116 @@ class BrowserAutomationNode(Node):
             service.end_session(session_id)
 
 
+KB_PASSAGES_HEADER = (
+    "Retrieved knowledge-base passages. These are partial excerpts ranked by "
+    "similarity to the search query — they may be incomplete or off-topic, and "
+    "the best answer may not be among them. Treat them as evidence to read "
+    "critically, not as a complete document."
+)
+
+KB_ANSWER_INSTRUCTION = (
+    "Answer the QUESTION below using ONLY the retrieved knowledge-base "
+    "passages in the CONTEXT block.\n"
+    "- The passages are partial excerpts ranked by similarity to the "
+    "question. They may be incomplete, off-topic, or contradictory — read "
+    "each one before relying on it, and ignore passages that are clearly "
+    "irrelevant.\n"
+    "- Cite the source line shown above each passage (filename plus "
+    "page/sheet, e.g. [PAPPG.pdf · p. 234]) for every factual claim. Never "
+    "attribute a claim to a passage that does not support it.\n"
+    "- If the passages do not contain a clear answer, say so explicitly "
+    "instead of guessing.\n\n"
+)
+
+
 class KnowledgeBaseQueryNode(Node):
-    """Workflow step that queries a knowledge base and returns matching chunks as context."""
+    """Workflow step that queries a knowledge base via RAG.
+
+    Two modes, selected by ``data["mode"]``:
+
+    * ``"passages"`` (default) — returns the matching chunks as a framed
+      plain-text context block for downstream steps to read losslessly.
+    * ``"answer"`` — additionally runs an LLM over the retrieved passages and
+      returns a grounded, citation-bearing answer.
+
+    The query supports ``{{ inputs.output }}`` placeholders so the lookup can
+    be driven by upstream step output. Both modes emit ``retrieved_sources``
+    citations. Misconfiguration, retrieval failures, and empty result sets
+    surface a ``warning`` (persisted on the step result) instead of silently
+    passing empty context downstream.
+    """
 
     def __init__(self, data: dict) -> None:
         super().__init__("KnowledgeBaseQuery")
         self.data = data
 
+    def _result(self, output, inputs, *, warning=None, sources=None):
+        result = {"output": output, "input": inputs.get("output"), "step_name": self.name}
+        if warning:
+            result["warning"] = warning
+        if sources:
+            result["retrieved_sources"] = sources
+        return result
+
     def process(self, inputs):
         from app.services.document_manager import DocumentManager
+        from app.utils import templating
 
-        kb_uuid = self.data.get("kb_uuid", "").strip()
-        query = self.data.get("query", "").strip()
-        k = int(self.data.get("k", 8))
+        kb_uuid = (self.data.get("kb_uuid") or "").strip()
+        mode = (self.data.get("mode") or "passages").strip().lower()
+        try:
+            k = int(self.data.get("k") or 8)
+        except (TypeError, ValueError):
+            k = 8
+        try:
+            min_similarity = float(self.data.get("min_similarity") or 0.0)
+        except (TypeError, ValueError):
+            min_similarity = 0.0
 
         if not kb_uuid:
-            return {"output": "", "input": inputs.get("output"), "step_name": self.name}
+            return self._result(
+                "", inputs,
+                warning="Knowledge Base Query is not configured: no knowledge base selected.",
+            )
 
+        raw_query = (self.data.get("query") or "").strip()
+        if not raw_query:
+            return self._result(
+                "", inputs,
+                warning="Knowledge Base Query is not configured: the query is empty.",
+            )
+
+        try:
+            query = templating.render(raw_query, inputs, json_encode=False).strip()
+        except templating.TemplateError as e:
+            return self._result(str(e), inputs, warning=str(e))
         if not query:
-            return {"output": "", "input": inputs.get("output"), "step_name": self.name}
+            return self._result(
+                "", inputs,
+                warning="Knowledge Base Query skipped: the query template rendered to an empty string.",
+            )
 
         self.report_progress("Querying knowledge base…")
 
         dm = DocumentManager()
-        results = dm.query_kb(kb_uuid, query, k=k)
+        try:
+            results = dm.query_kb(kb_uuid, query, k=k)
+        except Exception as e:
+            logger.error("KB query failed for kb_uuid=%s: %s", kb_uuid, e)
+            warning = f"Knowledge base lookup failed: {e}"
+            return self._result(warning, inputs, warning=warning)
+
+        if min_similarity > 0:
+            results = [
+                r for r in results
+                if not isinstance(r.get("similarity"), (int, float))
+                or r["similarity"] >= min_similarity
+            ]
 
         if not results:
-            return {"output": "", "input": inputs.get("output"), "step_name": self.name}
+            self.report_progress("No matching passages found")
+            warning = f"The knowledge base returned no matching passages for the query: {query!r}."
+            return self._result(f"({warning})", inputs, warning=warning)
 
         # Format as plain text context block so downstream LLM steps can use it naturally
         parts = []
@@ -1288,16 +1386,25 @@ class KnowledgeBaseQueryNode(Node):
                 "sheet": sheet if isinstance(sheet, str) else None,
                 "chunk_id": r.get("chunk_id"),
                 "score": r.get("score"),
+                "similarity": r.get("similarity"),
                 "content_preview": (r.get("content") or "")[:240],
             })
 
-        output = "\n\n---\n\n".join(parts)
-        return {
-            "output": output,
-            "input": inputs.get("output"),
-            "step_name": self.name,
-            "retrieved_sources": sources,
-        }
+        passages = "\n\n---\n\n".join(parts)
+
+        if mode != "answer":
+            return self._result(f"{KB_PASSAGES_HEADER}\n\n{passages}", inputs, sources=sources)
+
+        self.report_progress("Synthesizing answer from retrieved passages…")
+        answer = llm_chat_model(
+            model=self.data.get("model"),
+            prompt=KB_ANSWER_INSTRUCTION + f"QUESTION:\n{query}",
+            data=passages,
+            include_next_step=False,
+            system_config_doc=self._sys_cfg,
+            usage_acc=self._usage_acc,
+        )
+        return self._result(answer, inputs, sources=sources)
 
 
 # ---------------------------------------------------------------------------
@@ -1395,6 +1502,9 @@ class WorkflowEngine:
             sources = latest_output.get("retrieved_sources")
             if isinstance(sources, list) and sources:
                 entry["retrieved_sources"] = sources
+            warning = latest_output.get("warning")
+            if isinstance(warning, str) and warning:
+                entry["warning"] = warning
             data.append(entry)
 
         if latest_output is None:

--- a/backend/tests/test_workflow_engine_core.py
+++ b/backend/tests/test_workflow_engine_core.py
@@ -356,6 +356,32 @@ class TestMultiTaskNode:
         result = multi.process({"output": "prev"})
         assert result["output"] == "good"
 
+    def test_retrieved_sources_and_warning_propagate(self):
+        """Citations and warnings emitted by a wrapped task (e.g. a KB query)
+        must survive MultiTaskNode aggregation so the engine can persist them."""
+        multi = MultiTaskNode("KB Step")
+
+        class CitingNode(Node):
+            def process(self, inputs):
+                return {
+                    "output": "passages",
+                    "step_name": "KnowledgeBaseQuery",
+                    "retrieved_sources": [{"document_title": "a.pdf"}],
+                }
+
+        class WarningNode(Node):
+            def process(self, inputs):
+                return {"output": None, "step_name": "KnowledgeBaseQuery",
+                        "warning": "no matching passages"}
+
+        multi.add_task(CitingNode("citing"))
+        multi.add_task(WarningNode("warning"))
+        result = multi.process({"output": "prev"})
+
+        assert result["retrieved_sources"] == [{"document_title": "a.pdf"}]
+        assert "no matching passages" in result["warning"]
+        assert result["output"] == "passages"
+
     def test_inputs_deepcopied(self):
         """Each task gets its own copy of inputs."""
         multi = MultiTaskNode("Test Step")

--- a/backend/tests/test_workflow_nodes.py
+++ b/backend/tests/test_workflow_nodes.py
@@ -1338,21 +1338,146 @@ class TestKnowledgeBaseQueryNode:
         node = KnowledgeBaseQueryNode({"kb_uuid": "", "query": "test"})
         result = node.process({"output": "prev"})
         assert result["output"] == ""
+        assert "no knowledge base selected" in result["warning"]
 
     def test_empty_query(self):
         node = KnowledgeBaseQueryNode({"kb_uuid": "kb-123", "query": ""})
         result = node.process({"output": "prev"})
         assert result["output"] == ""
+        assert "query is empty" in result["warning"]
 
     @patch("app.services.document_manager.DocumentManager")
     def test_no_results(self, mock_dm_cls):
+        """An empty result set surfaces a warning and an explicit output
+        message instead of silently feeding "" to the next step."""
         mock_dm = MagicMock()
         mock_dm.query_kb.return_value = []
         mock_dm_cls.return_value = mock_dm
 
         node = KnowledgeBaseQueryNode({"kb_uuid": "kb-123", "query": "obscure"})
         result = node.process({"output": "prev"})
-        assert result["output"] == ""
+        assert "no matching passages" in result["output"]
+        assert "obscure" in result["warning"]
+
+    @patch("app.services.document_manager.DocumentManager")
+    def test_passages_output_has_framing_header(self, mock_dm_cls):
+        """Downstream LLM steps are told the chunks are partial retrieval
+        excerpts, mirroring the framing the chat RAG path uses."""
+        mock_dm = MagicMock()
+        mock_dm.query_kb.return_value = [
+            {"content": "Chunk text", "metadata": {"source_name": "doc.pdf"}},
+        ]
+        mock_dm_cls.return_value = mock_dm
+
+        node = KnowledgeBaseQueryNode({"kb_uuid": "kb-1", "query": "anything"})
+        result = node.process({"output": "prev"})
+        assert "partial excerpts" in result["output"]
+        assert "Chunk text" in result["output"]
+
+    @patch("app.services.document_manager.DocumentManager")
+    def test_templated_query_uses_previous_output(self, mock_dm_cls):
+        mock_dm = MagicMock()
+        mock_dm.query_kb.return_value = []
+        mock_dm_cls.return_value = mock_dm
+
+        node = KnowledgeBaseQueryNode({
+            "kb_uuid": "kb-1",
+            "query": "policies for {{ inputs.output }}",
+        })
+        node.process({"output": "NSF", "step_name": "Extraction"})
+
+        mock_dm.query_kb.assert_called_once_with("kb-1", "policies for NSF", k=8)
+
+    def test_template_error_surfaces_warning(self):
+        node = KnowledgeBaseQueryNode({
+            "kb_uuid": "kb-1",
+            "query": "{{ inputs.output.missing_key }}",
+        })
+        result = node.process({"output": {"other": 1}, "step_name": "Prompt"})
+        assert result["warning"]
+        assert result["output"] == result["warning"]
+
+    @patch("app.services.document_manager.DocumentManager")
+    def test_min_similarity_filters_low_relevance_chunks(self, mock_dm_cls):
+        mock_dm = MagicMock()
+        mock_dm.query_kb.return_value = [
+            {"content": "Relevant", "metadata": {"source_name": "a.pdf"}, "similarity": 0.8},
+            {"content": "Junk", "metadata": {"source_name": "b.pdf"}, "similarity": 0.05},
+        ]
+        mock_dm_cls.return_value = mock_dm
+
+        node = KnowledgeBaseQueryNode({
+            "kb_uuid": "kb-1", "query": "q", "min_similarity": "0.3",
+        })
+        result = node.process({"output": "prev"})
+        assert "Relevant" in result["output"]
+        assert "Junk" not in result["output"]
+        assert len(result["retrieved_sources"]) == 1
+
+    @patch("app.services.document_manager.DocumentManager")
+    def test_min_similarity_filtering_everything_warns(self, mock_dm_cls):
+        mock_dm = MagicMock()
+        mock_dm.query_kb.return_value = [
+            {"content": "Junk", "metadata": {"source_name": "b.pdf"}, "similarity": 0.05},
+        ]
+        mock_dm_cls.return_value = mock_dm
+
+        node = KnowledgeBaseQueryNode({
+            "kb_uuid": "kb-1", "query": "q", "min_similarity": 0.5,
+        })
+        result = node.process({"output": "prev"})
+        assert "no matching passages" in result["warning"]
+
+    @patch("app.services.document_manager.DocumentManager")
+    def test_query_error_soft_fails_with_warning(self, mock_dm_cls):
+        """A retrieval failure becomes a visible warning, not a dead workflow."""
+        mock_dm = MagicMock()
+        mock_dm.query_kb.side_effect = RuntimeError("chroma down")
+        mock_dm_cls.return_value = mock_dm
+
+        node = KnowledgeBaseQueryNode({"kb_uuid": "kb-1", "query": "q"})
+        result = node.process({"output": "prev"})
+        assert "chroma down" in result["warning"]
+        assert "chroma down" in result["output"]
+
+    @patch("app.services.workflow_engine.llm_chat_model")
+    @patch("app.services.document_manager.DocumentManager")
+    def test_answer_mode_synthesizes_grounded_answer(self, mock_dm_cls, mock_llm):
+        mock_dm = MagicMock()
+        mock_dm.query_kb.return_value = [
+            {"content": "Cost share is 50%", "metadata": {"source_name": "PAPPG.pdf", "page": 234}},
+        ]
+        mock_dm_cls.return_value = mock_dm
+        mock_llm.return_value = "Cost share is 50% [PAPPG.pdf · p. 234]"
+
+        node = KnowledgeBaseQueryNode({
+            "kb_uuid": "kb-1",
+            "query": "What is the cost share?",
+            "mode": "answer",
+            "model": "gpt-4o",
+        })
+        result = node.process({"output": "prev"})
+
+        assert result["output"] == "Cost share is 50% [PAPPG.pdf · p. 234]"
+        # Citations still flow even when the output is a synthesized answer.
+        assert result["retrieved_sources"][0]["document_title"] == "PAPPG.pdf"
+        call = mock_llm.call_args
+        assert call.kwargs["model"] == "gpt-4o"
+        assert "QUESTION:\nWhat is the cost share?" in call.kwargs["prompt"]
+        assert "Cost share is 50%" in call.kwargs["data"]
+
+    @patch("app.services.workflow_engine.llm_chat_model")
+    @patch("app.services.document_manager.DocumentManager")
+    def test_passages_mode_makes_no_llm_call(self, mock_dm_cls, mock_llm):
+        mock_dm = MagicMock()
+        mock_dm.query_kb.return_value = [
+            {"content": "Chunk", "metadata": {"source_name": "a.pdf"}},
+        ]
+        mock_dm_cls.return_value = mock_dm
+
+        node = KnowledgeBaseQueryNode({"kb_uuid": "kb-1", "query": "q"})
+        node.process({"output": "prev"})
+        mock_llm.assert_not_called()
 
     @patch("app.services.document_manager.DocumentManager")
     def test_emits_retrieved_sources_with_page_and_score(self, mock_dm_cls):

--- a/frontend/src/components/workspace/WorkflowEditorPanel.tsx
+++ b/frontend/src/components/workspace/WorkflowEditorPanel.tsx
@@ -8,7 +8,7 @@ import {
   ChevronDown, ChevronRight, ArrowUp, ArrowDown,
   Circle, Hand, Keyboard, Sparkles, ShieldCheck, Type,
   ArrowRight, Pause, TrendingUp, RefreshCw,
-  Upload, Clock, Copy, Check, FolderInput, Link2, Info,
+  Upload, Clock, Copy, Check, FolderInput, Link2, Info, AlertTriangle,
 } from 'lucide-react'
 import { useWorkspace } from '../../contexts/WorkspaceContext'
 import { useToast } from '../../contexts/ToastContext'
@@ -96,7 +96,7 @@ const TASK_TYPES: TaskTypeDef[] = [
   { name: 'ResearchNode', label: 'Research Node', icon: Search, color: '#8b5cf6', categories: ['all', 'web'], enabled: true,
     description: 'Runs an LLM-driven web search and synthesizes the findings into a written report.' },
   { name: 'KnowledgeBaseQuery', label: 'Knowledge Base Query', icon: Sparkles, color: '#0ea5e9', categories: ['all', 'text'], enabled: true,
-    description: 'Queries a connected knowledge base via RAG and returns the matching passages.' },
+    description: 'Asks a question of a connected knowledge base via RAG and returns a cited answer, or the raw matching passages.' },
   { name: 'APINode', label: 'API Node', icon: Zap, color: '#f97316', categories: ['all', 'web'], enabled: true,
     description: 'Calls an external HTTP API and returns the parsed response for downstream steps to use.' },
   { name: 'DocumentRenderer', label: 'Document Renderer', icon: FileText, color: '#0d9488', categories: ['all', 'output'], enabled: true,
@@ -372,7 +372,12 @@ export function WorkflowEditorPanel() {
       return
     }
     try {
-      const created = await addTask(editingStepId, { name: taskType.name })
+      // New KB Query steps default to answer mode (the intuitive behavior);
+      // pre-existing steps without a mode keep returning raw passages.
+      const created = await addTask(editingStepId, {
+        name: taskType.name,
+        ...(taskType.name === 'KnowledgeBaseQuery' ? { data: { mode: 'answer' } } : {}),
+      })
       setShowTaskPicker(false)
       await refresh()
       if (created?.id) {
@@ -2142,9 +2147,9 @@ function TaskEditModal({ task, selectedDocUuids, workflow, workflowId, onClose, 
   const color = getTaskColor(task.name)
   const taskIcon = getTaskIcon(task.name)
 
-  // Load models for LLM task types
+  // Load models for LLM task types (KB Query needs them for answer mode)
   useEffect(() => {
-    if (LLM_TASKS.includes(task.name)) {
+    if (LLM_TASKS.includes(task.name) || task.name === 'KnowledgeBaseQuery') {
       getModels().then(setModels).catch(() => {})
     }
   }, [task.name])
@@ -2947,7 +2952,34 @@ function TaskEditModal({ task, selectedDocUuids, workflow, workflowId, onClose, 
                 </div>
                 <div style={{ marginBottom: 16 }}>
                   <label style={{ display: 'block', fontSize: 13, fontWeight: 600, color: '#374151', marginBottom: 6 }}>
-                    Search Query
+                    Return
+                  </label>
+                  <div style={{ position: 'relative' }}>
+                    <select
+                      value={getTextValue('mode') || 'passages'}
+                      onChange={e => setTextValue('mode', e.target.value)}
+                      style={{
+                        width: '100%', padding: '8px 12px', fontSize: 13, fontFamily: 'inherit',
+                        border: '1px solid #d1d5db', borderRadius: 6, backgroundColor: '#fff',
+                        color: '#374151', appearance: 'none', paddingRight: 32,
+                      }}
+                    >
+                      <option value="answer">Synthesized answer — LLM answers the question, with citations</option>
+                      <option value="passages">Matching passages — raw retrieved chunks for the next step</option>
+                    </select>
+                    <ChevronDown style={{
+                      position: 'absolute', right: 10, top: '50%', transform: 'translateY(-50%)',
+                      width: 14, height: 14, color: '#9ca3af', pointerEvents: 'none',
+                    }} />
+                  </div>
+                  <div style={{ fontSize: 11, color: '#6b7280', marginTop: 4 }}>
+                    Use passages when a later step needs the raw evidence (extraction, form filling);
+                    use a synthesized answer when this step should resolve the question itself.
+                  </div>
+                </div>
+                <div style={{ marginBottom: 16 }}>
+                  <label style={{ display: 'block', fontSize: 13, fontWeight: 600, color: '#374151', marginBottom: 6 }}>
+                    {(getTextValue('mode') || 'passages') === 'answer' ? 'Question' : 'Search Query'}
                   </label>
                   <textarea
                     value={getTextValue('query')}
@@ -2961,25 +2993,49 @@ function TaskEditModal({ task, selectedDocUuids, workflow, workflowId, onClose, 
                     }}
                   />
                   <div style={{ fontSize: 11, color: '#6b7280', marginTop: 4 }}>
-                    The top matching chunks are returned as text and passed to the next step.
+                    Supports {'{{ inputs.output }}'} to query with the previous step's output —
+                    e.g. look up the sponsor name an earlier step extracted.
                   </div>
                 </div>
-                <div>
-                  <label style={{ display: 'block', fontSize: 13, fontWeight: 600, color: '#374151', marginBottom: 6 }}>
-                    Results to retrieve
-                  </label>
-                  <input
-                    type="number"
-                    min={1}
-                    max={20}
-                    value={getTextValue('k') || '8'}
-                    onChange={e => setTextValue('k', e.target.value)}
-                    style={{
-                      width: 80, padding: '8px 12px', fontSize: 13,
-                      fontFamily: 'inherit', border: '1px solid #d1d5db', borderRadius: 6,
-                      outline: 'none', boxSizing: 'border-box',
-                    }}
-                  />
+                <div style={{ display: 'flex', gap: 16 }}>
+                  <div>
+                    <label style={{ display: 'block', fontSize: 13, fontWeight: 600, color: '#374151', marginBottom: 6 }}>
+                      Results to retrieve
+                    </label>
+                    <input
+                      type="number"
+                      min={1}
+                      max={20}
+                      value={getTextValue('k') || '8'}
+                      onChange={e => setTextValue('k', e.target.value)}
+                      style={{
+                        width: 80, padding: '8px 12px', fontSize: 13,
+                        fontFamily: 'inherit', border: '1px solid #d1d5db', borderRadius: 6,
+                        outline: 'none', boxSizing: 'border-box',
+                      }}
+                    />
+                  </div>
+                  <div>
+                    <label style={{ display: 'block', fontSize: 13, fontWeight: 600, color: '#374151', marginBottom: 6 }}>
+                      Minimum relevance
+                    </label>
+                    <input
+                      type="number"
+                      min={0}
+                      max={1}
+                      step={0.05}
+                      value={getTextValue('min_similarity') || '0'}
+                      onChange={e => setTextValue('min_similarity', e.target.value)}
+                      style={{
+                        width: 80, padding: '8px 12px', fontSize: 13,
+                        fontFamily: 'inherit', border: '1px solid #d1d5db', borderRadius: 6,
+                        outline: 'none', boxSizing: 'border-box',
+                      }}
+                    />
+                    <div style={{ fontSize: 11, color: '#6b7280', marginTop: 4 }}>
+                      Drop passages below this similarity (0–1; 0 keeps all).
+                    </div>
+                  </div>
                 </div>
               </div>
             )}
@@ -3455,8 +3511,10 @@ function TaskEditModal({ task, selectedDocUuids, workflow, workflowId, onClose, 
               )
             })()}
 
-            {/* Model override for LLM tasks */}
-            {LLM_TASKS.includes(task.name) && models.length > 0 && (
+            {/* Model override for LLM tasks (KB Query only calls an LLM in answer mode) */}
+            {(LLM_TASKS.includes(task.name)
+              || (task.name === 'KnowledgeBaseQuery' && (getTextValue('mode') || 'passages') === 'answer'))
+              && models.length > 0 && (
               <div style={{ marginTop: 16 }}>
                 <label style={{ display: 'block', fontSize: 13, fontWeight: 600, color: '#374151', marginBottom: 6 }}>
                   Model Override <span style={{ fontWeight: 400, color: '#9ca3af' }}>(optional)</span>
@@ -4047,6 +4105,33 @@ function WorkflowOutputCard({ status, sessionId, workflowName, running, runElaps
     ].join('\n')
   }
 
+  // Steps can attach a warning under steps_output[step].warning (e.g. a KB
+  // query that matched nothing, or a misconfigured lookup). Surface it so a
+  // run that "succeeded" on thin context doesn't read as a clean pass.
+  const stepWarnings = Object.entries((status?.steps_output ?? {}) as Record<string, unknown>)
+    .map(([step, val]) => {
+      const warning = val && typeof val === 'object' ? (val as Record<string, unknown>).warning : undefined
+      return typeof warning === 'string' && warning ? { step, warning } : null
+    })
+    .filter((x): x is { step: string; warning: string } => x !== null)
+
+  const stepWarningsPanel = stepWarnings.length > 0 ? (
+    <div style={{ marginTop: 12 }}>
+      {stepWarnings.map(({ step, warning }) => (
+        <div key={step} style={{
+          display: 'flex', alignItems: 'flex-start', gap: 8,
+          border: '1px solid #fde68a', backgroundColor: '#fffbeb', borderRadius: 6,
+          padding: '8px 12px', marginBottom: 8, fontSize: 12, color: '#92400e',
+        }}>
+          <AlertTriangle style={{ width: 14, height: 14, flexShrink: 0, marginTop: 1 }} />
+          <div>
+            <span style={{ fontWeight: 600 }}>{step}:</span> {warning}
+          </div>
+        </div>
+      ))}
+    </div>
+  ) : null
+
   const apiRequestPanel = apiRequests.length > 0 ? (
     <div style={{ marginTop: 12 }}>
       {apiRequests.map(({ step, req }) => (
@@ -4245,6 +4330,7 @@ function WorkflowOutputCard({ status, sessionId, workflowName, running, runElaps
             }}
             dangerouslySetInnerHTML={{ __html: renderOutput(output) }}
           />
+          {stepWarningsPanel}
           {apiRequestPanel}
           <div style={{ marginTop: 12, display: 'flex', gap: 8, alignItems: 'center' }}>
           <div style={{ position: 'relative', display: 'inline-block' }}>
@@ -4335,6 +4421,7 @@ function WorkflowOutputCard({ status, sessionId, workflowName, running, runElaps
               docs={status.error_payload?.oversize_documents ?? []}
             />
           )}
+          {stepWarningsPanel}
           {apiRequestPanel}
         </div>
       )}
@@ -4370,10 +4457,12 @@ function WorkflowSourcesPanel({ sources }: { sources: WorkflowCitation[] }) {
           {sources.map((c, i) => {
             const locator = typeof c.page === 'number' ? `p. ${c.page}` : (c.sheet || null)
             const label = locator ? `${c.document_title} · ${locator}` : c.document_title
+            const relevance = typeof c.similarity === 'number' ? `${Math.round(c.similarity * 100)}% match` : null
+            const tooltip = [relevance, c.content_preview || null].filter(Boolean).join(' — ')
             return (
               <span
                 key={`${c.chunk_id ?? c.document_id ?? i}`}
-                title={c.content_preview || ''}
+                title={tooltip}
                 style={{
                   display: 'inline-flex', alignItems: 'center', gap: 4,
                   padding: '2px 8px', fontSize: 11, fontWeight: 500,

--- a/frontend/src/types/workflow.ts
+++ b/frontend/src/types/workflow.ts
@@ -95,6 +95,7 @@ export interface WorkflowCitation {
   sheet?: string | null;
   chunk_id?: string | null;
   score?: number | null;
+  similarity?: number | null;
   content_preview?: string;
 }
 


### PR DESCRIPTION
## Summary

Brings the Knowledge Base Query workflow node up to par with the chat RAG path. Previously the node returned raw chunks from a design-time-frozen query and failed silently in every error path.

- **Templated queries** — the query field renders `{{ inputs.output }}` placeholders (same `app.utils.templating` machinery as APINode), so a lookup can be driven by upstream step output (e.g. extract a sponsor name, then query that sponsor's policies).
- **Answer mode** — new `mode: passages | answer` toggle. Answer mode retrieves, then synthesizes a grounded answer via LLM with per-claim source citations and explicit "not found" behavior, mirroring the KB chat grounding rules. New steps created in the editor default to answer mode; existing saved steps keep returning passages (no behavior change). Model-override dropdown appears only in answer mode.
- **Visible failures** — missing KB, empty query, retrieval exceptions, and zero-hit queries surface a step `warning` (amber panel in the run output, same pattern as the API-request debug panel) instead of silently passing empty context to the next step. Retrieval errors soft-fail rather than killing the run.
- **Relevance signal** — `query_kb` now emits a 0–1 `similarity` alongside the raw Chroma distance; the node gains an optional "Minimum relevance" gate (default off), citation chips show "82% match" in tooltips, and passages output gets the partial-excerpts framing header the chat path already used.
- **Bug fix** — `MultiTaskNode` dropped `retrieved_sources` from wrapped tasks, so KB citations never reached the Sources panel in real (non-test-step) runs. It now merges citations and warnings through, with a regression test.

## Test plan

- [x] `pytest tests/test_workflow_nodes.py tests/test_workflow_engine_core.py` — 162 passed (9 new KB node tests: templating, template errors, answer mode, similarity gating, warning paths; 1 new MultiTaskNode propagation test)
- [x] `ruff check` clean on changed app files
- [x] Frontend: `tsc --noEmit` clean, `vitest run` 140 passed, eslint (only pre-existing warning)
- [ ] Manual: run a 2-step workflow (Extraction → KB Query with `{{ inputs.output }}`) against a seeded KB; verify cited answer, Sources panel chips, and the no-results warning panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)
