### PR TITLE
feat(chat): add "Add Knowledge Base" option to chat composer menu

### DIFF
--- a/frontend/src/components/chat/ChatInput.tsx
+++ b/frontend/src/components/chat/ChatInput.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect, type KeyboardEvent, type ReactNode } from 'react'
-import { Send, Plus, FileUp, Globe, Download, ChevronDown, Cpu } from 'lucide-react'
+import { Send, Plus, FileUp, Globe, BookOpen, Download, ChevronDown, Cpu } from 'lucide-react'
 import { getModels } from '../../api/config'
 import type { ModelInfo } from '../../types/workflow'
 import { ModelEffortPicker } from '../ModelEffortPicker'
@@ -9,6 +9,8 @@ interface Props {
   onSend: (message: string) => void
   onAttachFile?: (files: File[]) => void
   onAttachLink?: (url: string) => void
+  // Opens the knowledge base screen so the user can pick a KB to chat with.
+  onAddKnowledge?: () => void
   disabled?: boolean
   selectedModel?: string
   onModelChange?: (model: string) => void
@@ -22,7 +24,7 @@ interface Props {
 }
 
 export function ChatInput({
-  onSend, onAttachFile, onAttachLink, disabled,
+  onSend, onAttachFile, onAttachLink, onAddKnowledge, disabled,
   selectedModel, onModelChange, onExport, hasMessages, hasDocuments,
   contextMeter, focusSignal,
 }: Props) {
@@ -207,6 +209,17 @@ export function ChatInput({
                   <Globe className="h-4 w-4 shrink-0" style={{ width: 18 }} />
                   <span>Add Website</span>
                 </button>
+                {onAddKnowledge && (
+                  <button
+                    role="menuitem"
+                    onClick={() => { onAddKnowledge(); setShowAddMenu(false) }}
+                    className="flex w-full items-center gap-2.5 rounded-lg px-3 py-2.5 text-sm text-left text-[#1f2937] hover:bg-black/[.04] transition-colors"
+                    style={{ minHeight: 40 }}
+                  >
+                    <BookOpen className="h-4 w-4 shrink-0" style={{ width: 18 }} />
+                    <span>Add Knowledge Base</span>
+                  </button>
+                )}
               </div>
             )}
           </div>

--- a/frontend/src/components/chat/ChatPanel.tsx
+++ b/frontend/src/components/chat/ChatPanel.tsx
@@ -86,7 +86,7 @@ export function ChatPanel({ conversationToLoad, pendingMessage, onPendingMessage
     setActivity,
   } = useChat()
 
-  const { bumpActivitySignal, processingDoc, selectedDocsProcessing, selectedDocUuids, setSelectedDocUuids, selectedDocNames, setSelectedDocNames, selectedFolderUuids, activeKBUuid, activeKBTitle, activateKB, deactivateKB, activeProjectUuid, activeProjectTitle, setCurrentConversationUuid, focusChatSignal } = useWorkspace()
+  const { bumpActivitySignal, processingDoc, selectedDocsProcessing, selectedDocUuids, setSelectedDocUuids, selectedDocNames, setSelectedDocNames, selectedFolderUuids, activeKBUuid, activeKBTitle, activateKB, deactivateKB, activeProjectUuid, activeProjectTitle, setCurrentConversationUuid, focusChatSignal, setWorkspaceMode } = useWorkspace()
 
   // When scoped to a project, surface its file/index status so the empty state
   // reflects the project (not a generic assistant) and sets honest expectations.
@@ -981,6 +981,7 @@ export function ChatPanel({ conversationToLoad, pendingMessage, onPendingMessage
         onSend={handleSend}
         onAttachFile={handleAttachFile}
         onAttachLink={handleAttachLink}
+        onAddKnowledge={() => setWorkspaceMode('knowledge')}
         disabled={isStreaming}
         selectedModel={selectedModel}
         onModelChange={handleModelChange}


### PR DESCRIPTION
## Summary

Adds a third item — **Add Knowledge Base** — to the chat composer's **+ Add** menu, alongside *Add Document* and *Add Website*. Selecting it opens the knowledge base screen so the user can pick a KB to chat with, right from the home page chat.

Previously, chatting with a knowledge base required navigating to the Knowledge page first. This surfaces the same flow from the place users are already typing.

## How it works

- `ChatInput.tsx` — new optional `onAddKnowledge` prop renders the menu item (uses the `BookOpen` icon, matching the Knowledge nav).
- `ChatPanel.tsx` — wires the item to `setWorkspaceMode('knowledge')`, opening the KB screen. Picking a KB there returns to chat via the existing `activateKB()` path with the KB active.
- **No backend changes** — the chat endpoint already accepts `knowledge_base_uuid`; this just exposes the entry point.

## Testing

- `tsc --noEmit` — clean, zero errors.
- `eslint` on the two touched files — exit 0 (only pre-existing `exhaustive-deps` warnings, unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
