### PR TITLE
feat(telemetry): prompt on upgrade/redeploy + in-app admin opt-in banner

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -73,9 +73,14 @@ ENABLE_TRIAL_SYSTEM=false
 # --- Anonymous usage telemetry (opt-in sender) ---
 # A once-a-day heartbeat reporting only an anonymous random ID, the version, and
 # coarse usage buckets ("11-50 users"). Never documents, names, emails, or keys.
-# Inert unless BOTH enabled AND an endpoint are set. setup.sh can configure this.
+# Off by default. setup.sh asks on install AND on redeploy/upgrade; admins can
+# also enable it from the in-app banner (which records the choice in the DB).
 TELEMETRY_ENABLED=false
-TELEMETRY_ENDPOINT=
+# Where heartbeats are sent. Defaults to the maintainers' collector; override to
+# self-host, or blank it to hard-disable sending.
+TELEMETRY_ENDPOINT=https://vandalizer.nkn.uidaho.edu/api/telemetry/heartbeat
+# Set true once setup.sh has asked (yes or no) so the in-app banner doesn't re-ask.
+TELEMETRY_PROMPTED=false
 # Optional voluntary identity — leave blank to stay fully anonymous. Self-declared
 # only; never auto-derived. When organization is blank, no identity is sent.
 TELEMETRY_ORGANIZATION=

--- a/backend/app/celery_app.py
+++ b/backend/app/celery_app.py
@@ -132,13 +132,14 @@ if not settings.enable_trial_system:
     for _key in ("demo-process-waitlist", "demo-check-expirations", "demo-send-expiry-warnings"):
         celery.conf.beat_schedule.pop(_key, None)
 
-# Anonymous deployment heartbeat — only scheduled when the admin has opted in,
-# so an opt-out deployment never even registers the task with beat.
-if settings.telemetry_enabled:
-    celery.conf.beat_schedule["telemetry-daily-heartbeat"] = {
-        "task": "tasks.telemetry.send_heartbeat",
-        "schedule": crontab(hour=7, minute=23),  # daily, off-peak, non-round minute
-    }
+# Anonymous deployment heartbeat — always scheduled; the task resolves the
+# effective opt-in decision (SystemConfig DB + env default) at run time and
+# no-ops when telemetry is disabled. Always-scheduling is what lets the in-app
+# opt-in banner enable telemetry without a worker restart.
+celery.conf.beat_schedule["telemetry-daily-heartbeat"] = {
+    "task": "tasks.telemetry.send_heartbeat",
+    "schedule": crontab(hour=7, minute=23),  # daily, off-peak, non-round minute
+}
 
 # Alias for import convenience
 celery_app = celery

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -86,14 +86,25 @@ class Settings(BaseSettings):
     # emails, API keys, team names, or any free text.
     #
     # Trust guarantees baked into the implementation:
-    #   - Inert unless BOTH telemetry_enabled=True AND telemetry_endpoint is set,
-    #     so flipping the flag alone never leaks to a guessed domain.
+    #   - The single master gate is enablement (off by default); nothing is sent
+    #     until an admin opts in (via setup.sh or the in-app banner).
     #   - Every payload is logged locally (telemetry_log_payload) so an admin can
     #     read exactly what was sent.
     #   - Self-hosters can point telemetry_endpoint at their OWN collector.
+    #
+    # telemetry_enabled here is only the INITIAL/default state. The durable
+    # runtime decision lives in SystemConfig.telemetry_config (DB) once an admin
+    # decides via the in-app banner — so it can be toggled without an env edit or
+    # restart. See telemetry_service.resolve_runtime_config for the precedence.
     telemetry_enabled: bool = False
-    telemetry_endpoint: str = ""
+    # Defaulted so an admin who enables via the in-app banner on an existing
+    # install (whose .env predates telemetry) still has somewhere to send to.
+    # Override to self-host the collector, or blank it to hard-disable sending.
+    telemetry_endpoint: str = "https://vandalizer.nkn.uidaho.edu/api/telemetry/heartbeat"
     telemetry_log_payload: bool = True
+    # Set true by setup.sh once it has asked about telemetry (yes OR no), so the
+    # in-app banner never re-asks someone the installer already prompted.
+    telemetry_prompted: bool = False
 
     # Optional SECOND tier on top of the anonymous heartbeat: voluntary identity.
     # If an admin chooses to fill these in (typically at deploy time via

--- a/backend/app/models/system_config.py
+++ b/backend/app/models/system_config.py
@@ -65,6 +65,16 @@ DEFAULT_RETENTION_CONFIG = {
     "activity_stale_threshold_minutes": 30,
 }
 
+DEFAULT_TELEMETRY_CONFIG = {
+    # decided=True once an admin has made an explicit in-app choice; until then
+    # the env default (settings.telemetry_enabled) governs and the opt-in banner
+    # may show. organization/contact_email are the voluntary identity tier.
+    "decided": False,
+    "enabled": False,
+    "organization": "",
+    "contact_email": "",
+}
+
 DEFAULT_COMPLIANCE_CONFIG = {
     "enabled": False,
     "check_on_upload": True,
@@ -149,6 +159,11 @@ class SystemConfig(Document):
 
     # Compliance configuration (document content checks on upload)
     compliance_config: dict = {}
+
+    # Anonymous telemetry decision (see DEFAULT_TELEMETRY_CONFIG). Lets the
+    # in-app opt-in banner durably enable/disable the heartbeat without an env
+    # edit; empty until an admin decides.
+    telemetry_config: dict = {}
 
     # UI Configuration
     highlight_color: str = "#eab308"
@@ -244,6 +259,13 @@ class SystemConfig(Document):
         config = deepcopy(DEFAULT_COMPLIANCE_CONFIG)
         if self.compliance_config:
             _deep_merge(config, self.compliance_config)
+        return config
+
+    def get_telemetry_config(self) -> dict:
+        """Return telemetry decision with defaults merged in."""
+        config = deepcopy(DEFAULT_TELEMETRY_CONFIG)
+        if self.telemetry_config:
+            _deep_merge(config, self.telemetry_config)
         return config
 
     def is_compliance_enabled(self) -> bool:

--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -11,7 +11,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, Field
 
 from app.config import Settings
-from app.dependencies import get_current_user
+from app.dependencies import get_current_user, get_settings
 from app.models.activity import ActivityEvent
 from app.models.audit_log import AdminAuditLog
 from app.models.system_config import SystemConfig
@@ -1429,6 +1429,72 @@ async def update_config(
     await _audit(user, "update_config", "Updated system configuration")
 
     return {"status": "ok"}
+
+
+# ---------------------------------------------------------------------------
+# Anonymous telemetry opt-in (installation-wide; global admin only)
+# ---------------------------------------------------------------------------
+
+
+class TelemetryOptInRequest(BaseModel):
+    enabled: bool
+    organization: Optional[str] = None
+    contact_email: Optional[str] = None
+
+
+def _telemetry_status(cfg: SystemConfig, settings: Settings) -> dict:
+    """Resolve the effective opt-in state for the admin UI.
+
+    Mirrors telemetry_service.resolve_runtime_config: a DB decision is
+    authoritative once made, else the env default governs. The banner shows only
+    when telemetry is off, no in-app decision exists, AND the installer never
+    already asked (settings.telemetry_prompted)."""
+    tele = cfg.get_telemetry_config()
+    decided = bool(tele.get("decided"))
+    effective = bool(tele.get("enabled")) if decided else settings.telemetry_enabled
+    return {
+        "effective_enabled": effective,
+        "decided": decided,
+        "organization": tele.get("organization", ""),
+        "show_banner": (not effective) and (not decided) and (not settings.telemetry_prompted),
+    }
+
+
+@router.get("/telemetry/optin")
+async def get_telemetry_optin(
+    user: User = Depends(get_current_user),
+    settings: Settings = Depends(get_settings),
+):
+    await _require_superadmin(user)
+    cfg = await SystemConfig.get_config()
+    return _telemetry_status(cfg, settings)
+
+
+@router.post("/telemetry/optin")
+async def set_telemetry_optin(
+    body: TelemetryOptInRequest,
+    user: User = Depends(get_current_user),
+    settings: Settings = Depends(get_settings),
+):
+    await _require_superadmin(user)
+    cfg = await SystemConfig.get_config()
+    tele = cfg.get_telemetry_config()
+    tele["decided"] = True
+    tele["enabled"] = bool(body.enabled)
+    if body.organization is not None:
+        tele["organization"] = body.organization.strip()
+    if body.contact_email is not None:
+        tele["contact_email"] = body.contact_email.strip()
+    cfg.telemetry_config = tele
+    cfg.updated_at = datetime.datetime.now(datetime.timezone.utc)
+    cfg.updated_by = user.user_id
+    await cfg.save()
+    await _audit(
+        user,
+        "update_telemetry_optin",
+        f"Anonymous telemetry {'enabled' if body.enabled else 'disabled'}",
+    )
+    return _telemetry_status(cfg, settings)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/services/telemetry_service.py
+++ b/backend/app/services/telemetry_service.py
@@ -94,12 +94,48 @@ def _coarse_environment(settings: Settings) -> str:
     return "production" if settings.is_production else "other"
 
 
-def build_heartbeat_payload(db: Database[dict], settings: Settings) -> dict[str, Any]:
+def resolve_runtime_config(db: Database[dict], settings: Settings) -> dict[str, Any]:
+    """Resolve the effective telemetry decision from the DB + env defaults.
+
+    Precedence: once an admin makes an explicit in-app decision
+    (SystemConfig.telemetry_config.decided), that DB value is authoritative for
+    enablement and identity. Until then, the env defaults (set by setup.sh)
+    govern. Read with sync pymongo so the Celery heartbeat task stays sync.
+    """
+    doc = db["system_config"].find_one() or {}
+    tele = doc.get("telemetry_config") or {}
+    decided = bool(tele.get("decided"))
+
+    enabled = bool(tele.get("enabled")) if decided else settings.telemetry_enabled
+    organization = (tele.get("organization") if decided else "") or settings.telemetry_organization
+    contact_email = (tele.get("contact_email") if decided else "") or settings.telemetry_contact_email
+
+    return {
+        "enabled": enabled,
+        "organization": (organization or "").strip(),
+        "contact_email": (contact_email or "").strip(),
+        "endpoint": settings.telemetry_endpoint,
+    }
+
+
+def build_heartbeat_payload(
+    db: Database[dict],
+    settings: Settings,
+    *,
+    organization: str | None = None,
+    contact_email: str | None = None,
+) -> dict[str, Any]:
     """Assemble the exact, fixed-shape JSON that the heartbeat will POST.
 
     Pure assembly — no network. Kept separate so it can be unit-tested and so
-    the local audit log and the wire payload are guaranteed identical.
+    the local audit log and the wire payload are guaranteed identical. The
+    identity args override the env defaults when provided (the caller resolves
+    them via resolve_runtime_config); None falls back to settings.
     """
+    if organization is None:
+        organization = settings.telemetry_organization
+    if contact_email is None:
+        contact_email = settings.telemetry_contact_email
     now = datetime.now(timezone.utc)
     active_since = now - timedelta(days=ACTIVE_WINDOW_DAYS)
 
@@ -124,14 +160,14 @@ def build_heartbeat_payload(db: Database[dict], settings: Settings) -> dict[str,
         },
     }
 
-    # Voluntary identity tier — added ONLY when the admin self-declared an
-    # organization. When blank, the key is omitted entirely so the payload is
-    # honestly anonymous (not an empty-string "identity"). contact_email rides
-    # along only if an org was also given.
-    organization = settings.telemetry_organization.strip()
+    # Voluntary identity tier — added ONLY when an organization is set. When
+    # blank, the key is omitted entirely so the payload is honestly anonymous
+    # (not an empty-string "identity"). contact_email rides along only if an org
+    # was also given.
+    organization = organization.strip()
     if organization:
         identity: dict[str, str] = {"organization": organization}
-        contact_email = settings.telemetry_contact_email.strip()
+        contact_email = contact_email.strip()
         if contact_email:
             identity["contact_email"] = contact_email
         payload["identity"] = identity
@@ -146,19 +182,25 @@ def send_heartbeat(db: Database[dict], settings: Settings) -> dict[str, Any]:
     return value / logs). Never raises on a delivery failure — telemetry is
     best-effort and must never disrupt the deployment it reports on.
     """
-    if not settings.telemetry_enabled:
+    resolved = resolve_runtime_config(db, settings)
+    if not resolved["enabled"]:
         return {"status": "disabled"}
 
-    if not settings.telemetry_endpoint:
-        # Opt-in flag flipped but no destination configured: do nothing rather
-        # than guess a domain. This is the safety interlock from config.py.
+    if not resolved["endpoint"]:
+        # Enabled but no destination (endpoint blanked to hard-disable sending):
+        # do nothing rather than guess a domain.
         logger.warning(
-            "telemetry_enabled is set but telemetry_endpoint is empty — "
-            "no heartbeat sent. Set telemetry_endpoint to opt in fully."
+            "telemetry is enabled but telemetry_endpoint is empty — no heartbeat "
+            "sent. Set telemetry_endpoint to opt in fully."
         )
         return {"status": "no_endpoint"}
 
-    payload = build_heartbeat_payload(db, settings)
+    payload = build_heartbeat_payload(
+        db,
+        settings,
+        organization=resolved["organization"],
+        contact_email=resolved["contact_email"],
+    )
 
     if settings.telemetry_log_payload:
         # The audit guarantee: an admin can grep the worker log and see the
@@ -167,7 +209,7 @@ def send_heartbeat(db: Database[dict], settings: Settings) -> dict[str, Any]:
 
     try:
         with httpx.Client(timeout=_POST_TIMEOUT_SECONDS) as client:
-            resp = client.post(settings.telemetry_endpoint, json=payload)
+            resp = client.post(resolved["endpoint"], json=payload)
             resp.raise_for_status()
     except httpx.HTTPError as exc:
         logger.info("Telemetry heartbeat delivery failed: %s", exc)

--- a/backend/app/tasks/telemetry_tasks.py
+++ b/backend/app/tasks/telemetry_tasks.py
@@ -26,12 +26,12 @@ logger = logging.getLogger(__name__)
     default_retry_delay=300,
 )
 def send_heartbeat(self) -> dict:
-    """Send one anonymous deployment heartbeat (opt-in; no-op when disabled)."""
+    """Send one anonymous deployment heartbeat (opt-in; no-op when disabled).
+
+    The task is always scheduled; send_heartbeat resolves the effective decision
+    from SystemConfig (DB) + env each run, so toggling the in-app opt-in takes
+    effect on the next daily run without a worker restart.
+    """
     from app.services.telemetry_service import send_heartbeat as _send
 
-    settings = Settings()
-    if not settings.telemetry_enabled:
-        return {"status": "disabled"}
-
-    db = get_sync_db()
-    return _send(db, settings)
+    return _send(get_sync_db(), Settings())

--- a/backend/tests/test_telemetry.py
+++ b/backend/tests/test_telemetry.py
@@ -41,7 +41,7 @@ class _FakeColl:
     def count_documents(self, _q):
         return self._count
 
-    def find_one(self, _q):
+    def find_one(self, _q=None):
         return self._state
 
     def update_one(self, *_a, **_k):
@@ -136,6 +136,52 @@ def test_payload_email_without_org_stays_anonymous():
     db = _FakeDB(_counts(user=1))
     s = Settings(telemetry_enabled=True, telemetry_contact_email="ra@uidaho.edu")
     assert "identity" not in tx.build_heartbeat_payload(db, s)
+
+
+# ---------------------------------------------------------------------------
+# Runtime resolution — DB decision vs. env default precedence
+# ---------------------------------------------------------------------------
+
+
+class _ResolveDB:
+    """Serves a configurable system_config doc; anything else is a stub."""
+
+    def __init__(self, sysdoc):
+        self._sysdoc = sysdoc
+
+    def __getitem__(self, name):
+        if name == "system_config":
+            return _FakeColl(0, self._sysdoc)
+        return _FakeColl(0, {"instance_id": "x"})
+
+
+def test_resolve_env_default_when_no_db_decision():
+    db = _ResolveDB({})  # no telemetry_config in the doc
+    r = tx.resolve_runtime_config(
+        db, Settings(telemetry_enabled=True, telemetry_organization="EnvOrg")
+    )
+    assert r["enabled"] is True
+    assert r["organization"] == "EnvOrg"
+
+
+def test_resolve_db_enable_overrides_env_off():
+    db = _ResolveDB({"telemetry_config": {"decided": True, "enabled": True, "organization": "DBOrg"}})
+    r = tx.resolve_runtime_config(db, Settings(telemetry_enabled=False))
+    assert r["enabled"] is True
+    assert r["organization"] == "DBOrg"
+
+
+def test_resolve_db_disable_overrides_env_on():
+    db = _ResolveDB({"telemetry_config": {"decided": True, "enabled": False}})
+    r = tx.resolve_runtime_config(db, Settings(telemetry_enabled=True))
+    assert r["enabled"] is False
+
+
+def test_resolve_undecided_db_ignores_db_identity():
+    # decided=False means the env governs even if stale identity sits in the doc.
+    db = _ResolveDB({"telemetry_config": {"decided": False, "organization": "StaleOrg"}})
+    r = tx.resolve_runtime_config(db, Settings(telemetry_enabled=True, telemetry_organization="EnvOrg"))
+    assert r["organization"] == "EnvOrg"
 
 
 # ---------------------------------------------------------------------------
@@ -303,3 +349,50 @@ async def test_analytics_aggregates_active_named_and_anonymous():
     assert [d["organization"] for d in out["named_deployments"]] == ["U of Idaho", "Stale U"]
     assert out["named_deployments"][0]["active"] is True
     assert out["named_deployments"][1]["active"] is False
+
+
+# ---------------------------------------------------------------------------
+# Admin opt-in banner status (show_banner / effective_enabled precedence)
+# ---------------------------------------------------------------------------
+
+
+def _cfg(tele):
+    """Stand-in for a SystemConfig exposing get_telemetry_config()."""
+    return SimpleNamespace(get_telemetry_config=lambda: tele)
+
+
+def test_banner_shows_for_fresh_unprompted_install():
+    from app.routers.admin import _telemetry_status
+
+    s = _telemetry_status(_cfg({"decided": False, "enabled": False, "organization": ""}), Settings())
+    assert s["show_banner"] is True
+    assert s["effective_enabled"] is False
+
+
+def test_banner_hidden_when_installer_already_prompted():
+    from app.routers.admin import _telemetry_status
+
+    s = _telemetry_status(
+        _cfg({"decided": False, "enabled": False, "organization": ""}),
+        Settings(telemetry_prompted=True),
+    )
+    assert s["show_banner"] is False
+
+
+def test_banner_hidden_when_env_already_enabled():
+    from app.routers.admin import _telemetry_status
+
+    s = _telemetry_status(_cfg({"decided": False}), Settings(telemetry_enabled=True))
+    assert s["show_banner"] is False
+    assert s["effective_enabled"] is True
+
+
+def test_db_decision_disables_overrides_env_and_hides_banner():
+    from app.routers.admin import _telemetry_status
+
+    s = _telemetry_status(
+        _cfg({"decided": True, "enabled": False, "organization": ""}),
+        Settings(telemetry_enabled=True),
+    )
+    assert s["effective_enabled"] is False
+    assert s["show_banner"] is False

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -6,8 +6,15 @@ the full disclosure: exactly what is sent, what is never sent, and how to turn i
 on, off, or point it at your own collector.
 
 **It is off by default.** A fresh install sends nothing. Telemetry only happens
-after an administrator explicitly enables it (the `./setup.sh` installer asks,
-defaulting to *no*).
+after an administrator explicitly enables it. There are three ways they're asked:
+
+- `./setup.sh` asks on **first install** (defaulting to *no*).
+- `./setup.sh` asks again on **redeploy/upgrade** if the deployment was never
+  asked — so existing installs predating telemetry get the choice. It asks at
+  most once, and never blocks non-interactive auto-update/cron runs.
+- An **in-app banner** in the Admin panel offers a one-click opt-in to any global
+  admin whose deployment hasn't already decided (and wasn't already asked by the
+  installer).
 
 ## What is sent
 
@@ -71,22 +78,34 @@ The installer offers this as a separate, explicit choice (also defaulting to
 
 ## Enabling, disabling, and self-hosting
 
-All configuration is via environment variables (`backend/.env`):
+Telemetry can be controlled two ways, and a clear precedence keeps them from
+fighting:
+
+- **In-app (recommended):** the Admin opt-in banner. A global admin's choice is
+  stored in the database and takes effect on the next daily heartbeat — no
+  restart, no file editing. **Once an in-app choice is made, it is authoritative**
+  and overrides the env default below (so you can also use it to turn telemetry
+  back *off*).
+- **Environment variables (`backend/.env`):** the initial default, used until an
+  in-app decision exists. Best for `setup.sh`-driven and scripted deployments.
 
 | Variable | Default | Purpose |
 | --- | --- | --- |
-| `TELEMETRY_ENABLED` | `false` | Master opt-in switch for the heartbeat. |
-| `TELEMETRY_ENDPOINT` | _(empty)_ | Where heartbeats are sent. Inert unless set. |
+| `TELEMETRY_ENABLED` | `false` | Initial opt-in state (until an in-app decision is made). |
+| `TELEMETRY_ENDPOINT` | _maintainers' collector_ | Where heartbeats are sent. Blank it to hard-disable sending. |
 | `TELEMETRY_LOG_PAYLOAD` | `true` | Log each payload locally before sending. |
+| `TELEMETRY_PROMPTED` | `false` | Set by `setup.sh` once it has asked, so the in-app banner won't re-ask. |
 | `TELEMETRY_ORGANIZATION` | _(empty)_ | Optional self-declared identity. |
 | `TELEMETRY_CONTACT_EMAIL` | _(empty)_ | Optional contact, sent only with an org. |
 
-The heartbeat is **inert unless both `TELEMETRY_ENABLED=true` and
-`TELEMETRY_ENDPOINT` are set**, so flipping the switch alone never sends data to
-a guessed destination.
+The single master gate is **enablement** (off by default) — nothing is sent
+until an admin opts in. `TELEMETRY_ENDPOINT` defaults to the maintainers'
+collector so an admin who enables via the in-app banner (e.g. on an older
+install whose `.env` predates telemetry) has somewhere to send to.
 
-- **To disable:** set `TELEMETRY_ENABLED=false` (or leave it). Takes effect on
-  the next worker restart.
+- **To disable:** click *No thanks* in the banner, or — on an env-driven
+  deployment that never used the banner — set `TELEMETRY_ENABLED=false` and
+  restart. To stop *all* sending regardless of state, blank `TELEMETRY_ENDPOINT`.
 - **To send to your own collector instead:** point `TELEMETRY_ENDPOINT` at any
   URL that accepts the JSON above — including your own Vandalizer instance acting
   as a collector (see below).

--- a/frontend/src/api/admin.ts
+++ b/frontend/src/api/admin.ts
@@ -1,5 +1,25 @@
 import { apiFetch } from './client'
 
+// Telemetry opt-in (installation-wide; global admin)
+
+export interface TelemetryOptInStatus {
+  effective_enabled: boolean
+  decided: boolean
+  organization: string
+  show_banner: boolean
+}
+
+export function getTelemetryOptIn() {
+  return apiFetch<TelemetryOptInStatus>('/api/admin/telemetry/optin')
+}
+
+export function setTelemetryOptIn(body: { enabled: boolean; organization?: string; contact_email?: string }) {
+  return apiFetch<TelemetryOptInStatus>('/api/admin/telemetry/optin', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  })
+}
+
 // Fleet telemetry analytics (collector instance only)
 
 export interface NamedDeployment {

--- a/frontend/src/components/admin/TelemetryOptInBanner.tsx
+++ b/frontend/src/components/admin/TelemetryOptInBanner.tsx
@@ -1,0 +1,112 @@
+import { useCallback, useEffect, useState } from 'react'
+import { BarChart3, X } from 'lucide-react'
+
+import { getTelemetryOptIn, setTelemetryOptIn } from '../../api/admin'
+
+/**
+ * One-time opt-in prompt for anonymous usage telemetry, shown to global admins
+ * on the Admin page when the deployment has never made a telemetry decision and
+ * the installer never asked. Dismissing or choosing either option records the
+ * decision server-side, so it does not reappear.
+ */
+export function TelemetryOptInBanner() {
+  const [show, setShow] = useState(false)
+  const [org, setOrg] = useState('')
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    getTelemetryOptIn()
+      .then(s => setShow(s.show_banner))
+      .catch(() => {})
+  }, [])
+
+  const decide = useCallback(async (enabled: boolean) => {
+    setBusy(true)
+    setError(null)
+    try {
+      await setTelemetryOptIn({ enabled, organization: enabled ? org.trim() : undefined })
+      setShow(false)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Could not save your choice')
+      setBusy(false)
+    }
+  }, [org])
+
+  if (!show) return null
+
+  return (
+    <div style={{
+      border: '1px solid #c7d2fe', backgroundColor: '#eef2ff', borderRadius: 10,
+      padding: '14px 16px', marginBottom: 16,
+    }}>
+      <div style={{ display: 'flex', alignItems: 'flex-start', gap: 12 }}>
+        <BarChart3 size={18} color="#4f46e5" style={{ marginTop: 2, flexShrink: 0 }} />
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div style={{ fontSize: 14, fontWeight: 600, color: '#312e81' }}>
+            Help improve Vandalizer with anonymous usage stats?
+          </div>
+          <div style={{ fontSize: 13, color: '#4338ca', marginTop: 4, lineHeight: 1.5 }}>
+            A once-a-day heartbeat sends only an anonymous ID, the version, and coarse
+            usage buckets (e.g. "11–50 users"). Never documents, names, emails, or keys.{' '}
+            <a href="https://github.com/ui-insight/vandalizer/blob/main/docs/telemetry.md"
+               target="_blank" rel="noreferrer"
+               style={{ color: '#4f46e5', fontWeight: 500 }}>
+              What's collected
+            </a>
+          </div>
+
+          <div style={{ marginTop: 10, display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
+            <input
+              type="text"
+              value={org}
+              onChange={e => setOrg(e.target.value)}
+              placeholder="Optional: your organization (blank = anonymous)"
+              disabled={busy}
+              style={{
+                flex: '1 1 260px', minWidth: 200,
+                padding: '6px 10px', fontSize: 13,
+                border: '1px solid #c7d2fe', borderRadius: 6, backgroundColor: '#fff',
+              }}
+            />
+            <button
+              onClick={() => void decide(true)}
+              disabled={busy}
+              style={{
+                padding: '7px 14px', fontSize: 13, fontWeight: 600,
+                backgroundColor: '#4f46e5', color: '#fff',
+                border: 'none', borderRadius: 6, cursor: busy ? 'default' : 'pointer',
+              }}
+            >
+              Enable telemetry
+            </button>
+            <button
+              onClick={() => void decide(false)}
+              disabled={busy}
+              style={{
+                padding: '7px 14px', fontSize: 13, fontWeight: 500,
+                backgroundColor: 'transparent', color: '#4338ca',
+                border: '1px solid #c7d2fe', borderRadius: 6, cursor: busy ? 'default' : 'pointer',
+              }}
+            >
+              No thanks
+            </button>
+          </div>
+          {error && <div style={{ fontSize: 12, color: '#dc2626', marginTop: 8 }}>{error}</div>}
+        </div>
+
+        <button
+          onClick={() => void decide(false)}
+          disabled={busy}
+          title="Dismiss (declines telemetry)"
+          style={{
+            background: 'none', border: 'none', cursor: busy ? 'default' : 'pointer',
+            color: '#6366f1', padding: 2, flexShrink: 0,
+          }}
+        >
+          <X size={16} />
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/Admin.tsx
+++ b/frontend/src/pages/Admin.tsx
@@ -74,6 +74,7 @@ import { ApiKeysTab } from '../components/admin/ApiKeysTab'
 import { ComplianceTab } from '../components/admin/ComplianceTab'
 import { KnowledgeBasesTab } from '../components/admin/KnowledgeBasesTab'
 import { TelemetryTab } from '../components/admin/TelemetryTab'
+import { TelemetryOptInBanner } from '../components/admin/TelemetryOptInBanner'
 import { getFeatureFlags } from '../api/config'
 
 function applyThemeToDOM(theme: ThemeConfig) {
@@ -7235,6 +7236,7 @@ export default function Admin() {
         <div style={{ flex: 1, padding: '20px 32px', minWidth: 0 }}>
           <UpdateBanner />
           {isGlobalAdmin && <CatalogUpdateBanner onView={() => setActiveTab('catalog')} />}
+          {isGlobalAdmin && <TelemetryOptInBanner />}
           {activeTab === 'usage' && <UsageTab />}
           {activeTab === 'users' && <UsersTab />}
           {activeTab === 'teams' && <TeamsTab />}

--- a/setup.sh
+++ b/setup.sh
@@ -845,35 +845,8 @@ bootstrap() {
   local ORG_NAME=""
   prompt "Institution / organization name" "" ORG_NAME
 
-  # --- Anonymous usage telemetry (opt-in) ---
-  echo ""
-  echo -e "  ${SYM_NEURAL}  ${BOLD}Usage telemetry${RESET} ${DIM}(optional)${RESET}"
-  echo -e "  ${DIM}     A once-a-day heartbeat helps the Vandalizer maintainers see how${RESET}"
-  echo -e "  ${DIM}     many deployments exist and roughly how heavily they're used.${RESET}"
-  echo -e "  ${DIM}     Sends ONLY: an anonymous random ID, the version, and coarse usage${RESET}"
-  echo -e "  ${DIM}     buckets (\"11-50 users\"). NEVER documents, names, emails, or keys.${RESET}"
-  echo -e "  ${DIM}     Off by default; change TELEMETRY_* in backend/.env anytime.${RESET}"
-  echo ""
-  if confirm "Send anonymous usage telemetry?" "n"; then
-    set_env "TELEMETRY_ENABLED" "true"
-    # Provisional collector on the U of I instance; override in .env to self-host.
-    set_env "TELEMETRY_ENDPOINT" "https://vandalizer.nkn.uidaho.edu/api/telemetry/heartbeat"
-    echo -e "  ${SYM_CHECK}  Anonymous telemetry ${BOLD}enabled${RESET}"
-
-    # Voluntary identity tier — only offered when they already named the
-    # institution above, and only attached if they explicitly agree.
-    if [[ -n "$ORG_NAME" ]]; then
-      if confirm "Identify this deployment as \"${ORG_NAME}\" (otherwise stays anonymous)?" "n"; then
-        set_env "TELEMETRY_ORGANIZATION" "$ORG_NAME"
-        echo -e "  ${SYM_CHECK}  Telemetry will identify this deployment as ${BOLD}${ORG_NAME}${RESET}"
-      else
-        echo -e "  ${SYM_CHECK}  Telemetry will stay ${BOLD}anonymous${RESET}"
-      fi
-    fi
-  else
-    set_env "TELEMETRY_ENABLED" "false"
-    echo -e "  ${SYM_CHECK}  Telemetry ${BOLD}disabled${RESET}"
-  fi
+  # --- Anonymous usage telemetry (opt-in) — reuse the just-entered org name ---
+  configure_telemetry "$ORG_NAME"
 
   echo ""
   echo -e "  ${SYM_NEURAL}  ${BOLD}Verified catalog${RESET}"
@@ -1823,6 +1796,54 @@ asyncio.run(main())
   fi
 }
 
+# Anonymous telemetry opt-in. Asked at most once (TELEMETRY_PROMPTED in .env
+# guards re-asking), never blocks non-interactive runs (auto-update/cron), and
+# is shared by first-time bootstrap and every redeploy/upgrade. $1 = a suggested
+# org name (first install passes the just-entered ORG_NAME; redeploy passes "").
+configure_telemetry() {
+  [[ -t 0 ]] || return 0                                  # non-interactive — skip
+  [[ -f "$ENV_FILE" ]] || return 0
+  grep -q "^TELEMETRY_PROMPTED=true" "$ENV_FILE" 2>/dev/null && return 0  # already asked
+
+  local suggested_org="${1:-}"
+
+  echo ""
+  echo -e "  ${SYM_NEURAL}  ${BOLD}Usage telemetry${RESET} ${DIM}(optional)${RESET}"
+  echo -e "  ${DIM}     A once-a-day heartbeat helps the Vandalizer maintainers see how${RESET}"
+  echo -e "  ${DIM}     many deployments exist and roughly how heavily they're used.${RESET}"
+  echo -e "  ${DIM}     Sends ONLY: an anonymous random ID, the version, and coarse usage${RESET}"
+  echo -e "  ${DIM}     buckets (\"11-50 users\"). NEVER documents, names, emails, or keys.${RESET}"
+  echo -e "  ${DIM}     Change it anytime in Admin, or via TELEMETRY_* in backend/.env.${RESET}"
+  echo ""
+
+  # Mark as asked regardless of the answer, so neither setup.sh nor the in-app
+  # banner prompts again.
+  set_env "TELEMETRY_PROMPTED" "true"
+
+  if confirm "Send anonymous usage telemetry?" "n"; then
+    set_env "TELEMETRY_ENABLED" "true"
+    echo -e "  ${SYM_CHECK}  Anonymous telemetry ${BOLD}enabled${RESET}"
+
+    # Voluntary identity tier. Reuse a known org name if we have one; otherwise
+    # offer to enter one. Empty keeps the heartbeat anonymous.
+    local org="$suggested_org"
+    if [[ -n "$org" ]]; then
+      confirm "Identify this deployment as \"${org}\" (otherwise stays anonymous)?" "n" || org=""
+    else
+      prompt "Organization name to identify this deployment (blank = anonymous)" "" org
+    fi
+    if [[ -n "${org// /}" ]]; then
+      set_env "TELEMETRY_ORGANIZATION" "$org"
+      echo -e "  ${SYM_CHECK}  Telemetry will identify this deployment as ${BOLD}${org}${RESET}"
+    else
+      echo -e "  ${SYM_CHECK}  Telemetry will stay ${BOLD}anonymous${RESET}"
+    fi
+  else
+    set_env "TELEMETRY_ENABLED" "false"
+    echo -e "  ${SYM_CHECK}  Telemetry ${BOLD}disabled${RESET}"
+  fi
+}
+
 # Shared rebuild+restart logic used by upgrade and redeploy
 do_redeploy() {
   echo ""
@@ -1862,6 +1883,10 @@ do_redeploy() {
 
   # One-time: capture the institution name if this deployment never set one.
   prompt_org_name_if_unset
+
+  # One-time: ask about anonymous telemetry if this deployment hasn't been asked
+  # (covers existing installs upgrading via redeploy/upgrade). No-op on cron.
+  configure_telemetry ""
 
   # Clean up dangling images and build cache to reclaim disk space
   echo ""


### PR DESCRIPTION
## Summary

Follow-up to #531 (merged). That PR's `setup.sh` opt-in only reached **first-time installs** — but most operators update via `--redeploy`/`--upgrade`, which never hit the bootstrap prompt, so the existing install base was never asked. This closes that gap from both ends.

### `setup.sh` — ask on redeploy/upgrade too
- Extracted the opt-in into a reusable `configure_telemetry()` and call it from the shared `do_redeploy()` (covers redeploy + upgrade + scan), mirroring the existing `prompt_org_name_if_unset` pattern: **tty-guarded** (never blocks auto-update/cron) and **idempotent** (asks at most once, guarded by `TELEMETRY_PROMPTED` in `.env`).

### In-app admin opt-in banner
- Telemetry enablement is now **DB-backed** (`SystemConfig.telemetry_config`) so a global admin can opt in/out at runtime — no env edit, no restart. The env var is the initial default; once an in-app decision is made it is **authoritative** (`resolve_runtime_config` precedence). The daily heartbeat is now always scheduled and self-gates on the resolved decision.
- New `GET`/`POST /api/admin/telemetry/optin` (global-admin only).
- `TelemetryOptInBanner` shows on the Admin page only when telemetry is **off, undecided, and the installer never asked** — so it never double-asks someone `setup.sh` already prompted.
- `TELEMETRY_ENDPOINT` now **defaults to the collector** so banner-enable works on older installs whose `.env` predates telemetry; blank it to hard-disable sending.

### Precedence (how the two controls coexist)
- No in-app decision → env default (`TELEMETRY_ENABLED`) governs.
- In-app decision made → DB value wins (also the way to turn it back **off**).
- Banner suppressed once either the installer asked (`TELEMETRY_PROMPTED`) or an in-app decision exists.

### Tests & docs
- `test_telemetry.py` extended for resolution precedence + banner-status logic (**38 pass**).
- `docs/telemetry.md` updated for the DB-backed toggle, the banner, the upgrade-path prompt, and the new endpoint default.

## Reviewer notes
- **Provisional endpoint** `https://vandalizer.nkn.uidaho.edu/api/telemetry/heartbeat` is now the config default (not just written by `setup.sh`) — confirm the host before merge.
- Heartbeat beat entry is now always registered (self-gates), a deliberate change from #531's env-gated registration, so DB toggling works without a worker restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
