### PR TITLE
fix(mgmt): /stats 500 — FindMany has no .distinct()

### DIFF
--- a/backend/app/routers/mgmt.py
+++ b/backend/app/routers/mgmt.py
@@ -260,9 +260,11 @@ async def stats(_: ApiKey = Depends(require_mgmt_scope("metrics:read"))):
     total_tokens = _coerce_int(token_agg[0].get("total_tokens")) if token_agg else 0
     documents_size_bytes_total = total_tokens * 4  # ~4 bytes/token
 
-    active_user_ids = await ActivityEvent.find(
-        {"started_at": {"$gte": cutoff_30d}}
-    ).distinct("user_id")
+    # Beanie's FindMany has no `.distinct()`; go through the motor collection,
+    # which takes the filter as its second argument.
+    active_user_ids = await ActivityEvent.get_motor_collection().distinct(
+        "user_id", {"started_at": {"$gte": cutoff_30d}}
+    )
 
     return StatsResponse(
         users_total=users_total,

--- a/backend/tests/test_mgmt_api.py
+++ b/backend/tests/test_mgmt_api.py
@@ -163,6 +163,10 @@ class TestRequireMgmtScope:
                 ))
                 M.find = MagicMock(return_value=MagicMock(
                     count=AsyncMock(return_value=0),
+                ))
+                # /stats reads distinct active users through the motor
+                # collection — Beanie's FindMany has no `.distinct()`.
+                M.get_motor_collection = MagicMock(return_value=MagicMock(
                     distinct=AsyncMock(return_value=[]),
                 ))
             # /stats now sums token_count via a Beanie aggregation rather than
@@ -208,6 +212,10 @@ class TestRequireMgmtScope:
                 ))
                 M.find = MagicMock(return_value=MagicMock(
                     count=AsyncMock(return_value=0),
+                ))
+                # /stats reads distinct active users through the motor
+                # collection — Beanie's FindMany has no `.distinct()`.
+                M.get_motor_collection = MagicMock(return_value=MagicMock(
                     distinct=AsyncMock(return_value=[]),
                 ))
             aggregate_mock = MagicMock(return_value=MagicMock(
@@ -255,6 +263,10 @@ class TestRequireMgmtScope:
                 ))
                 M.find = MagicMock(return_value=MagicMock(
                     count=AsyncMock(return_value=0),
+                ))
+                # /stats reads distinct active users through the motor
+                # collection — Beanie's FindMany has no `.distinct()`.
+                M.get_motor_collection = MagicMock(return_value=MagicMock(
                     distinct=AsyncMock(return_value=[]),
                 ))
             MockDoc.aggregate = MagicMock(return_value=MagicMock(
@@ -294,6 +306,10 @@ class TestRequireMgmtScope:
                 ))
                 M.find = MagicMock(return_value=MagicMock(
                     count=AsyncMock(return_value=0),
+                ))
+                # /stats reads distinct active users through the motor
+                # collection — Beanie's FindMany has no `.distinct()`.
+                M.get_motor_collection = MagicMock(return_value=MagicMock(
                     distinct=AsyncMock(return_value=[]),
                 ))
             MockDoc.aggregate = MagicMock(return_value=MagicMock(


### PR DESCRIPTION
## Problem

`GET /api/mgmt/v1/stats` returns **500** on prod (`vandalizer.nkn.uidaho.edu`) with:

```
AttributeError: 'FindMany' object has no attribute 'distinct'
```

Every other `/api/mgmt/v1/*` read endpoint works — none of them use `.distinct()`. (Reproduced internally on OAuth Dev with a freshly generated Management API key.)

## Root cause

`app/routers/mgmt.py` called `.distinct()` on a Beanie `FindMany` query object:

```python
active_user_ids = await ActivityEvent.find({...}).distinct("user_id")
```

Beanie's `FindMany` (1.30.0) has no `.distinct()`. The method lives on the underlying motor collection — the pattern already used correctly in `support_service.py`.

## Fix

Route the distinct active-user query through the motor collection, which takes the filter as its second argument:

```python
active_user_ids = await ActivityEvent.get_motor_collection().distinct(
    "user_id", {"started_at": {"$gte": cutoff_30d}}
)
```

## Why CI didn't catch it

The four `/stats` tests mocked `ActivityEvent.find(...)` with a `MagicMock` that *invented* a `.distinct` attribute the real query object never had — so the tests passed while prod 500'd. Updated the mocks to attach `distinct` to `get_motor_collection()`, matching the real call shape.

Note: these remain mock-based, so they verify the call *shape* but not that Beanie supports it. A tier-2 (`INTEGRATION_MONGODB=1`) test against a real collection would be the durable guard against this class of bug.

## Testing

- `pytest tests/test_mgmt_api.py` — 19 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
