### PR TITLE
feat: role-based UI modes for Research Administrators and Developers

### DIFF
--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -24,6 +24,7 @@ class User(Document):
     demo_expires_at: Optional[datetime.datetime] = None
     demo_status: Optional[str] = None  # active | expired | locked
     organization_id: Optional[str] = None  # org uuid for university hierarchy
+    app_role: Optional[str] = None  # "research_admin" | "developer" | None (None = developer)
 
     # Engagement tracking
     last_login_at: Optional[datetime.datetime] = None

--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -345,6 +345,7 @@ class UserDetailResponse(BaseModel):
     is_admin: bool = False
     is_staff: bool = False
     is_examiner: bool = False
+    app_role: Optional[str] = None
     tokens_in: int = 0
     tokens_out: int = 0
     workflows_started: int = 0
@@ -1056,6 +1057,7 @@ async def user_detail(
             if show_platform_role_flags
             else False
         ),
+        app_role=getattr(target_user, "app_role", None) if show_platform_role_flags else None,
         tokens_in=tokens_in, tokens_out=tokens_out,
         workflows_started=workflows_started,
         workflows_completed=workflows_completed,
@@ -1206,6 +1208,7 @@ class UpdateRolesRequest(BaseModel):
     is_admin: Optional[bool] = None
     is_staff: Optional[bool] = None
     is_examiner: Optional[bool] = None
+    app_role: Optional[str] = None
 
 
 @router.put("/users/{user_id}/roles")
@@ -1226,11 +1229,13 @@ async def update_user_roles(
         target.is_staff = body.is_staff
     if body.is_examiner is not None:
         target.is_examiner = body.is_examiner
+    if body.app_role is not None:
+        target.app_role = body.app_role if body.app_role != "developer" else None
     await target.save()
 
     await _audit(
         user, "update_user_roles",
-        f"Updated roles for {user_id}: admin={target.is_admin}, staff={target.is_staff}, examiner={target.is_examiner}",
+        f"Updated roles for {user_id}: admin={target.is_admin}, staff={target.is_staff}, examiner={target.is_examiner}, app_role={target.app_role}",
     )
 
     return {"ok": True}

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -75,6 +75,7 @@ async def _user_response(user: User) -> UserResponse:
         is_demo_user=user.is_demo_user,
         current_team=str(user.current_team) if user.current_team else None,
         current_team_uuid=current_team_uuid,
+        app_role=user.app_role,
     )
 
 

--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -87,3 +87,4 @@ class UserResponse(BaseModel):
     is_demo_user: bool = False
     current_team: Optional[str] = None
     current_team_uuid: Optional[str] = None
+    app_role: Optional[str] = None

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,6 +6,7 @@ import { TeamProvider } from './contexts/TeamContext'
 import { ToastProvider } from './contexts/ToastContext'
 import { CertificationPanelProvider } from './contexts/CertificationPanelContext'
 import { BrandingProvider } from './contexts/BrandingContext'
+import { AppModeProvider } from './contexts/AppModeContext'
 import { CertificationPanel } from './components/certification/CertificationPanel'
 import { ConfirmProvider } from './components/shared/useConfirm'
 import { queryClient } from './lib/queryClient'
@@ -85,6 +86,7 @@ export default function App() {
       <QueryClientProvider client={queryClient}>
         <BrandingProvider>
           <AuthProvider>
+            <AppModeProvider>
             <TeamProvider>
               <ToastProvider>
                 <ConfirmProvider>
@@ -95,6 +97,7 @@ export default function App() {
                 </ConfirmProvider>
               </ToastProvider>
             </TeamProvider>
+            </AppModeProvider>
           </AuthProvider>
         </BrandingProvider>
       </QueryClientProvider>

--- a/frontend/src/api/admin.ts
+++ b/frontend/src/api/admin.ts
@@ -192,6 +192,7 @@ export interface UserDetailResponse {
   is_admin: boolean
   is_staff: boolean
   is_examiner: boolean
+  app_role: string | null
   tokens_in: number
   tokens_out: number
   workflows_started: number
@@ -363,7 +364,7 @@ export function getIsolatedUsers() {
   return apiFetch<IsolatedUserItem[]>('/api/admin/users/isolated')
 }
 
-export function updateUserRoles(userId: string, roles: { is_admin?: boolean; is_staff?: boolean; is_examiner?: boolean }) {
+export function updateUserRoles(userId: string, roles: { is_admin?: boolean; is_staff?: boolean; is_examiner?: boolean; app_role?: string }) {
   return apiFetch<{ ok: boolean }>(`/api/admin/users/${encodeURIComponent(userId)}/roles`, {
     method: 'PUT',
     body: JSON.stringify(roles),

--- a/frontend/src/components/auth/ProtectedRoute.tsx
+++ b/frontend/src/components/auth/ProtectedRoute.tsx
@@ -4,9 +4,15 @@ import {
   consumePendingInviteToken,
   consumePendingJoinLinkToken,
 } from '../../lib/pendingInvite'
+import { useAppMode } from '../../contexts/AppModeContext'
+
+const RA_ALLOWED_PREFIXES = ['/', '/chat', '/workflows']
+const isAllowedForRA = (path: string) =>
+  path === '/' || RA_ALLOWED_PREFIXES.slice(1).some(p => path.startsWith(p))
 
 export function ProtectedRoute({ children }: { children: React.ReactNode }) {
   const { user, loading, demoExpired, demoFeedbackToken } = useAuth()
+  const { isRA } = useAppMode()
 
   if (loading) {
     return (
@@ -40,6 +46,10 @@ export function ProtectedRoute({ children }: { children: React.ReactNode }) {
   const pendingJoin = consumePendingJoinLinkToken()
   if (pendingJoin) {
     return <Navigate to="/join" search={{ token: pendingJoin }} />
+  }
+
+  if (isRA && !isAllowedForRA(window.location.pathname)) {
+    return <Navigate to="/" search={{ mode: undefined, tab: undefined, workflow: undefined, extraction: undefined, automation: undefined, kb: undefined, workflow_share_token: undefined }} />
   }
 
   return <>{children}</>

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -8,12 +8,15 @@ import { FeedbackPromptCard } from '../support/FeedbackPromptCard'
 import { useOptionalWorkspace } from '../../contexts/WorkspaceContext'
 import { useBranding } from '../../contexts/BrandingContext'
 import { useFeedbackPrompt } from '../../hooks/useFeedbackPrompt'
+import { useAppMode } from '../../contexts/AppModeContext'
+import { cn } from '../../lib/cn'
 
 export function Header() {
   const navigate = useNavigate()
   const workspace = useOptionalWorkspace()
   const branding = useBranding()
   const brandIcon = branding.iconUrl
+  const { mode, canToggle, setMode } = useAppMode()
   const [supportOpen, setSupportOpen] = useState(false)
   const [supportTicket, setSupportTicket] = useState<string | undefined>()
   const [promptCardHidden, setPromptCardHidden] = useState(false)
@@ -100,6 +103,30 @@ export function Header() {
             />
           </button>
         </div>
+
+        {/* Center: RA / Developer mode toggle (Developers only) */}
+        {canToggle && (
+          <div className="flex rounded-full border border-gray-200 bg-gray-100 p-0.5 text-xs font-medium">
+            <button
+              onClick={() => setMode('ra')}
+              className={cn(
+                'rounded-full px-3 py-1 transition-all',
+                mode === 'ra' ? 'bg-white shadow text-blue-700' : 'text-gray-500 hover:text-gray-700',
+              )}
+            >
+              RA Mode
+            </button>
+            <button
+              onClick={() => setMode('developer')}
+              className={cn(
+                'rounded-full px-3 py-1 transition-all',
+                mode === 'developer' ? 'bg-white shadow text-blue-700' : 'text-gray-500 hover:text-gray-700',
+              )}
+            >
+              Developer Mode
+            </button>
+          </div>
+        )}
 
         {/* Right: Notifications + Support + Teams dropdown */}
         <div className="flex items-center gap-4">

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -3,11 +3,13 @@ import { Link, useRouterState } from '@tanstack/react-router'
 import { cn } from '../../lib/cn'
 import { useAuth } from '../../hooks/useAuth'
 import { useTeams } from '../../hooks/useTeams'
+import { useAppMode } from '../../contexts/AppModeContext'
 
 export function Sidebar() {
   const pathname = useRouterState({ select: (s) => s.location.pathname })
   const { user } = useAuth()
   const { currentTeam } = useTeams()
+  const { isRA } = useAppMode()
 
   const isTeamAdmin = currentTeam?.role === 'owner' || currentTeam?.role === 'admin'
   // Mirror the admin panel's own access rule (Admin.tsx hasAccess): admin, staff, or
@@ -15,19 +17,25 @@ export function Sidebar() {
   // below, and every admin-panel endpoint would 403 them.
   const showAdmin = !!user?.is_admin || !!user?.is_staff || isTeamAdmin
 
-  const links = [
-    { href: '/', label: 'Documents', icon: FileText },
-    { href: '/chat', label: 'Chat', icon: MessageSquare },
-    { href: '/library', label: 'Library', icon: BookOpen },
-    { href: '/workflows', label: 'Workflows', icon: Workflow },
-    { href: '/automation', label: 'Automation', icon: Zap },
-    { href: '/office', label: 'Office 365', icon: Cloud },
-    { href: '/browser-automation', label: 'Browser', icon: Globe },
-    { href: '/teams', label: 'Teams', icon: Users },
-    { href: '/credentials', label: 'Credentials', icon: KeyRound },
-    ...(user?.is_examiner ? [{ href: '/verification', label: 'Verification', icon: ClipboardCheck }] : []),
-    ...(showAdmin ? [{ href: '/admin', label: 'Admin', icon: Shield }] : []),
-  ] as const
+  const links = isRA
+    ? [
+        { href: '/', label: 'Documents', icon: FileText },
+        { href: '/chat', label: 'Chat', icon: MessageSquare },
+        { href: '/workflows', label: 'Workflows', icon: Workflow },
+      ]
+    : [
+        { href: '/', label: 'Documents', icon: FileText },
+        { href: '/chat', label: 'Chat', icon: MessageSquare },
+        { href: '/library', label: 'Library', icon: BookOpen },
+        { href: '/workflows', label: 'Workflows', icon: Workflow },
+        { href: '/automation', label: 'Automation', icon: Zap },
+        { href: '/office', label: 'Office 365', icon: Cloud },
+        { href: '/browser-automation', label: 'Browser', icon: Globe },
+        { href: '/teams', label: 'Teams', icon: Users },
+        { href: '/credentials', label: 'Credentials', icon: KeyRound },
+        ...(user?.is_examiner ? [{ href: '/verification', label: 'Verification', icon: ClipboardCheck }] : []),
+        ...(showAdmin ? [{ href: '/admin', label: 'Admin', icon: Shield }] : []),
+      ]
 
   return (
     <aside className="flex w-56 flex-col border-r border-gray-200 bg-gray-50">

--- a/frontend/src/components/workspace/UtilityBar.tsx
+++ b/frontend/src/components/workspace/UtilityBar.tsx
@@ -1,15 +1,29 @@
+import { useEffect } from 'react'
 import { MessageSquare, FolderOpen, Workflow, BookOpen } from 'lucide-react'
 import { useWorkspace, type WorkspaceMode } from '../../contexts/WorkspaceContext'
+import { useAppMode } from '../../contexts/AppModeContext'
 
-const MODES: { mode: WorkspaceMode; icon: typeof MessageSquare; label: string }[] = [
+const ALL_MODES: { mode: WorkspaceMode; icon: typeof MessageSquare; label: string }[] = [
   { mode: 'chat', icon: MessageSquare, label: 'Chat' },
   { mode: 'files', icon: FolderOpen, label: 'Files' },
   { mode: 'automations', icon: Workflow, label: 'Automations' },
   { mode: 'knowledge', icon: BookOpen, label: 'Knowledge' },
 ]
 
+const RA_MODES = new Set<WorkspaceMode>(['chat', 'files'])
+
 export function UtilityBar({ hasActiveAutomation = false }: { hasActiveAutomation?: boolean }) {
   const { workspaceMode, setWorkspaceMode, resetToHome } = useWorkspace()
+  const { isRA } = useAppMode()
+
+  const MODES = isRA ? ALL_MODES.filter(m => RA_MODES.has(m.mode)) : ALL_MODES
+
+  // Redirect out of restricted modes when switching to RA
+  useEffect(() => {
+    if (isRA && !RA_MODES.has(workspaceMode)) {
+      setWorkspaceMode('files')
+    }
+  }, [isRA, workspaceMode, setWorkspaceMode])
 
   return (
     <div

--- a/frontend/src/components/workspace/WorkflowEditorPanel.tsx
+++ b/frontend/src/components/workspace/WorkflowEditorPanel.tsx
@@ -25,6 +25,7 @@ import {
   improvePrompt,
 } from '../../api/workflows'
 import { RunHistoryTab } from './RunHistoryTab'
+import { useAppMode } from '../../contexts/AppModeContext'
 import type { ValidationCheck, ValidationCheckDefinition, ValidationInputDefinition, QualityHistoryRun, BatchStatus, WorkflowQualityStatus, PromptImprovement } from '../../api/workflows'
 import { ItemPickerModal } from './ItemPickerModal'
 import { getModels } from '../../api/config'
@@ -199,6 +200,7 @@ export function WorkflowEditorPanel() {
   const queryClient = useQueryClient()
   const { toast } = useToast()
   const { user } = useAuth()
+  const { isRA } = useAppMode()
   const shareLink = useShareLink()
   const { openWorkflowId, openWorkflowShareToken, openWorkflow, closeWorkflow, consumeWorkflowSession, selectedDocUuids, bumpActivitySignal } = useWorkspace()
   const [workflow, setWorkflow] = useState<Workflow | null>(null)
@@ -542,13 +544,13 @@ export function WorkflowEditorPanel() {
             />
           ) : (
             <div
-              style={{ display: 'flex', alignItems: 'center', gap: 8, cursor: 'pointer', flex: 1 }}
-              onClick={() => { setTitleValue(workflow.name); setEditingTitle(true) }}
+              style={{ display: 'flex', alignItems: 'center', gap: 8, cursor: isRA ? 'default' : 'pointer', flex: 1 }}
+              onClick={isRA ? undefined : () => { setTitleValue(workflow.name); setEditingTitle(true) }}
             >
               <span style={{ fontSize: 18, fontWeight: 600, color: '#202124', letterSpacing: '-0.01em' }}>
                 {workflow.name}
               </span>
-              <Pencil style={{ width: 14, height: 14, color: '#9ca3af' }} />
+              {!isRA && <Pencil style={{ width: 14, height: 14, color: '#9ca3af' }} />}
               {((workflow as Workflow & { verified?: boolean }).verified || !canManage) && (
                 <span
                   title={
@@ -601,7 +603,7 @@ export function WorkflowEditorPanel() {
               }
             }}
           />
-          {canManage && (
+          {canManage && !isRA && (
             <button
               onClick={() => shareLink('workflow', workflow.id, workflow.name)}
               title="Copy share link"
@@ -623,7 +625,7 @@ export function WorkflowEditorPanel() {
       </div>
 
       {/* ===== TAB BAR ===== */}
-      <div ref={tabBarRef} style={{ display: 'flex', borderBottom: '1px solid #e5e7eb', padding: tabsCompact ? '0 8px' : '0 24px', backgroundColor: '#fff', flexShrink: 0 }}>
+      {!isRA && <div ref={tabBarRef} style={{ display: 'flex', borderBottom: '1px solid #e5e7eb', padding: tabsCompact ? '0 8px' : '0 24px', backgroundColor: '#fff', flexShrink: 0 }}>
         {TABS.map(tab => {
           const TabIcon = tab.icon
           const badge = tab.key === 'input' ? inputBadge : 0
@@ -676,10 +678,40 @@ export function WorkflowEditorPanel() {
             </button>
           )
         })}
-      </div>
+      </div>}
+
+      {/* ===== RA OUTPUT AREA ===== */}
+      {isRA && (
+        <div style={{ flex: 1, overflowY: 'auto', minHeight: 0, padding: 24 }}>
+          {(runner.running || runner.status) && !runner.batchStatus && (
+            <WorkflowOutputCard
+              status={runner.status}
+              sessionId={runner.sessionId}
+              workflowName={workflow?.name}
+              running={runner.running}
+              runElapsed={runElapsed}
+              showDownloadPopup={showDownloadPopup}
+              setShowDownloadPopup={setShowDownloadPopup}
+            />
+          )}
+          {runner.batchStatus && (
+            <BatchOutputCard
+              batchStatus={runner.batchStatus}
+              running={runner.running}
+              runElapsed={runElapsed}
+            />
+          )}
+          {!runner.running && !runner.status && !runner.batchStatus && (
+            <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', paddingTop: 60, color: '#9ca3af', gap: 12, textAlign: 'center' }}>
+              <Play style={{ width: 36, height: 36, color: '#d1d5db' }} />
+              <p style={{ margin: 0, fontSize: 14 }}>Results will appear here after you run the workflow.</p>
+            </div>
+          )}
+        </div>
+      )}
 
       {/* ===== TAB CONTENT ===== */}
-      <div style={{ flex: 1, overflowY: 'auto', minHeight: 0 }}>
+      <div style={{ flex: isRA ? 0 : 1, overflow: isRA ? 'hidden' : 'auto', maxHeight: isRA ? 0 : undefined, minHeight: 0 }}>
         {activeTab === 'design' && (
           <>
             <DesignCanvas
@@ -794,7 +826,7 @@ export function WorkflowEditorPanel() {
       </div>
 
       {/* Nudge banner for unvalidated workflows after run */}
-      {activeTab === 'design' && !nudgeDismissed && qualityStatus?.status === 'unvalidated' && runner.status?.status === 'completed' && (
+      {!isRA && activeTab === 'design' && !nudgeDismissed && qualityStatus?.status === 'unvalidated' && runner.status?.status === 'completed' && (
         <div style={{
           padding: '8px 24px', backgroundColor: '#eff6ff', borderTop: '1px solid #dbeafe',
           display: 'flex', alignItems: 'center', gap: 8, flexShrink: 0,

--- a/frontend/src/contexts/AppModeContext.tsx
+++ b/frontend/src/contexts/AppModeContext.tsx
@@ -1,0 +1,52 @@
+import { createContext, useCallback, useContext, useEffect, useState, type ReactNode } from 'react'
+import { useAuth } from '../hooks/useAuth'
+
+export type AppMode = 'ra' | 'developer'
+
+interface AppModeContextValue {
+  mode: AppMode
+  isRA: boolean
+  canToggle: boolean
+  setMode: (m: AppMode) => void
+}
+
+const AppModeContext = createContext<AppModeContextValue | null>(null)
+
+const STORAGE_KEY = 'appMode'
+
+export function AppModeProvider({ children }: { children: ReactNode }) {
+  const { user } = useAuth()
+  const isRARole = user?.app_role === 'research_admin'
+
+  const [mode, setModeState] = useState<AppMode>(() => {
+    const stored = localStorage.getItem(STORAGE_KEY)
+    return stored === 'ra' ? 'ra' : 'developer'
+  })
+
+  useEffect(() => {
+    if (isRARole) {
+      setModeState('ra')
+    }
+  }, [isRARole])
+
+  const setMode = useCallback(
+    (m: AppMode) => {
+      if (isRARole) return
+      localStorage.setItem(STORAGE_KEY, m)
+      setModeState(m)
+    },
+    [isRARole],
+  )
+
+  return (
+    <AppModeContext.Provider value={{ mode, isRA: mode === 'ra', canToggle: !isRARole, setMode }}>
+      {children}
+    </AppModeContext.Provider>
+  )
+}
+
+export function useAppMode() {
+  const ctx = useContext(AppModeContext)
+  if (!ctx) throw new Error('useAppMode must be used inside AppModeProvider')
+  return ctx
+}

--- a/frontend/src/pages/Admin.tsx
+++ b/frontend/src/pages/Admin.tsx
@@ -183,6 +183,7 @@ function RoleBadge({ role }: { role: string }) {
     admin: { bg: '#fef3c7', text: '#92400e' },
     staff: { bg: '#dcfce7', text: '#166534' },
     examiner: { bg: '#dbeafe', text: '#1e40af' },
+    research_admin: { bg: '#f0e6ff', text: '#6d28d9' },
   }
   const c = colors[role] || { bg: '#f3f4f6', text: '#374151' }
   return (
@@ -598,6 +599,7 @@ function UserDrillDown({ userId, onBack }: { userId: string; onBack: () => void 
             {data.is_admin && <RoleBadge role="admin" />}
             {data.is_staff && <RoleBadge role="staff" />}
             {data.is_examiner && <RoleBadge role="examiner" />}
+            {data.app_role === 'research_admin' && <RoleBadge role="research_admin" />}
           </div>
           <div style={{ fontSize: 13, color: '#6b7280' }}>{data.email || data.user_id}</div>
         </div>
@@ -639,6 +641,53 @@ function UserDrillDown({ userId, onBack }: { userId: string; onBack: () => void 
                     width: 18, height: 18, borderRadius: 4,
                     border: active ? '2px solid #22c55e' : '2px solid #d1d5db',
                     background: active ? '#22c55e' : '#fff',
+                    display: 'flex', alignItems: 'center', justifyContent: 'center',
+                  }}>
+                    {active && <Check size={12} color="#fff" />}
+                  </div>
+                  {label}
+                </button>
+              )
+            })}
+          </div>
+        </div>
+
+        {/* App Role */}
+        <div style={{ background: '#fff', border: '1px solid #e5e7eb', borderRadius: 'var(--ui-radius, 12px)', padding: '16px 20px' }}>
+          <div style={{ fontSize: 13, fontWeight: 600, color: '#374151', marginBottom: 12 }}>App Role</div>
+          <div style={{ display: 'flex', gap: 12 }}>
+            {([['developer', 'Developer'], ['research_admin', 'Research Administrator']] as const).map(([value, label]) => {
+              const active = value === 'research_admin'
+                ? data.app_role === 'research_admin'
+                : !data.app_role || data.app_role === 'developer'
+              return (
+                <button
+                  key={value}
+                  disabled={savingRoles}
+                  onClick={async () => {
+                    setSavingRoles(true)
+                    try {
+                      await updateUserRoles(userId, { app_role: value })
+                      setData(prev => prev ? { ...prev, app_role: value === 'developer' ? null : value } : prev)
+                    } finally {
+                      setSavingRoles(false)
+                    }
+                  }}
+                  style={{
+                    display: 'flex', alignItems: 'center', gap: 8,
+                    padding: '8px 16px', borderRadius: 'var(--ui-radius, 12px)',
+                    border: active ? '2px solid #3b82f6' : '2px solid #e5e7eb',
+                    background: active ? '#eff6ff' : '#fff',
+                    cursor: savingRoles ? 'wait' : 'pointer',
+                    fontSize: 13, fontWeight: 600,
+                    color: active ? '#1d4ed8' : '#6b7280',
+                    opacity: savingRoles ? 0.6 : 1,
+                  }}
+                >
+                  <div style={{
+                    width: 18, height: 18, borderRadius: 4,
+                    border: active ? '2px solid #3b82f6' : '2px solid #d1d5db',
+                    background: active ? '#3b82f6' : '#fff',
                     display: 'flex', alignItems: 'center', justifyContent: 'center',
                   }}>
                     {active && <Check size={12} color="#fff" />}

--- a/frontend/src/pages/Workflows.tsx
+++ b/frontend/src/pages/Workflows.tsx
@@ -7,6 +7,7 @@ import { useToast } from '../contexts/ToastContext'
 import { useAuth } from '../hooks/useAuth'
 import { AuthorChip } from '../components/shared/AuthorChip'
 import { useConfirm } from '../components/shared/useConfirm'
+import { useAppMode } from '../contexts/AppModeContext'
 
 type SortKey = 'name' | 'runs' | 'steps'
 
@@ -16,6 +17,7 @@ export default function Workflows() {
   const { toast } = useToast()
   const { user } = useAuth()
   const confirm = useConfirm()
+  const { isRA } = useAppMode()
   const [newName, setNewName] = useState('')
   const [creating, setCreating] = useState(false)
   const [importing, setImporting] = useState(false)
@@ -80,8 +82,8 @@ export default function Workflows() {
           <span className="text-sm text-gray-400">{workflows.length} total</span>
         </div>
 
-        {/* Create new */}
-        <div className="mb-4">
+        {/* Create new — hidden in RA mode */}
+        {!isRA && <div className="mb-4">
           <div className="flex gap-2">
             <input
               type="text"
@@ -120,7 +122,7 @@ export default function Workflows() {
               }}
             />
           </div>
-        </div>
+        </div>}
 
         {/* Search & Sort */}
         <div className="flex items-center gap-3 mb-4">

--- a/frontend/src/types/user.ts
+++ b/frontend/src/types/user.ts
@@ -10,6 +10,7 @@ export interface User {
   is_demo_user: boolean
   current_team: string | null
   current_team_uuid: string | null
+  app_role: string | null
 }
 
 export interface Team {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -30,6 +30,7 @@ export default defineConfig({
     sourcemap: uploadSourceMaps,
   },
   server: {
+    allowedHosts: true,
     proxy: {
       '/api': 'http://localhost:8001',
     },


### PR DESCRIPTION
## Summary

  - Adds an app_role field to the User model ("research_admin" or null) assignable by admins via the Users panel
  - Introduces a frontend AppModeContext that locks RA users to a restricted interface and lets Developer-role users toggle between modes
  - RA mode limits navigation to Documents, Chat, and Workflows; hides all design/edit controls in the workflow panel; and shows only the run input and output area when a workflow is opened

## Changes
 ### Backend
  - app_role: Optional[str] added to User model and exposed in UserResponse (auth) and UserDetailResponse (admin)
  - update_user_roles endpoint accepts app_role so admins can assign the role without a migration
 
 ### Frontend
  - AppModeContext — new context driving isRA / canToggle throughout the app; Developer toggle state persists in localStorage
  - Header — segmented RA Mode / Developer Mode pill, visible to Developers only
  - Sidebar + UtilityBar — filtered to Documents, Chat, Workflows in RA mode
  - ProtectedRoute — redirects RAs away from any path outside the allowed set
  - Workflows — Create button hidden in RA mode
  - WorkflowEditorPanel — in RA mode, hides the tab bar and all editor controls; shows only the workflow name, a results/output area, and the run toolbar
  - Admin panel — App Role selector added to the user detail view

## Test Plan

- [ ] Shared checks pass (`make ci`)
- [ ] Release check passes if packaging or deployment changed (`make release-check`)
- [ ] Manually tested the affected feature(s)
- [ ] Updated `CHANGELOG.md` for user-facing or operator-facing changes
- [ ] Updated deploy/release docs (`README.md`, `DEPLOY.md`, `OPERATIONS.md`, or `RELEASE_CHECKLIST.md`) if the install or release path changed
- [ ] Assign app_role = "research_admin" to a user via Admin → Users; log in as that user — sidebar shows only Documents, Chat, Workflows; no toggle visible in header
- [ ] Navigate directly to /automation or /admin as an RA — should redirect to /
- [ ] Open a workflow as an RA — only the name, output area, and RUN button visible; no tabs, no step list
- [ ] Log in as a Developer — full sidebar and header toggle visible; toggling to RA Mode collapses navigation and workflow editor; toggling back restores full view; preference survives page refresh
- [ ] Admin panel → edit a user → set App Role → save; re-login as that user — mode is correct


## Related Issues

Closes #506 
