### PR TITLE
fix(kb): make PDF document & URL sources ingest reliably

### DIFF
--- a/backend/app/services/knowledge_service.py
+++ b/backend/app/services/knowledge_service.py
@@ -1071,9 +1071,31 @@ async def _ingest_document_source(source: KnowledgeBaseSource, kb: KnowledgeBase
     await source.save()
     try:
         doc = await SmartDocument.find_one(SmartDocument.uuid == source.document_uuid)
-        if not doc or not (doc.raw_text or "").strip():
+        if not doc:
             source.status = "error"
-            source.error_message = "Document not found or has no text"
+            source.error_message = "Document not found"
+            await source.save()
+            return
+
+        if not (doc.raw_text or "").strip():
+            # No text yet. A document's text is populated asynchronously by the
+            # extraction worker (perform_extraction_and_update), so a source
+            # added right after upload routinely lands here while extraction is
+            # still in flight — for PDFs the OCR-first path can take minutes.
+            # Don't error permanently: park the source as "pending" and let the
+            # extraction-completion hook in update_document_fields re-ingest it
+            # once raw_text exists. Only error when extraction has actually
+            # finished (or failed) with no usable text.
+            in_flight = bool(doc.processing) or doc.task_status in (
+                "extracting", "readying", "layout",
+            )
+            if in_flight and doc.task_status != "error":
+                source.status = "pending"
+                source.error_message = None
+                await source.save()
+                return
+            source.status = "error"
+            source.error_message = doc.error_message or "Document has no extractable text"
             await source.save()
             return
 

--- a/backend/app/services/web_fetcher.py
+++ b/backend/app/services/web_fetcher.py
@@ -40,6 +40,20 @@ _USER_AGENT = (
     "Mozilla/5.0 (compatible; VandalizerBot/1.0; +https://vandalizer.uidaho.edu)"
 )
 
+# Browser-like headers. Many .gov/.edu sites sit behind a CDN/WAF (Akamai,
+# Cloudfront) that stalls or resets connections from clients that don't send a
+# full browser header set — the request hangs until our read timeout fires and
+# the source is recorded as an error. Sending Accept/Accept-Language alongside
+# the UA clears the most common of these heuristics.
+_DEFAULT_HEADERS = {
+    "User-Agent": _USER_AGENT,
+    "Accept": "text/html,application/xhtml+xml,application/pdf,*/*;q=0.8",
+    "Accept-Language": "en-US,en;q=0.9",
+}
+
+# Cap on the raw PDF payload we'll pull from a URL before extracting text.
+_MAX_PDF_BYTES = 50 * 1024 * 1024  # 50 MB
+
 
 @dataclass
 class WebFetchResult:
@@ -84,6 +98,68 @@ def _extract_main_text(html: str) -> str:
     for tag in soup.find_all(["script", "style", "nav", "footer", "header", "aside", "form", "noscript"]):
         tag.decompose()
     return _normalize_whitespace(soup.get_text(separator="\n"))
+
+
+def _looks_like_pdf(url: str, content_type: str) -> bool:
+    """True when a response is a PDF, by content-type or URL extension."""
+    if "application/pdf" in (content_type or "").lower():
+        return True
+    path = urlparse(url).path.lower()
+    return path.endswith(".pdf")
+
+
+def _extract_pdf_response(content: bytes, url: str) -> tuple[str, str]:
+    """Extract text + a title from PDF bytes fetched over HTTP.
+
+    Uses PyMuPDF (no OCR) to stay fast and dependency-light in the fetch path;
+    image-only PDFs will yield little text, which the caller treats as an empty
+    result. Title prefers the PDF's metadata, falling back to the URL filename.
+    """
+    if not content:
+        return "", urlparse(url).path.rsplit("/", 1)[-1] or urlparse(url).netloc
+    if len(content) > _MAX_PDF_BYTES:
+        logger.warning(
+            "PDF at %s is %d bytes (> %d cap) — skipping extraction",
+            url, len(content), _MAX_PDF_BYTES,
+        )
+        return "", urlparse(url).path.rsplit("/", 1)[-1] or urlparse(url).netloc
+
+    import os
+    import tempfile
+
+    from app.services.document_readers import extract_text_from_pdf
+
+    filename = urlparse(url).path.rsplit("/", 1)[-1] or urlparse(url).netloc
+    tmp_path = None
+    try:
+        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as tmp:
+            tmp.write(content)
+            tmp_path = tmp.name
+        text = extract_text_from_pdf(tmp_path)
+        title = _pdf_title(tmp_path) or filename
+        return _normalize_whitespace(text or ""), title
+    except Exception as e:
+        logger.warning("Failed to extract PDF from %s: %s", url, e)
+        return "", filename
+    finally:
+        if tmp_path:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+
+
+def _pdf_title(pdf_path: str) -> Optional[str]:
+    """Best-effort title from PDF metadata; None if unavailable."""
+    try:
+        import pymupdf
+
+        with pymupdf.open(pdf_path) as doc:
+            title = (doc.metadata or {}).get("title") or ""
+        title = title.strip()
+        return title[:300] or None
+    except Exception:
+        return None
 
 
 def _normalize_whitespace(text: str) -> str:
@@ -145,11 +221,27 @@ async def fetch_url(
     async with httpx.AsyncClient(
         timeout=settings.web_fetcher_timeout_seconds,
         follow_redirects=True,
-        headers={"User-Agent": _USER_AGENT},
+        headers=_DEFAULT_HEADERS,
     ) as client:
         resp = await client.get(url)
         status_code = resp.status_code
         resp.raise_for_status()
+
+        # PDF links (common for KB URL sources — agency forms, terms documents)
+        # must be parsed as PDFs, not decoded as HTML. trafilatura/BeautifulSoup
+        # on PDF bytes yields either nothing or raw binary, so without this a
+        # direct .pdf URL ingests garbage or fails outright.
+        if _looks_like_pdf(url, resp.headers.get("content-type", "")):
+            pdf_text, pdf_title = _extract_pdf_response(resp.content, url)
+            return WebFetchResult(
+                url=url,
+                title=pdf_title,
+                text=pdf_text[: settings.web_fetcher_max_chars],
+                raw_html=None,  # no HTML — nothing to crawl from a PDF
+                used_browser=False,
+                status_code=status_code,
+            )
+
         raw_html = resp.text[: settings.web_fetcher_max_chars]
 
     text = _extract_main_text(raw_html)

--- a/backend/app/tasks/document_tasks.py
+++ b/backend/app/tasks/document_tasks.py
@@ -423,6 +423,7 @@ def update_document_fields(self, document_uuid: str) -> None:
             {"uuid": document_uuid},
             {"$set": {"task_id": None}},
         )
+        _resume_pending_kb_sources(db, document_uuid, extraction_failed=True)
         return
 
     db.smart_document.update_one(
@@ -430,11 +431,61 @@ def update_document_fields(self, document_uuid: str) -> None:
         {"$set": {"task_id": None, "task_status": "complete"}},
     )
 
+    # Now that raw_text is populated, ingest any KB sources that were added
+    # before extraction finished and parked in "pending" (see
+    # knowledge_service._ingest_document_source).
+    _resume_pending_kb_sources(db, document_uuid, extraction_failed=False)
+
     # Check for folder watch automations targeting this document's folder
     try:
         _check_folder_watch_automations(db, document_uuid)
     except Exception as e:
         logger.error("Error checking folder watch automations for %s: %s", document_uuid, e)
+
+
+def _resume_pending_kb_sources(db, document_uuid: str, extraction_failed: bool) -> None:
+    """Settle KB document-sources that were waiting on this document's extraction.
+
+    A KB source added before its document finished extracting is parked in
+    "pending" by ``_ingest_document_source``. When extraction completes we
+    re-ingest those sources; when it fails we mark them errored so they don't
+    spin forever. No-op when nothing is waiting.
+    """
+    pending = list(
+        db.knowledge_base_sources.find(
+            {
+                "document_uuid": document_uuid,
+                "source_type": "document",
+                "status": "pending",
+            },
+            {"uuid": 1, "knowledge_base_uuid": 1},
+        )
+    )
+    if not pending:
+        return
+
+    if extraction_failed:
+        from app.tasks.knowledge_base_tasks import _recalculate_kb
+
+        doc = db.smart_document.find_one({"uuid": document_uuid}, {"error_message": 1})
+        message = (doc or {}).get("error_message") or "Document has no extractable text"
+        affected_kbs = set()
+        for src in pending:
+            db.knowledge_base_sources.update_one(
+                {"uuid": src["uuid"]},
+                {"$set": {"status": "error", "error_message": message}},
+            )
+            affected_kbs.add(src["knowledge_base_uuid"])
+        for kb_uuid in affected_kbs:
+            _recalculate_kb(db, kb_uuid)
+        return
+
+    for src in pending:
+        celery_app.send_task(
+            "tasks.documents.kb_ingest_document",
+            args=[src["uuid"]],
+            queue="documents",
+        )
 
 
 def _check_folder_watch_automations(db, document_uuid: str) -> None:

--- a/backend/app/tasks/knowledge_base_tasks.py
+++ b/backend/app/tasks/knowledge_base_tasks.py
@@ -105,6 +105,7 @@ def kb_ingest_document(self, source_uuid: str) -> None:
             source_id=source_uuid,
             source_name=doc.get("title", ""),
             raw_text=raw_text,
+            text_markers=doc.get("text_markers") or [],
         )
 
         db.knowledge_base_sources.update_one(

--- a/backend/tests/test_document_tasks.py
+++ b/backend/tests/test_document_tasks.py
@@ -273,6 +273,61 @@ class TestUpdateDocumentFields:
         update_document_fields(document_uuid="doc-1")
 
 
+class TestResumePendingKbSources:
+    @patch("app.tasks.document_tasks._check_folder_watch_automations")
+    @patch("app.tasks.document_tasks.celery_app")
+    @patch("app.tasks.document_tasks.get_sync_db")
+    def test_complete_redispatches_pending_sources(self, mock_get_db, mock_celery, mock_check):
+        from app.tasks.document_tasks import update_document_fields
+
+        db = MagicMock()
+        mock_get_db.return_value = db
+        db.smart_document.find_one.return_value = {"task_status": "extracting"}
+        db.smart_document.update_one.return_value = MagicMock(matched_count=1)
+        db.knowledge_base_sources.find.return_value = [
+            {"uuid": "src-1", "knowledge_base_uuid": "kb-1"},
+            {"uuid": "src-2", "knowledge_base_uuid": "kb-1"},
+        ]
+
+        update_document_fields(document_uuid="doc-1")
+
+        # Each pending source is handed to the re-ingest task on the documents queue.
+        assert mock_celery.send_task.call_count == 2
+        names = {c.args[0] for c in mock_celery.send_task.call_args_list}
+        assert names == {"tasks.documents.kb_ingest_document"}
+        dispatched = {c.kwargs["args"][0] for c in mock_celery.send_task.call_args_list}
+        assert dispatched == {"src-1", "src-2"}
+
+    @patch("app.tasks.document_tasks._check_folder_watch_automations")
+    @patch("app.tasks.knowledge_base_tasks._recalculate_kb")
+    @patch("app.tasks.document_tasks.celery_app")
+    @patch("app.tasks.document_tasks.get_sync_db")
+    def test_error_marks_pending_sources_errored(self, mock_get_db, mock_celery, mock_recalc, mock_check):
+        from app.tasks.document_tasks import update_document_fields
+
+        db = MagicMock()
+        mock_get_db.return_value = db
+        # First find_one: task_status for the gate. Second: error_message lookup.
+        db.smart_document.find_one.side_effect = [
+            {"task_status": "error"},
+            {"error_message": "It may be image-only or encrypted."},
+        ]
+        db.knowledge_base_sources.find.return_value = [
+            {"uuid": "src-1", "knowledge_base_uuid": "kb-1"},
+        ]
+
+        update_document_fields(document_uuid="doc-1")
+
+        # The waiting source is flipped to error with the document's message.
+        src_update = db.knowledge_base_sources.update_one.call_args[0]
+        assert src_update[0] == {"uuid": "src-1"}
+        assert src_update[1]["$set"]["status"] == "error"
+        assert "image-only" in src_update[1]["$set"]["error_message"]
+        mock_recalc.assert_called_once_with(db, "kb-1")
+        # No re-ingest dispatched on failure.
+        mock_celery.send_task.assert_not_called()
+
+
 # ---------------------------------------------------------------------------
 # _check_folder_watch_automations
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_knowledge_base_tasks.py
+++ b/backend/tests/test_knowledge_base_tasks.py
@@ -195,6 +195,7 @@ class TestKbIngestDocument:
             source_id="src-uuid",
             source_name="test.pdf",
             raw_text="Some document text content.",
+            text_markers=[],
         )
 
         # Last update before _recalculate_kb should set status=ready

--- a/backend/tests/test_knowledge_ingest.py
+++ b/backend/tests/test_knowledge_ingest.py
@@ -1,0 +1,119 @@
+"""Unit tests for KB document-source ingestion timing.
+
+A KB source can be added before its document's async text extraction has
+finished. ``_ingest_document_source`` must park such a source as "pending"
+(to be re-ingested by the extraction-completion hook) rather than recording a
+permanent "no text" error.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services import knowledge_service
+
+
+def _make_source():
+    src = SimpleNamespace(
+        uuid="src-1",
+        document_uuid="doc-1",
+        status="pending",
+        error_message=None,
+        chunk_count=0,
+        processed_at=None,
+    )
+    src.save = AsyncMock()
+    return src
+
+
+def _make_doc(**overrides):
+    base = dict(
+        uuid="doc-1",
+        raw_text="",
+        processing=False,
+        task_status=None,
+        error_message=None,
+        title="terms.pdf",
+        text_markers=[],
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+@pytest.mark.asyncio
+async def test_parks_pending_while_extraction_in_flight():
+    source = _make_source()
+    doc = _make_doc(processing=True, task_status="extracting")
+
+    with patch.object(knowledge_service, "SmartDocument",
+                      MagicMock(find_one=AsyncMock(return_value=doc))), \
+         patch.object(knowledge_service, "_get_dm") as mock_get_dm:
+        await knowledge_service._ingest_document_source(source, MagicMock(uuid="kb-1"))
+
+    assert source.status == "pending"
+    assert source.error_message is None
+    # Must not attempt to embed an empty document.
+    mock_get_dm.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_errors_when_extraction_finished_empty():
+    source = _make_source()
+    doc = _make_doc(task_status="complete", processing=False)
+
+    with patch.object(knowledge_service, "SmartDocument",
+                      MagicMock(find_one=AsyncMock(return_value=doc))), \
+         patch.object(knowledge_service, "_get_dm") as mock_get_dm:
+        await knowledge_service._ingest_document_source(source, MagicMock(uuid="kb-1"))
+
+    assert source.status == "error"
+    assert "no extractable text" in source.error_message.lower()
+    mock_get_dm.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_errors_when_extraction_failed_uses_doc_message():
+    source = _make_source()
+    doc = _make_doc(task_status="error", error_message="It may be image-only or encrypted.")
+
+    with patch.object(knowledge_service, "SmartDocument",
+                      MagicMock(find_one=AsyncMock(return_value=doc))):
+        await knowledge_service._ingest_document_source(source, MagicMock(uuid="kb-1"))
+
+    assert source.status == "error"
+    assert source.error_message == "It may be image-only or encrypted."
+
+
+@pytest.mark.asyncio
+async def test_missing_document_errors_distinctly():
+    source = _make_source()
+
+    with patch.object(knowledge_service, "SmartDocument",
+                      MagicMock(find_one=AsyncMock(return_value=None))):
+        await knowledge_service._ingest_document_source(source, MagicMock(uuid="kb-1"))
+
+    assert source.status == "error"
+    assert source.error_message == "Document not found"
+
+
+@pytest.mark.asyncio
+async def test_ingests_when_text_present():
+    source = _make_source()
+    doc = _make_doc(raw_text="Real content here.", task_status="complete",
+                    text_markers=[{"char_offset": 0, "kind": "page", "value": 1}])
+
+    dm = MagicMock()
+    dm.add_to_kb.return_value = 9
+
+    with patch.object(knowledge_service, "SmartDocument",
+                      MagicMock(find_one=AsyncMock(return_value=doc))), \
+         patch.object(knowledge_service, "_get_dm", return_value=dm):
+        await knowledge_service._ingest_document_source(source, MagicMock(uuid="kb-1"))
+
+    assert source.status == "ready"
+    assert source.chunk_count == 9
+    # Markers are forwarded so chunks keep page citations.
+    _, kwargs = dm.add_to_kb.call_args
+    called_args = dm.add_to_kb.call_args[0]
+    assert doc.text_markers in called_args or kwargs.get("text_markers") == doc.text_markers

--- a/backend/tests/test_web_fetcher.py
+++ b/backend/tests/test_web_fetcher.py
@@ -235,3 +235,71 @@ def test_sync_wrapper_runs_async_path():
 
     assert isinstance(result, WebFetchResult)
     assert "reimburse" in result.text.lower()
+
+
+# ---------------------------------------------------------------------------
+# PDF URLs are parsed as PDFs, not decoded as HTML
+# ---------------------------------------------------------------------------
+
+def _tiny_pdf_bytes(text: str) -> bytes:
+    """Build a one-page text PDF in memory via PyMuPDF."""
+    import pymupdf
+
+    doc = pymupdf.open()
+    page = doc.new_page()
+    page.insert_text((72, 72), text)
+    data = doc.tobytes()
+    doc.close()
+    return data
+
+
+def _mock_pdf_client(content: bytes, content_type: str = "application/pdf", status: int = 200):
+    resp = MagicMock()
+    resp.content = content
+    resp.status_code = status
+    resp.headers = {"content-type": content_type}
+    resp.raise_for_status = MagicMock()
+    # resp.text would be binary garbage — assert we never read it for PDFs.
+    type(resp).text = property(lambda self: (_ for _ in ()).throw(
+        AssertionError("fetch_url must not decode PDF bytes as text")
+    ))
+
+    client = MagicMock()
+    client.get = AsyncMock(return_value=resp)
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=False)
+    return client
+
+
+@pytest.mark.asyncio
+async def test_pdf_content_type_is_extracted_as_pdf():
+    settings = Settings(web_fetcher_browser_enabled=False)
+    pdf = _tiny_pdf_bytes("USDA General Terms and Conditions for Federal Awards")
+
+    with patch("app.services.web_fetcher.httpx.AsyncClient",
+               return_value=_mock_pdf_client(pdf)), \
+         patch("app.services.web_fetcher.validate_outbound_url",
+               return_value="https://www.usda.gov/x/terms.pdf"):
+        result = await fetch_url("https://www.usda.gov/x/terms.pdf", settings=settings)
+
+    assert "USDA General Terms" in result.text
+    # No HTML to crawl from a PDF — parent_html must be None.
+    assert result.raw_html is None
+    assert result.used_browser is False
+    assert result.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_pdf_detected_by_url_extension_when_content_type_generic():
+    """A .pdf URL served as octet-stream is still parsed as a PDF."""
+    settings = Settings(web_fetcher_browser_enabled=False)
+    pdf = _tiny_pdf_bytes("Effective December 31 2025")
+
+    with patch("app.services.web_fetcher.httpx.AsyncClient",
+               return_value=_mock_pdf_client(pdf, content_type="application/octet-stream")), \
+         patch("app.services.web_fetcher.validate_outbound_url",
+               return_value="https://example.gov/doc.pdf"):
+        result = await fetch_url("https://example.gov/doc.pdf", settings=settings)
+
+    assert "Effective December 31 2025" in result.text
+    assert result.raw_html is None


### PR DESCRIPTION
## Summary

A support ticket reported a USDA terms PDF failing to enter a knowledge base **both** ways — by file upload (*"Document not found or has no text"*) and by direct URL (*status "error", 0 pages crawled*). These turned out to be **two unrelated bugs** that happened to land on the same document.

## File upload → "Document not found or has no text"

A KB document source read the document's `raw_text` **exactly once**, at *Add Documents* time, and errored permanently if extraction hadn't finished. Extraction runs asynchronously (`perform_extraction_and_update`) and, for PDFs, tries the OCR endpoint first (120s timeout × retries) before falling back to PyMuPDF — so `raw_text` can be empty for minutes, and nothing re-ingested the source after it filled in.

- `_ingest_document_source` now parks the source as **`pending`** (UI spinner, no error) while the document is still extracting, and only errors when extraction has genuinely finished/failed with no text. Missing documents get a distinct *"Document not found"*.
- `update_document_fields` (the extraction-completion task) now **settles** those pending sources — re-ingests on success via `kb_ingest_document`, marks errored on failure.
- `kb_ingest_document` forwards `text_markers` so re-ingested PDFs keep page citations.

## URL → "error", 0 pages crawled

`fetch_url` decoded **every** response as HTML, so a direct `.pdf` link was fed to trafilatura/BeautifulSoup → nothing, or ~1.1 MB of raw binary. It also sent a bare bot User-Agent that CDN/WAF-fronted `.gov` sites stall.

- `fetch_url` now sends browser-like `Accept`/`Accept-Language` headers and, when the response is `application/pdf` (or the URL ends in `.pdf`), extracts via the PDF reader and returns `raw_html=None` (a PDF has nothing to crawl).

> ⚠️ **Caveat on this specific host:** live testing showed USDA's edge stalls/resets even full-browser-header requests — that's their bot protection, not our bug. The PDF-content-type fix makes URL-to-PDF work generally and stops the silent-garbage failure mode; the file-upload path is the reliable route for this particular document.

## Tests

- **new** `test_knowledge_ingest.py` — pending-while-extracting, finished-empty, extraction-failed, missing-doc, happy-path w/ marker pass-through
- `test_document_tasks.py` — re-dispatch on complete, error-marking on failure
- `test_web_fetcher.py` — PDF by content-type and by `.pdf` extension; asserts PDF bytes are never decoded as text

Full backend suite green (2548 passed, 160 skipped); ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)