### PR TITLE
fix(celery): register engagement and retention task modules in worker

### DIFF
--- a/backend/celery_worker.py
+++ b/backend/celery_worker.py
@@ -28,3 +28,5 @@ from app.tasks import classification_tasks  # noqa: F401  — tasks.document.cla
 from app.tasks import demo_tasks  # noqa: F401  — tasks.demo.*
 from app.tasks import approval_tasks  # noqa: F401  — tasks.approvals.*
 from app.tasks import catalog_tasks  # noqa: F401  — tasks.catalog.upgrade
+from app.tasks import engagement_tasks  # noqa: F401  — tasks.engagement.*
+from app.tasks import retention_tasks  # noqa: F401  — tasks.retention.*


### PR DESCRIPTION
## Problem

`engagement_tasks` and `retention_tasks` are scheduled in the beat schedule (`backend/app/celery_app.py`) but were never imported in `backend/celery_worker.py`. Since Celery registers tasks at import time, their tasks were absent from the worker's task registry.

As a result, beat dispatched these jobs on schedule and workers raised `celery.exceptions.NotRegistered`, silently dropping the messages. This meant the following jobs **never ran**:

**Data retention** (`tasks.retention.*`)
- `schedule_deletions` — daily 2:00am
- `execute_soft_deletes` — daily 3:00am
- `execute_hard_deletes` — daily 4:00am
- `cleanup_ancillary` — daily 5:00am

**User engagement** (`tasks.engagement.*`)
- `process_onboarding_drips` — daily 10:00am
- `process_inactivity_nudges` — daily 10:30am

## Fix

Add the two missing module imports to `celery_worker.py` so their `@celery_app.task` decorators register, matching the existing pattern for every other task module.

## Verification

After the fix, importing `celery_worker` registers all six tasks:

```
tasks.engagement.process_inactivity_nudges
tasks.engagement.process_onboarding_drips
tasks.retention.cleanup_ancillary
tasks.retention.execute_hard_deletes
tasks.retention.execute_soft_deletes
tasks.retention.schedule_deletions
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)