### PR TITLE
feat(telemetry): opt-in anonymous deployment heartbeat + fleet collector

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -160,6 +160,15 @@ All of these are stored in the `SystemConfig` document in MongoDB and applied at
 
 Because the project is open source under GPL v3, the footer keeps a small "Powered by Vandalizer" credit and the NSF GRANTED acknowledgement whenever custom branding is in effect, so creator and funder lineage stay visible.
 
+### Anonymous usage telemetry (optional)
+
+Vandalizer can send the maintainers an **opt-in, anonymous** daily heartbeat
+(deployment count, version, and coarse usage buckets — never document content,
+names, or emails). It is **off by default**; `./setup.sh` asks before enabling
+it, and you can optionally self-identify or point it at your own collector. See
+[docs/telemetry.md](docs/telemetry.md) for the full disclosure and the
+`TELEMETRY_*` variables.
+
 ### Production Configuration (reference)
 
 `./setup.sh` writes the production `backend/.env` for you. This subsection is a **reference** for what those variables mean — useful when you need to edit `.env` later, externalize a database, or rebuild the file by hand on the manual path.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -69,3 +69,20 @@ RESEND_FROM_NAME=Vandalizer
 # Set to true to enable the demo/trial signup system.
 # Disabled by default for self-hosted deployments.
 ENABLE_TRIAL_SYSTEM=false
+
+# --- Anonymous usage telemetry (opt-in sender) ---
+# A once-a-day heartbeat reporting only an anonymous random ID, the version, and
+# coarse usage buckets ("11-50 users"). Never documents, names, emails, or keys.
+# Inert unless BOTH enabled AND an endpoint are set. setup.sh can configure this.
+TELEMETRY_ENABLED=false
+TELEMETRY_ENDPOINT=
+# Optional voluntary identity — leave blank to stay fully anonymous. Self-declared
+# only; never auto-derived. When organization is blank, no identity is sent.
+TELEMETRY_ORGANIZATION=
+TELEMETRY_CONTACT_EMAIL=
+
+# --- Telemetry receiver (collector instance only) ---
+# Turns THIS deployment into the fleet collector: exposes the public
+# /api/telemetry/heartbeat ingest route and the admin Telemetry dashboard.
+# Leave false on every normal deployment — both stay completely hidden.
+TELEMETRY_COLLECTOR_ENABLED=false

--- a/backend/app/celery_app.py
+++ b/backend/app/celery_app.py
@@ -132,5 +132,13 @@ if not settings.enable_trial_system:
     for _key in ("demo-process-waitlist", "demo-check-expirations", "demo-send-expiry-warnings"):
         celery.conf.beat_schedule.pop(_key, None)
 
+# Anonymous deployment heartbeat — only scheduled when the admin has opted in,
+# so an opt-out deployment never even registers the task with beat.
+if settings.telemetry_enabled:
+    celery.conf.beat_schedule["telemetry-daily-heartbeat"] = {
+        "task": "tasks.telemetry.send_heartbeat",
+        "schedule": crontab(hour=7, minute=23),  # daily, off-peak, non-round minute
+    }
+
 # Alias for import convenience
 celery_app = celery

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -75,6 +75,42 @@ class Settings(BaseSettings):
     # for air-gapped or privacy-strict deployments.
     disable_update_check: bool = False
 
+    # Anonymous deployment telemetry — OPT-IN, OFF by default.
+    #
+    # When enabled, a once-daily heartbeat lets the maintainers see how many
+    # deployments exist and roughly how heavily they're used. It sends ONLY:
+    #   - a stable random instance UUID (generated locally, no link to identity)
+    #   - the running version and coarse environment (production / non-production)
+    #   - usage as COARSE BUCKETS ("11-50 users", not exact counts)
+    # It NEVER sends document content, filenames, titles, user identities,
+    # emails, API keys, team names, or any free text.
+    #
+    # Trust guarantees baked into the implementation:
+    #   - Inert unless BOTH telemetry_enabled=True AND telemetry_endpoint is set,
+    #     so flipping the flag alone never leaks to a guessed domain.
+    #   - Every payload is logged locally (telemetry_log_payload) so an admin can
+    #     read exactly what was sent.
+    #   - Self-hosters can point telemetry_endpoint at their OWN collector.
+    telemetry_enabled: bool = False
+    telemetry_endpoint: str = ""
+    telemetry_log_payload: bool = True
+
+    # Optional SECOND tier on top of the anonymous heartbeat: voluntary identity.
+    # If an admin chooses to fill these in (typically at deploy time via
+    # setup.sh), the heartbeat additionally reports who the deployment is, so the
+    # maintainers can see *named* adoption rather than just counts. Empty by
+    # default — a blank organization keeps the heartbeat fully anonymous (the
+    # identity block is omitted from the payload entirely). NEVER auto-derived
+    # from email domains, IPs, or licenses; self-declared only.
+    telemetry_organization: str = ""
+    telemetry_contact_email: str = ""
+
+    # RECEIVER role — turns THIS deployment into the fleet telemetry collector.
+    # Off by default, so every other deployment running this same codebase keeps
+    # the ingest route and the admin analytics screen completely hidden. Only the
+    # maintainers' own instance (the heartbeat's default endpoint) sets this True.
+    telemetry_collector_enabled: bool = False
+
     # Web fetcher — controls Playwright fallback for JS-rendered pages.
     # When True (default), pages whose static HTML yields too little text are
     # re-fetched in a headless Chromium so client-rendered SPAs (Next.js,

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -47,6 +47,7 @@ from app.models.api_key import ApiKey
 from app.models.credential import Credential
 from app.models.llm_usage import LlmUsageRecord
 from app.models.project import Project, ProjectMembership, ProjectPin, ProjectJoinLink
+from app.models.telemetry import TelemetryHeartbeat
 
 ALL_MODELS = [
     User,
@@ -117,6 +118,7 @@ ALL_MODELS = [
     ProjectMembership,
     ProjectPin,
     ProjectJoinLink,
+    TelemetryHeartbeat,
 ]
 
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -16,7 +16,7 @@ from app.exceptions import AppError
 from app.middleware.csrf import CSRFMiddleware
 from app.observability import init_sentry
 from app.rate_limit import limiter
-from app.routers import activity, admin, audit, auth, automations, browser_automation, certification, chat, config, credentials, demo, documents, extractions, feedback, feedback_prompt, files, folders, graph_webhooks, knowledge, library, mgmt, notifications, office, optimizer_inbox, organizations, projects, reviews, spaces, support, teams, verification, workflows
+from app.routers import activity, admin, audit, auth, automations, browser_automation, certification, chat, config, credentials, demo, documents, extractions, feedback, feedback_prompt, files, folders, graph_webhooks, knowledge, library, mgmt, notifications, office, optimizer_inbox, organizations, projects, reviews, spaces, support, teams, telemetry, verification, workflows
 
 
 @lru_cache
@@ -232,6 +232,11 @@ app.include_router(support.router, prefix="/api/support", tags=["support"])
 app.include_router(mgmt.router, prefix="/api/mgmt/v1", tags=["mgmt"])
 if _boot_settings.enable_trial_system:
     app.include_router(feedback_prompt.router, prefix="/api/feedback/prompts", tags=["feedback-prompts"])
+# Telemetry RECEIVER — only on the collector instance. Every other deployment of
+# this codebase leaves both the public ingest route and the admin analytics
+# route unregistered (404), so the feature is fully hidden off-collector.
+if _boot_settings.telemetry_collector_enabled:
+    app.include_router(telemetry.router, prefix="/api/telemetry", tags=["telemetry"])
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/models/telemetry.py
+++ b/backend/app/models/telemetry.py
@@ -1,0 +1,45 @@
+"""Telemetry receiver model — one row per known deployment.
+
+This lives on the collector instance (the one with telemetry_collector_enabled).
+Each incoming heartbeat upserts the row for its instance_id, so the collection is
+a roster of live deployments, not an ever-growing event log: counts and version
+distribution fall straight out of it. Stores ONLY the anonymous heartbeat fields
+plus the voluntary identity an admin chose to self-declare.
+"""
+
+import datetime
+from typing import Optional
+
+import pymongo
+from beanie import Document
+from pydantic import Field
+
+
+class TelemetryHeartbeat(Document):
+    # The anonymous, stable per-install id (uuid4 from the sender). Unique key:
+    # repeat heartbeats from the same deployment update this row in place.
+    instance_id: str
+    version: str = "unknown"
+    environment: str = "other"  # coarse: "production" | "other"
+
+    # Coarse usage buckets as sent — e.g. {"users": "11-50", ...}. Never exact.
+    metrics: dict[str, str] = Field(default_factory=dict)
+
+    # Voluntary identity — present only if the deployment self-declared it.
+    organization: Optional[str] = None
+    contact_email: Optional[str] = None
+
+    first_seen: datetime.datetime = Field(
+        default_factory=lambda: datetime.datetime.now(datetime.timezone.utc)
+    )
+    last_seen: datetime.datetime = Field(
+        default_factory=lambda: datetime.datetime.now(datetime.timezone.utc)
+    )
+    heartbeat_count: int = 0
+
+    class Settings:
+        name = "telemetry_heartbeat"
+        indexes = [
+            pymongo.IndexModel("instance_id", unique=True),
+            "last_seen",
+        ]

--- a/backend/app/routers/config.py
+++ b/backend/app/routers/config.py
@@ -233,12 +233,18 @@ async def update_theme(req: UpdateThemeConfigRequest, user: User = Depends(get_c
 
 
 @router.get("/features")
-async def get_features(user: User = Depends(get_current_user)):
+async def get_features(
+    user: User = Depends(get_current_user),
+    settings: Settings = Depends(get_settings),
+):
     """Return feature flags for the current deployment."""
     config = await SystemConfig.get_config()
     return {
         "m365_enabled": False,
         "compliance_enabled": config.is_compliance_enabled(),
+        # True only on the fleet collector instance — gates the admin telemetry
+        # dashboard so it stays hidden on every other deployment.
+        "telemetry_collector_enabled": settings.telemetry_collector_enabled,
     }
 
 

--- a/backend/app/routers/telemetry.py
+++ b/backend/app/routers/telemetry.py
@@ -1,0 +1,175 @@
+"""Telemetry receiver — runs only on the collector instance.
+
+This router is registered ONLY when telemetry_collector_enabled is True (see
+app/main.py), so on every other deployment of this codebase both the public
+ingest endpoint and the admin analytics endpoint simply do not exist.
+
+Two endpoints:
+  - POST /api/telemetry/heartbeat — public, unauthenticated (pings come from
+    arbitrary deployments we have no shared secret with), strictly validated,
+    rate-limited, and write-only. It upserts the sender's roster row.
+  - GET  /api/telemetry/analytics — admin/staff only, the data behind the
+    in-app fleet dashboard.
+"""
+
+from __future__ import annotations
+
+import datetime
+import logging
+from typing import Annotated, Optional
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, ConfigDict, Field, StringConstraints
+from starlette.requests import Request
+
+from app.dependencies import get_current_user
+from app.models.telemetry import TelemetryHeartbeat
+from app.models.user import User
+from app.rate_limit import limiter
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+ACTIVE_WINDOW_DAYS = 30
+
+# Bounded strings so a malformed/hostile sender can't write unbounded blobs into
+# the collection. The values we expect are short (bucket labels, a version tag,
+# an org name), so these caps are generous.
+ShortStr = Annotated[str, StringConstraints(max_length=32)]
+LabelStr = Annotated[str, StringConstraints(max_length=200)]
+
+
+def _utcnow() -> datetime.datetime:
+    return datetime.datetime.now(datetime.timezone.utc)
+
+
+# ---------------------------------------------------------------------------
+# Ingest payload validation — mirrors the client's build_heartbeat_payload.
+# extra="ignore" lets future schema additions arrive without 422-ing old
+# collectors; unknown fields are simply dropped.
+# ---------------------------------------------------------------------------
+
+
+class HeartbeatMetrics(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    users: ShortStr = ""
+    active_users_30d: ShortStr = ""
+    teams: ShortStr = ""
+    documents: ShortStr = ""
+    workflows: ShortStr = ""
+
+
+class HeartbeatIdentity(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    organization: LabelStr = ""
+    contact_email: LabelStr = ""
+
+
+class HeartbeatIn(BaseModel):
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    schema_version: int = Field(1, alias="schema")
+    instance_id: Annotated[str, StringConstraints(min_length=8, max_length=64)]
+    version: ShortStr = "unknown"
+    environment: ShortStr = "other"
+    metrics: HeartbeatMetrics = Field(default_factory=HeartbeatMetrics)
+    identity: Optional[HeartbeatIdentity] = None
+
+
+@router.post("/heartbeat")
+@limiter.limit("30/hour")
+async def receive_heartbeat(request: Request, payload: HeartbeatIn) -> dict:
+    """Record one deployment heartbeat. Write-only: never echoes data back."""
+    # Coarse environment only — anything we don't recognize collapses to "other"
+    # rather than being stored verbatim.
+    environment = payload.environment if payload.environment == "production" else "other"
+
+    organization = None
+    contact_email = None
+    if payload.identity and payload.identity.organization.strip():
+        organization = payload.identity.organization.strip()
+        contact_email = payload.identity.contact_email.strip() or None
+
+    now = _utcnow()
+    existing = await TelemetryHeartbeat.find_one(
+        TelemetryHeartbeat.instance_id == payload.instance_id
+    )
+    if existing is not None:
+        existing.version = payload.version
+        existing.environment = environment
+        existing.metrics = payload.metrics.model_dump()
+        existing.organization = organization
+        existing.contact_email = contact_email
+        existing.last_seen = now
+        existing.heartbeat_count += 1
+        await existing.save()
+    else:
+        await TelemetryHeartbeat(
+            instance_id=payload.instance_id,
+            version=payload.version,
+            environment=environment,
+            metrics=payload.metrics.model_dump(),
+            organization=organization,
+            contact_email=contact_email,
+            first_seen=now,
+            last_seen=now,
+            heartbeat_count=1,
+        ).insert()
+
+    return {"status": "ok"}
+
+
+# ---------------------------------------------------------------------------
+# Analytics — the in-app fleet dashboard data (admin/staff only).
+# ---------------------------------------------------------------------------
+
+
+def _tally(values: list[str]) -> dict[str, int]:
+    out: dict[str, int] = {}
+    for v in values:
+        key = v or "unknown"
+        out[key] = out.get(key, 0) + 1
+    return out
+
+
+@router.get("/analytics")
+async def telemetry_analytics(user: User = Depends(get_current_user)) -> dict:
+    """Aggregate fleet stats for the admin dashboard."""
+    if not (user.is_admin or user.is_staff):
+        raise HTTPException(status_code=403, detail="Admin access required")
+
+    active_cutoff = _utcnow() - datetime.timedelta(days=ACTIVE_WINDOW_DAYS)
+
+    # The roster is one row per deployment — small enough to scan and aggregate
+    # in-process rather than maintaining a pipeline.
+    rows = await TelemetryHeartbeat.find_all().to_list()
+
+    total = len(rows)
+    active = [r for r in rows if r.last_seen >= active_cutoff]
+
+    named = [
+        {
+            "organization": r.organization,
+            "version": r.version,
+            "environment": r.environment,
+            "last_seen": r.last_seen.isoformat(),
+            "active": r.last_seen >= active_cutoff,
+        }
+        for r in rows
+        if r.organization
+    ]
+    named.sort(key=lambda d: d["last_seen"], reverse=True)
+
+    return {
+        "total_instances": total,
+        "active_instances_30d": len(active),
+        "named_instances": len(named),
+        "anonymous_instances": total - len(named),
+        "by_version": _tally([r.version for r in active]),
+        "by_environment": _tally([r.environment for r in active]),
+        "users_buckets": _tally([r.metrics.get("users", "") for r in active]),
+        "named_deployments": named,
+    }

--- a/backend/app/services/telemetry_service.py
+++ b/backend/app/services/telemetry_service.py
@@ -1,0 +1,176 @@
+"""Anonymous deployment telemetry — the once-daily heartbeat.
+
+This is the privacy-first "how many deployments exist and roughly how heavily
+are they used" signal for self-hosted Vandalizer. It is OPT-IN: nothing leaves
+the box unless an admin sets both ``telemetry_enabled=True`` and a
+``telemetry_endpoint`` (see ``app.config.Settings``).
+
+What the heartbeat sends:
+  - a stable random instance UUID (generated here, persisted in Mongo; it is not
+    derived from anything identifying and cannot be reversed to an institution)
+  - the running version and a coarse environment ("production" / "other")
+  - usage as COARSE BUCKETS only ("11-50", never an exact count)
+
+What it never sends: document content, filenames, titles, user identities,
+emails, API keys, team names, or any free text. The payload is a fixed,
+auditable shape — see ``build_heartbeat_payload`` — and every send is logged
+locally when ``telemetry_log_payload`` is on, so an admin can read exactly what
+was transmitted.
+
+Sync (pymongo + httpx.Client) because it runs from a Celery beat task.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import Any
+from uuid import uuid4
+
+import httpx
+from pymongo.database import Database
+
+from app.config import Settings
+from app.services.version_service import get_current_version
+
+logger = logging.getLogger(__name__)
+
+# Dedicated single-doc collection. Kept separate from the SystemConfig singleton
+# so telemetry state never rides along with operational config edits.
+_STATE_COLLECTION = "telemetry_state"
+_STATE_ID = "instance"
+
+# Window over which a user counts as "active" for the active-user bucket.
+ACTIVE_WINDOW_DAYS = 30
+
+_POST_TIMEOUT_SECONDS = 5.0
+
+
+def get_or_create_instance_id(db: Database[dict]) -> str:
+    """Return this deployment's stable anonymous instance UUID, minting one on
+    first call. The value is random (uuid4) — it identifies the *install*, not
+    the institution, and is the only stable token in the heartbeat."""
+    doc = db[_STATE_COLLECTION].find_one({"_id": _STATE_ID})
+    if doc and doc.get("instance_id"):
+        return str(doc["instance_id"])
+
+    instance_id = str(uuid4())
+    # upsert so two workers racing on first boot converge on one id (the unique
+    # _id makes the second insert a no-op update rather than a duplicate row).
+    db[_STATE_COLLECTION].update_one(
+        {"_id": _STATE_ID},
+        {"$setOnInsert": {"instance_id": instance_id, "created_at": datetime.now(timezone.utc)}},
+        upsert=True,
+    )
+    # Re-read in case a racing worker won the insert with a different id.
+    doc = db[_STATE_COLLECTION].find_one({"_id": _STATE_ID})
+    return str((doc or {}).get("instance_id", instance_id))
+
+
+def _bucket(n: int) -> str:
+    """Collapse an exact count into a coarse, non-identifying range.
+
+    Buckets (not raw numbers) are the whole point: "this deployment has between
+    11 and 50 users" is useful for fleet sizing while revealing almost nothing
+    about a specific institution.
+    """
+    if n <= 0:
+        return "0"
+    if n == 1:
+        return "1"
+    if n <= 10:
+        return "2-10"
+    if n <= 50:
+        return "11-50"
+    if n <= 200:
+        return "51-200"
+    if n <= 1000:
+        return "201-1000"
+    return "1000+"
+
+
+def _coarse_environment(settings: Settings) -> str:
+    """Only production vs. everything-else — never the free-text deployment label."""
+    return "production" if settings.is_production else "other"
+
+
+def build_heartbeat_payload(db: Database[dict], settings: Settings) -> dict[str, Any]:
+    """Assemble the exact, fixed-shape JSON that the heartbeat will POST.
+
+    Pure assembly — no network. Kept separate so it can be unit-tested and so
+    the local audit log and the wire payload are guaranteed identical.
+    """
+    now = datetime.now(timezone.utc)
+    active_since = now - timedelta(days=ACTIVE_WINDOW_DAYS)
+
+    user_count = db["user"].count_documents({})
+    active_user_count = db["user"].count_documents({"last_login_at": {"$gte": active_since}})
+    team_count = db["team"].count_documents({})
+    document_count = db["smart_document"].count_documents({})
+    workflow_count = db["workflow"].count_documents({})
+
+    payload: dict[str, Any] = {
+        "schema": 1,
+        "instance_id": get_or_create_instance_id(db),
+        "version": get_current_version(),
+        "environment": _coarse_environment(settings),
+        "sent_at": now.isoformat(),
+        "metrics": {
+            "users": _bucket(user_count),
+            "active_users_30d": _bucket(active_user_count),
+            "teams": _bucket(team_count),
+            "documents": _bucket(document_count),
+            "workflows": _bucket(workflow_count),
+        },
+    }
+
+    # Voluntary identity tier — added ONLY when the admin self-declared an
+    # organization. When blank, the key is omitted entirely so the payload is
+    # honestly anonymous (not an empty-string "identity"). contact_email rides
+    # along only if an org was also given.
+    organization = settings.telemetry_organization.strip()
+    if organization:
+        identity: dict[str, str] = {"organization": organization}
+        contact_email = settings.telemetry_contact_email.strip()
+        if contact_email:
+            identity["contact_email"] = contact_email
+        payload["identity"] = identity
+
+    return payload
+
+
+def send_heartbeat(db: Database[dict], settings: Settings) -> dict[str, Any]:
+    """Build, locally log, and POST one heartbeat.
+
+    Returns a small result dict describing what happened (for the Celery task's
+    return value / logs). Never raises on a delivery failure — telemetry is
+    best-effort and must never disrupt the deployment it reports on.
+    """
+    if not settings.telemetry_enabled:
+        return {"status": "disabled"}
+
+    if not settings.telemetry_endpoint:
+        # Opt-in flag flipped but no destination configured: do nothing rather
+        # than guess a domain. This is the safety interlock from config.py.
+        logger.warning(
+            "telemetry_enabled is set but telemetry_endpoint is empty — "
+            "no heartbeat sent. Set telemetry_endpoint to opt in fully."
+        )
+        return {"status": "no_endpoint"}
+
+    payload = build_heartbeat_payload(db, settings)
+
+    if settings.telemetry_log_payload:
+        # The audit guarantee: an admin can grep the worker log and see the
+        # complete, literal payload that was transmitted.
+        logger.info("Telemetry heartbeat payload: %s", payload)
+
+    try:
+        with httpx.Client(timeout=_POST_TIMEOUT_SECONDS) as client:
+            resp = client.post(settings.telemetry_endpoint, json=payload)
+            resp.raise_for_status()
+    except httpx.HTTPError as exc:
+        logger.info("Telemetry heartbeat delivery failed: %s", exc)
+        return {"status": "delivery_failed", "error": str(exc)}
+
+    return {"status": "sent", "instance_id": payload["instance_id"]}

--- a/backend/app/tasks/telemetry_tasks.py
+++ b/backend/app/tasks/telemetry_tasks.py
@@ -1,0 +1,37 @@
+"""Celery task for the anonymous deployment heartbeat.
+
+Scheduled once a day via Celery Beat (see app/celery_app.py), but the beat
+entry is only registered when telemetry_enabled is True, so an opt-out
+deployment never even schedules the task. The task also re-checks the flag at
+run time as a belt-and-suspenders guard.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from app.celery_app import celery_app
+from app.config import Settings
+from app.tasks import TRANSIENT_EXCEPTIONS, get_sync_db
+
+logger = logging.getLogger(__name__)
+
+
+@celery_app.task(
+    bind=True,
+    name="tasks.telemetry.send_heartbeat",
+    autoretry_for=TRANSIENT_EXCEPTIONS,
+    retry_backoff=True,
+    max_retries=2,
+    default_retry_delay=300,
+)
+def send_heartbeat(self) -> dict:
+    """Send one anonymous deployment heartbeat (opt-in; no-op when disabled)."""
+    from app.services.telemetry_service import send_heartbeat as _send
+
+    settings = Settings()
+    if not settings.telemetry_enabled:
+        return {"status": "disabled"}
+
+    db = get_sync_db()
+    return _send(db, settings)

--- a/backend/celery_worker.py
+++ b/backend/celery_worker.py
@@ -33,6 +33,7 @@ from app.tasks import approval_tasks  # noqa: F401  — tasks.approvals.*
 from app.tasks import catalog_tasks  # noqa: F401  — tasks.catalog.upgrade
 from app.tasks import engagement_tasks  # noqa: F401  — tasks.engagement.*
 from app.tasks import retention_tasks  # noqa: F401  — tasks.retention.*
+from app.tasks import telemetry_tasks  # noqa: F401  — tasks.telemetry.send_heartbeat
 
 # Initialize Sentry in the worker process. Celery workers never import
 # app.main, so without this call task crashes are never reported. Task imports

--- a/backend/tests/test_telemetry.py
+++ b/backend/tests/test_telemetry.py
@@ -1,0 +1,301 @@
+"""Tests for anonymous deployment telemetry — sender service + receiver routes.
+
+Follows the repo convention of mocking Beanie model methods rather than standing
+up a database. Covers: bucket coarsening, payload assembly + the voluntary
+identity tier, the send-side opt-in interlocks, ingest validation/upsert, and
+the admin analytics aggregation + access gate.
+"""
+
+import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic import ValidationError
+
+from app.config import Settings
+from app.routers import telemetry as rx
+from app.services import telemetry_service as tx
+
+
+@pytest.fixture(autouse=True)
+def _disable_rate_limiter():
+    """Unit-test the ingest handler directly; slowapi's decorator otherwise
+    demands a real starlette Request. Restored after each test."""
+    prev = rx.limiter.enabled
+    rx.limiter.enabled = False
+    yield
+    rx.limiter.enabled = prev
+
+
+# ---------------------------------------------------------------------------
+# Fake sync DB for the sender's build_heartbeat_payload / instance id
+# ---------------------------------------------------------------------------
+
+
+class _FakeColl:
+    def __init__(self, count, state):
+        self._count = count
+        self._state = state
+
+    def count_documents(self, _q):
+        return self._count
+
+    def find_one(self, _q):
+        return self._state
+
+    def update_one(self, *_a, **_k):
+        return None
+
+
+class _FakeDB:
+    """Returns a per-collection document count; serves a fixed instance id."""
+
+    def __init__(self, counts):
+        self._counts = counts
+        self._state = {"instance_id": "fixed-instance-id"}
+
+    def __getitem__(self, name):
+        return _FakeColl(self._counts.get(name, 0), self._state)
+
+
+# ---------------------------------------------------------------------------
+# Bucketing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "n,expected",
+    [
+        (0, "0"), (-5, "0"), (1, "1"), (2, "2-10"), (10, "2-10"),
+        (11, "11-50"), (50, "11-50"), (51, "51-200"), (200, "51-200"),
+        (201, "201-1000"), (1000, "201-1000"), (1001, "1000+"), (99999, "1000+"),
+    ],
+)
+def test_bucket_boundaries(n, expected):
+    assert tx._bucket(n) == expected
+
+
+def test_coarse_environment_only_prod_or_other():
+    assert tx._coarse_environment(Settings(environment="production")) == "production"
+    assert tx._coarse_environment(Settings(environment="staging")) == "other"
+    assert tx._coarse_environment(Settings(environment="development")) == "other"
+
+
+# ---------------------------------------------------------------------------
+# Payload assembly + voluntary identity tier
+# ---------------------------------------------------------------------------
+
+
+def _counts(**kw):
+    base = {"user": 0, "team": 0, "smart_document": 0, "workflow": 0}
+    base.update(kw)
+    return base
+
+
+def test_payload_buckets_and_shape():
+    db = _FakeDB(_counts(user=30, team=3, smart_document=120, workflow=7))
+    p = tx.build_heartbeat_payload(db, Settings(telemetry_enabled=True))
+    assert p["schema"] == 1
+    assert p["instance_id"] == "fixed-instance-id"
+    assert p["metrics"] == {
+        "users": "11-50",
+        "active_users_30d": "11-50",
+        "teams": "2-10",
+        "documents": "51-200",
+        "workflows": "2-10",
+    }
+
+
+def test_payload_anonymous_when_no_org():
+    db = _FakeDB(_counts(user=1))
+    p = tx.build_heartbeat_payload(db, Settings(telemetry_enabled=True))
+    assert "identity" not in p
+
+
+def test_payload_includes_identity_when_org_set():
+    db = _FakeDB(_counts(user=1))
+    s = Settings(
+        telemetry_enabled=True,
+        telemetry_organization="University of Idaho",
+        telemetry_contact_email="ra@uidaho.edu",
+    )
+    p = tx.build_heartbeat_payload(db, s)
+    assert p["identity"] == {
+        "organization": "University of Idaho",
+        "contact_email": "ra@uidaho.edu",
+    }
+
+
+def test_payload_email_without_org_stays_anonymous():
+    """contact_email must never leak without a deliberate org declaration."""
+    db = _FakeDB(_counts(user=1))
+    s = Settings(telemetry_enabled=True, telemetry_contact_email="ra@uidaho.edu")
+    assert "identity" not in tx.build_heartbeat_payload(db, s)
+
+
+# ---------------------------------------------------------------------------
+# Send-side opt-in interlocks
+# ---------------------------------------------------------------------------
+
+
+def test_send_noop_when_disabled():
+    assert tx.send_heartbeat(_FakeDB(_counts()), Settings(telemetry_enabled=False)) == {
+        "status": "disabled"
+    }
+
+
+def test_send_requires_endpoint():
+    s = Settings(telemetry_enabled=True, telemetry_endpoint="")
+    assert tx.send_heartbeat(_FakeDB(_counts()), s)["status"] == "no_endpoint"
+
+
+def test_send_posts_payload_when_configured():
+    db = _FakeDB(_counts(user=5))
+    s = Settings(telemetry_enabled=True, telemetry_endpoint="https://collector.example/hb")
+
+    mock_resp = MagicMock()
+    mock_resp.raise_for_status = MagicMock()
+    mock_client = MagicMock()
+    mock_client.__enter__ = MagicMock(return_value=mock_client)
+    mock_client.__exit__ = MagicMock(return_value=False)
+    mock_client.post = MagicMock(return_value=mock_resp)
+
+    with patch.object(tx.httpx, "Client", return_value=mock_client):
+        result = tx.send_heartbeat(db, s)
+
+    assert result["status"] == "sent"
+    _, kwargs = mock_client.post.call_args
+    assert kwargs["json"]["metrics"]["users"] == "2-10"
+
+
+# ---------------------------------------------------------------------------
+# Ingest payload validation
+# ---------------------------------------------------------------------------
+
+
+def test_ingest_parses_client_shape_and_ignores_extra():
+    p = rx.HeartbeatIn.model_validate({
+        "schema": 1,
+        "instance_id": "abcd1234ef",
+        "version": "v2026.04.1",
+        "environment": "production",
+        "metrics": {"users": "11-50"},
+        "identity": {"organization": "U of Idaho"},
+        "future_field": "ignored",
+    })
+    assert p.instance_id == "abcd1234ef"
+    assert p.identity.organization == "U of Idaho"
+
+
+def test_ingest_identity_optional():
+    p = rx.HeartbeatIn.model_validate({"schema": 1, "instance_id": "abcd1234ef"})
+    assert p.identity is None
+    assert p.environment == "other"
+
+
+def test_ingest_rejects_short_instance_id():
+    with pytest.raises(ValidationError):
+        rx.HeartbeatIn.model_validate({"instance_id": "short"})
+
+
+def test_ingest_rejects_oversized_strings():
+    with pytest.raises(ValidationError):
+        rx.HeartbeatIn.model_validate({"instance_id": "abcd1234ef", "version": "v" * 100})
+
+
+# ---------------------------------------------------------------------------
+# Ingest upsert behavior
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ingest_inserts_new_instance():
+    payload = rx.HeartbeatIn.model_validate({
+        "schema": 1, "instance_id": "new-instance-id", "version": "v1.0.0",
+        "environment": "production", "metrics": {"users": "2-10"},
+    })
+    created = MagicMock()
+    created.insert = AsyncMock()
+    with patch.object(rx, "TelemetryHeartbeat") as Model:
+        Model.find_one = AsyncMock(return_value=None)
+        Model.return_value = created
+        out = await rx.receive_heartbeat(MagicMock(), payload)
+    assert out == {"status": "ok"}
+    created.insert.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_ingest_updates_existing_and_increments_count():
+    payload = rx.HeartbeatIn.model_validate({
+        "schema": 1, "instance_id": "known-id", "version": "v2.0.0",
+        "environment": "weird-value", "metrics": {"users": "51-200"},
+        "identity": {"organization": "  Boise State  ", "contact_email": "x@bsu.edu"},
+    })
+    existing = MagicMock()
+    existing.heartbeat_count = 4
+    existing.save = AsyncMock()
+    with patch.object(rx, "TelemetryHeartbeat") as Model:
+        Model.find_one = AsyncMock(return_value=existing)
+        await rx.receive_heartbeat(MagicMock(), payload)
+
+    existing.save.assert_awaited_once()
+    assert existing.heartbeat_count == 5
+    assert existing.version == "v2.0.0"
+    # Unknown environment collapses to "other"; org is trimmed.
+    assert existing.environment == "other"
+    assert existing.organization == "Boise State"
+    assert existing.contact_email == "x@bsu.edu"
+
+
+# ---------------------------------------------------------------------------
+# Analytics aggregation + access gate
+# ---------------------------------------------------------------------------
+
+
+def test_tally_counts_and_defaults_unknown():
+    assert rx._tally(["a", "a", "b", ""]) == {"a": 2, "b": 1, "unknown": 1}
+
+
+def _row(version, env, users, org, days_ago):
+    last_seen = rx._utcnow() - datetime.timedelta(days=days_ago)
+    return SimpleNamespace(
+        version=version, environment=env, metrics={"users": users},
+        organization=org, last_seen=last_seen,
+    )
+
+
+@pytest.mark.asyncio
+async def test_analytics_requires_admin():
+    non_admin = SimpleNamespace(is_admin=False, is_staff=False)
+    with pytest.raises(rx.HTTPException) as exc:
+        await rx.telemetry_analytics(user=non_admin)
+    assert exc.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_analytics_aggregates_active_named_and_anonymous():
+    rows = [
+        _row("v1", "production", "2-10", "U of Idaho", days_ago=1),    # active, named
+        _row("v1", "other", "11-50", None, days_ago=5),               # active, anon
+        _row("v2", "production", "2-10", "Stale U", days_ago=99),     # inactive, named
+    ]
+    admin = SimpleNamespace(is_admin=True, is_staff=False)
+    with patch.object(rx, "TelemetryHeartbeat") as Model:
+        Model.find_all = MagicMock(
+            return_value=MagicMock(to_list=AsyncMock(return_value=rows))
+        )
+        out = await rx.telemetry_analytics(user=admin)
+
+    assert out["total_instances"] == 3
+    assert out["active_instances_30d"] == 2
+    assert out["named_instances"] == 2          # counts named regardless of active
+    assert out["anonymous_instances"] == 1
+    # Distributions are computed over ACTIVE rows only.
+    assert out["by_version"] == {"v1": 2}
+    assert out["by_environment"] == {"production": 1, "other": 1}
+    assert out["users_buckets"] == {"2-10": 1, "11-50": 1}
+    # Named list is sorted most-recent first and carries the active flag.
+    assert [d["organization"] for d in out["named_deployments"]] == ["U of Idaho", "Stale U"]
+    assert out["named_deployments"][0]["active"] is True
+    assert out["named_deployments"][1]["active"] is False

--- a/backend/tests/test_telemetry.py
+++ b/backend/tests/test_telemetry.py
@@ -77,8 +77,12 @@ def test_bucket_boundaries(n, expected):
 
 
 def test_coarse_environment_only_prod_or_other():
-    assert tx._coarse_environment(Settings(environment="production")) == "production"
-    assert tx._coarse_environment(Settings(environment="staging")) == "other"
+    # A real jwt_secret_key is required to construct Settings in a non-development
+    # environment (the _check_jwt_secret validator rejects the "change-me" default),
+    # so supply one here — CI has no .env to provide it.
+    secret = {"jwt_secret_key": "test-secret"}
+    assert tx._coarse_environment(Settings(environment="production", **secret)) == "production"
+    assert tx._coarse_environment(Settings(environment="staging", **secret)) == "other"
     assert tx._coarse_environment(Settings(environment="development")) == "other"
 
 

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -1,0 +1,110 @@
+# Telemetry
+
+Vandalizer can send the maintainers an **anonymous, opt-in heartbeat** so we can
+see how many deployments exist and roughly how heavily they're used. This page is
+the full disclosure: exactly what is sent, what is never sent, and how to turn it
+on, off, or point it at your own collector.
+
+**It is off by default.** A fresh install sends nothing. Telemetry only happens
+after an administrator explicitly enables it (the `./setup.sh` installer asks,
+defaulting to *no*).
+
+## What is sent
+
+When enabled, one HTTP `POST` is sent once per day with a payload of this exact
+shape:
+
+```json
+{
+  "schema": 1,
+  "instance_id": "8f3c1e2a-...-random-uuid",
+  "version": "v2026.06.1",
+  "environment": "production",
+  "sent_at": "2026-06-29T07:23:00+00:00",
+  "metrics": {
+    "users": "11-50",
+    "active_users_30d": "11-50",
+    "teams": "2-10",
+    "documents": "51-200",
+    "workflows": "2-10"
+  }
+}
+```
+
+- **`instance_id`** — a random UUID generated locally on first heartbeat and
+  stored in your own database. It identifies the *install*, not you; it is not
+  derived from anything about your institution and cannot be reversed.
+- **`version`** / **`environment`** — the running version, and a coarse
+  `production` vs. `other` only (never your `DEPLOYMENT_LABEL` or hostname).
+- **`metrics`** — usage as **coarse buckets** (`"11-50"`), never exact counts.
+
+## What is never sent
+
+Document content or filenames, titles, user names or emails, team or
+organization names, API keys, IP-derived identity, or any free text. The payload
+is a fixed, validated shape — there is no field in which such data could ride
+along.
+
+Every heartbeat is also written to your own application log before it is sent
+(`TELEMETRY_LOG_PAYLOAD=true`, the default), so an administrator can read the
+literal bytes that left the box.
+
+## Optional: identify your deployment
+
+By default the heartbeat is fully anonymous. If you *want* the maintainers to
+know who you are — for adoption reporting, or to receive security advisories —
+you can voluntarily attach your organization name:
+
+```bash
+TELEMETRY_ORGANIZATION="University of Idaho"
+TELEMETRY_CONTACT_EMAIL="research-admin@uidaho.edu"   # optional
+```
+
+The installer offers this as a separate, explicit choice (also defaulting to
+*stay anonymous*). Rules:
+
+- It is **self-declared only**. Vandalizer never infers your identity from email
+  domains, IP geolocation, or anything else.
+- If `TELEMETRY_ORGANIZATION` is blank, **no identity block is sent at all** —
+  not even an empty one. A contact email alone is never transmitted without an
+  organization.
+
+## Enabling, disabling, and self-hosting
+
+All configuration is via environment variables (`backend/.env`):
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `TELEMETRY_ENABLED` | `false` | Master opt-in switch for the heartbeat. |
+| `TELEMETRY_ENDPOINT` | _(empty)_ | Where heartbeats are sent. Inert unless set. |
+| `TELEMETRY_LOG_PAYLOAD` | `true` | Log each payload locally before sending. |
+| `TELEMETRY_ORGANIZATION` | _(empty)_ | Optional self-declared identity. |
+| `TELEMETRY_CONTACT_EMAIL` | _(empty)_ | Optional contact, sent only with an org. |
+
+The heartbeat is **inert unless both `TELEMETRY_ENABLED=true` and
+`TELEMETRY_ENDPOINT` are set**, so flipping the switch alone never sends data to
+a guessed destination.
+
+- **To disable:** set `TELEMETRY_ENABLED=false` (or leave it). Takes effect on
+  the next worker restart.
+- **To send to your own collector instead:** point `TELEMETRY_ENDPOINT` at any
+  URL that accepts the JSON above — including your own Vandalizer instance acting
+  as a collector (see below).
+
+## Running your own collector
+
+Any Vandalizer deployment can act as the receiver by setting:
+
+```bash
+TELEMETRY_COLLECTOR_ENABLED=true
+```
+
+This — and only this — exposes the public `POST /api/telemetry/heartbeat` ingest
+route and an admin **Telemetry** dashboard (fleet size, version distribution,
+active deployments, and any self-declared organizations). On every deployment
+where the flag is unset, both the route and the dashboard do not exist at all.
+
+The ingest endpoint is unauthenticated by design (heartbeats arrive from
+deployments with no shared secret), and is rate-limited and strictly validated.
+Received data is stored in a dedicated `telemetry_heartbeat` collection, kept
+separate from any operational or document data.

--- a/frontend/src/api/admin.ts
+++ b/frontend/src/api/admin.ts
@@ -1,5 +1,30 @@
 import { apiFetch } from './client'
 
+// Fleet telemetry analytics (collector instance only)
+
+export interface NamedDeployment {
+  organization: string
+  version: string
+  environment: string
+  last_seen: string
+  active: boolean
+}
+
+export interface TelemetryAnalytics {
+  total_instances: number
+  active_instances_30d: number
+  named_instances: number
+  anonymous_instances: number
+  by_version: Record<string, number>
+  by_environment: Record<string, number>
+  users_buckets: Record<string, number>
+  named_deployments: NamedDeployment[]
+}
+
+export function getTelemetryAnalytics() {
+  return apiFetch<TelemetryAnalytics>('/api/telemetry/analytics')
+}
+
 // Version / update check
 
 export interface VersionStatus {

--- a/frontend/src/api/config.ts
+++ b/frontend/src/api/config.ts
@@ -116,6 +116,9 @@ export function getAutomationStats() {
 
 export interface FeatureFlags {
   m365_enabled: boolean
+  compliance_enabled?: boolean
+  // True only on the fleet collector instance — gates the admin Telemetry tab.
+  telemetry_collector_enabled?: boolean
 }
 
 export function getFeatureFlags() {

--- a/frontend/src/components/admin/TelemetryTab.tsx
+++ b/frontend/src/components/admin/TelemetryTab.tsx
@@ -1,0 +1,158 @@
+import { useCallback, useEffect, useState } from 'react'
+import {
+  Globe, Activity, Tag, EyeOff, RefreshCw, Server,
+} from 'lucide-react'
+
+import { getTelemetryAnalytics, type TelemetryAnalytics } from '../../api/admin'
+import { relativeTime } from '../../utils/time'
+
+function StatCard({ icon: Icon, label, value, color }: {
+  icon: typeof Tag
+  label: string
+  value: string | number
+  color: string
+}) {
+  return (
+    <div style={{
+      flex: 1, minWidth: 160,
+      backgroundColor: '#fff', border: '1px solid #e5e7eb',
+      borderRadius: 8, padding: 16,
+      display: 'flex', flexDirection: 'column', gap: 8,
+    }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, color: '#6b7280', fontSize: 13 }}>
+        <Icon size={16} color={color} />
+        {label}
+      </div>
+      <div style={{ fontSize: 24, fontWeight: 700, color: '#111827' }}>{value}</div>
+    </div>
+  )
+}
+
+// A simple labeled distribution: sorted desc, bar width relative to the max.
+function Distribution({ title, data }: { title: string; data: Record<string, number> }) {
+  const entries = Object.entries(data).sort((a, b) => b[1] - a[1])
+  const max = entries.reduce((m, [, n]) => Math.max(m, n), 0) || 1
+  return (
+    <div style={{
+      flex: 1, minWidth: 240,
+      backgroundColor: '#fff', border: '1px solid #e5e7eb', borderRadius: 8, padding: 16,
+    }}>
+      <div style={{ fontSize: 13, fontWeight: 600, color: '#374151', marginBottom: 12 }}>{title}</div>
+      {entries.length === 0 ? (
+        <div style={{ fontSize: 13, color: '#9ca3af' }}>No data yet</div>
+      ) : (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+          {entries.map(([key, n]) => (
+            <div key={key} style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+              <div style={{ width: 90, fontSize: 12, color: '#6b7280', textAlign: 'right', flexShrink: 0 }}>{key}</div>
+              <div style={{ flex: 1, height: 18, backgroundColor: '#f3f4f6', borderRadius: 4, overflow: 'hidden' }}>
+                <div style={{ width: `${(n / max) * 100}%`, height: '100%', backgroundColor: '#6366f1', borderRadius: 4 }} />
+              </div>
+              <div style={{ width: 32, fontSize: 12, fontWeight: 600, color: '#111827', textAlign: 'right' }}>{n}</div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export function TelemetryTab() {
+  const [data, setData] = useState<TelemetryAnalytics | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const reload = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      setData(await getTelemetryAnalytics())
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to load telemetry')
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => { void reload() }, [reload])
+
+  if (loading && !data) {
+    return <div style={{ padding: 24, color: '#6b7280' }}>Loading…</div>
+  }
+  if (error) {
+    return <div style={{ padding: 24, color: '#dc2626' }}>{error}</div>
+  }
+  if (!data) return null
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        <div>
+          <h2 style={{ fontSize: 18, fontWeight: 700, margin: 0 }}>Fleet Telemetry</h2>
+          <p style={{ fontSize: 13, color: '#6b7280', margin: '4px 0 0' }}>
+            Anonymous heartbeats from deployments that opted in. Counts are coarse buckets; identity appears only where a deployment self-declared it.
+          </p>
+        </div>
+        <button
+          onClick={() => void reload()}
+          style={{
+            display: 'flex', alignItems: 'center', gap: 6,
+            padding: '8px 12px', fontSize: 13, fontWeight: 500,
+            backgroundColor: '#fff', border: '1px solid #e5e7eb', borderRadius: 8,
+            color: '#374151', cursor: 'pointer',
+          }}
+        >
+          <RefreshCw size={14} /> Refresh
+        </button>
+      </div>
+
+      <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap' }}>
+        <StatCard icon={Globe} label="Total deployments" value={data.total_instances} color="#6366f1" />
+        <StatCard icon={Activity} label="Active (30d)" value={data.active_instances_30d} color="#22c55e" />
+        <StatCard icon={Tag} label="Named" value={data.named_instances} color="#3b82f6" />
+        <StatCard icon={EyeOff} label="Anonymous" value={data.anonymous_instances} color="#9ca3af" />
+      </div>
+
+      <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap' }}>
+        <Distribution title="By version (active)" data={data.by_version} />
+        <Distribution title="By environment (active)" data={data.by_environment} />
+        <Distribution title="Users per deployment (active)" data={data.users_buckets} />
+      </div>
+
+      <div style={{ backgroundColor: '#fff', border: '1px solid #e5e7eb', borderRadius: 8, overflow: 'hidden' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '12px 16px', borderBottom: '1px solid #f3f4f6' }}>
+          <Server size={16} color="#6b7280" />
+          <span style={{ fontSize: 13, fontWeight: 600, color: '#374151' }}>
+            Named deployments ({data.named_deployments.length})
+          </span>
+        </div>
+        {data.named_deployments.length === 0 ? (
+          <div style={{ padding: 24, fontSize: 13, color: '#9ca3af' }}>
+            No deployments have self-identified yet.
+          </div>
+        ) : (
+          <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 13 }}>
+            <thead>
+              <tr style={{ textAlign: 'left', color: '#6b7280' }}>
+                <th style={{ padding: '8px 16px', fontWeight: 500 }}>Organization</th>
+                <th style={{ padding: '8px 16px', fontWeight: 500 }}>Version</th>
+                <th style={{ padding: '8px 16px', fontWeight: 500 }}>Environment</th>
+                <th style={{ padding: '8px 16px', fontWeight: 500 }}>Last seen</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.named_deployments.map((d, i) => (
+                <tr key={`${d.organization}-${i}`} style={{ borderTop: '1px solid #f3f4f6', opacity: d.active ? 1 : 0.5 }}>
+                  <td style={{ padding: '8px 16px', fontWeight: 600, color: '#111827' }}>{d.organization}</td>
+                  <td style={{ padding: '8px 16px', color: '#374151' }}>{d.version}</td>
+                  <td style={{ padding: '8px 16px', color: '#374151' }}>{d.environment}</td>
+                  <td style={{ padding: '8px 16px', color: '#6b7280' }}>{relativeTime(d.last_seen)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/Admin.tsx
+++ b/frontend/src/pages/Admin.tsx
@@ -73,6 +73,8 @@ import { CatalogTab } from '../components/admin/CatalogTab'
 import { ApiKeysTab } from '../components/admin/ApiKeysTab'
 import { ComplianceTab } from '../components/admin/ComplianceTab'
 import { KnowledgeBasesTab } from '../components/admin/KnowledgeBasesTab'
+import { TelemetryTab } from '../components/admin/TelemetryTab'
+import { getFeatureFlags } from '../api/config'
 
 function applyThemeToDOM(theme: ThemeConfig) {
   const root = document.documentElement
@@ -91,7 +93,7 @@ function readFileAsDataUrl(file: File): Promise<string> {
   })
 }
 
-type Tab = 'usage' | 'users' | 'teams' | 'organizations' | 'workflows' | 'quality' | 'knowledgebases' | 'compliance' | 'audit' | 'demo' | 'email' | 'certifications' | 'apikeys' | 'catalog' | 'config'
+type Tab = 'usage' | 'users' | 'teams' | 'organizations' | 'workflows' | 'quality' | 'knowledgebases' | 'compliance' | 'audit' | 'demo' | 'email' | 'certifications' | 'apikeys' | 'catalog' | 'telemetry' | 'config'
 
 const TABS: { key: Tab; label: string; icon: typeof BarChart3 }[] = [
   { key: 'usage', label: 'Usage', icon: BarChart3 },
@@ -108,6 +110,7 @@ const TABS: { key: Tab; label: string; icon: typeof BarChart3 }[] = [
   { key: 'certifications', label: 'Certifications', icon: Award },
   { key: 'apikeys', label: 'API Keys', icon: KeyRound },
   { key: 'catalog', label: 'Catalog', icon: PackageOpen },
+  { key: 'telemetry', label: 'Telemetry', icon: Globe },
   { key: 'config', label: 'Config', icon: Settings },
 ]
 
@@ -7126,9 +7129,12 @@ export default function Admin() {
   const { currentTeam } = useTeams()
   const [activeTab, setActiveTab] = useState<Tab>('usage')
   const [trialEnabled, setTrialEnabled] = useState(false)
+  // Only true on the fleet collector instance; hides the Telemetry tab elsewhere.
+  const [telemetryCollector, setTelemetryCollector] = useState(false)
 
   useEffect(() => {
     getAuthConfig().then(c => setTrialEnabled(!!c.trial_system_enabled)).catch(() => {})
+    getFeatureFlags().then(f => setTelemetryCollector(!!f.telemetry_collector_enabled)).catch(() => {})
   }, [])
 
   // Honor ?tab=<key> deep links (e.g. the catalog-update notification).
@@ -7151,7 +7157,7 @@ export default function Admin() {
   // endpoints accept a team scope. Tabs whose backends require admin/staff (email,
   // plus everything in hiddenForNonAdmin) stay hidden so we never render a tab that
   // can only 403.
-  const hiddenForNonAdmin = ['config', 'catalog', 'quality', 'knowledgebases', 'compliance', 'demo', 'organizations', 'approvals', 'audit', 'certifications', 'apikeys', 'email', 'teams']
+  const hiddenForNonAdmin = ['config', 'catalog', 'quality', 'knowledgebases', 'compliance', 'demo', 'organizations', 'approvals', 'audit', 'certifications', 'apikeys', 'email', 'teams', 'telemetry']
   let visibleTabs = isGlobalAdmin
     ? TABS
     : isStaff
@@ -7160,6 +7166,10 @@ export default function Admin() {
 
   if (!trialEnabled) {
     visibleTabs = visibleTabs.filter(t => t.key !== 'demo')
+  }
+  // The Telemetry tab exists only on the collector instance.
+  if (!telemetryCollector) {
+    visibleTabs = visibleTabs.filter(t => t.key !== 'telemetry')
   }
 
   if (!hasAccess) {
@@ -7239,6 +7249,7 @@ export default function Admin() {
           {activeTab === 'certifications' && (isGlobalAdmin || isStaff) && <CertificationsTab />}
           {activeTab === 'apikeys' && (isGlobalAdmin || isStaff) && <ApiKeysTab />}
           {activeTab === 'catalog' && isGlobalAdmin && <CatalogTab />}
+          {activeTab === 'telemetry' && isGlobalAdmin && telemetryCollector && <TelemetryTab />}
           {activeTab === 'config' && isGlobalAdmin && <ConfigTab />}
         </div>
       </div>

--- a/setup.sh
+++ b/setup.sh
@@ -845,6 +845,36 @@ bootstrap() {
   local ORG_NAME=""
   prompt "Institution / organization name" "" ORG_NAME
 
+  # --- Anonymous usage telemetry (opt-in) ---
+  echo ""
+  echo -e "  ${SYM_NEURAL}  ${BOLD}Usage telemetry${RESET} ${DIM}(optional)${RESET}"
+  echo -e "  ${DIM}     A once-a-day heartbeat helps the Vandalizer maintainers see how${RESET}"
+  echo -e "  ${DIM}     many deployments exist and roughly how heavily they're used.${RESET}"
+  echo -e "  ${DIM}     Sends ONLY: an anonymous random ID, the version, and coarse usage${RESET}"
+  echo -e "  ${DIM}     buckets (\"11-50 users\"). NEVER documents, names, emails, or keys.${RESET}"
+  echo -e "  ${DIM}     Off by default; change TELEMETRY_* in backend/.env anytime.${RESET}"
+  echo ""
+  if confirm "Send anonymous usage telemetry?" "n"; then
+    set_env "TELEMETRY_ENABLED" "true"
+    # Provisional collector on the U of I instance; override in .env to self-host.
+    set_env "TELEMETRY_ENDPOINT" "https://vandalizer.nkn.uidaho.edu/api/telemetry/heartbeat"
+    echo -e "  ${SYM_CHECK}  Anonymous telemetry ${BOLD}enabled${RESET}"
+
+    # Voluntary identity tier — only offered when they already named the
+    # institution above, and only attached if they explicitly agree.
+    if [[ -n "$ORG_NAME" ]]; then
+      if confirm "Identify this deployment as \"${ORG_NAME}\" (otherwise stays anonymous)?" "n"; then
+        set_env "TELEMETRY_ORGANIZATION" "$ORG_NAME"
+        echo -e "  ${SYM_CHECK}  Telemetry will identify this deployment as ${BOLD}${ORG_NAME}${RESET}"
+      else
+        echo -e "  ${SYM_CHECK}  Telemetry will stay ${BOLD}anonymous${RESET}"
+      fi
+    fi
+  else
+    set_env "TELEMETRY_ENABLED" "false"
+    echo -e "  ${SYM_CHECK}  Telemetry ${BOLD}disabled${RESET}"
+  fi
+
   echo ""
   echo -e "  ${SYM_NEURAL}  ${BOLD}Verified catalog${RESET}"
   echo -e "  ${DIM}     The bootstrap will also seed research administration content:${RESET}"


### PR DESCRIPTION
## Summary

Adds a **privacy-first, opt-in** telemetry system so the maintainers can see how many self-hosted deployments exist and roughly how heavily they're used — without collecting anything sensitive.

**Off by default.** A fresh install sends nothing; `./setup.sh` asks before enabling, defaulting to *no*.

### Sender (every deployment)
- Daily heartbeat sending **only**: an anonymous random instance UUID, the version, coarse environment (`production`/`other`), and **bucketed** usage counts (`"11-50"`). Never document content, filenames, names, emails, or keys.
- **Two interlocks:** inert unless both `TELEMETRY_ENABLED` and `TELEMETRY_ENDPOINT` are set, and every payload is logged locally before sending (`TELEMETRY_LOG_PAYLOAD`).
- **Optional voluntary identity** (`TELEMETRY_ORGANIZATION` / `TELEMETRY_CONTACT_EMAIL`) — self-declared only, never auto-derived, and omitted entirely when blank (a contact email alone never transmits).
- `setup.sh` prompts at install time (defaults to no / anonymous), reusing the institution name already collected.

### Receiver (collector instance only — `TELEMETRY_COLLECTOR_ENABLED`)
- `TelemetryHeartbeat` roster model, a rate-limited + strictly-validated public ingest route, and an admin-only analytics endpoint.
- Both routes are **unregistered (404) and the dashboard hidden** on every deployment where the flag is unset — verified.
- Admin **Telemetry** dashboard: fleet size, active-30d, version/environment distributions, and self-identified deployments. Gated via `/api/config/features`.

### Tests & docs
- 30 unit tests (`tests/test_telemetry.py`) covering bucketing, payload + identity rules, send interlocks, ingest validation/upsert, and analytics aggregation + the admin gate.
- `docs/telemetry.md` — full disclosure (exact payload, what's never sent, how to disable / self-host), linked from `DEPLOY.md`.

## Reviewer notes / decisions
- **Ingest is unauthenticated by design** — heartbeats arrive from deployments with no shared secret; protected by rate limiting + strict schema/length validation. A token baked into open-source client defaults wouldn't be a real secret.
- **Roster model stores latest-state only** (one row per instance), so there are no time-series/trend charts yet — a conscious deferral. Adding trends later means a daily aggregate snapshot.
- **Provisional endpoint:** `setup.sh` writes `https://vandalizer.nkn.uidaho.edu/api/telemetry/heartbeat` — confirm the host before merge.
- Analytics aggregates in-process (fine to thousands of instances); would want a pipeline beyond that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
