### PR TITLE
fix(tests): mock DemoApplication lookup in locked-demo /auth/me test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- **`test_me_demo_locked_user_blocked` failed on a clean `main`.** The `GET /api/auth/me` unit test for locked demo users had not been updated when `get_current_user` began looking up the `DemoApplication` to surface the end-of-trial feedback token: it mocked neither the lookup (so the Beanie query-field access raised `AttributeError: user_id` before the 403 was returned) nor the response shape (it still asserted the old string `"DEMO_EXPIRED"` detail rather than the structured `{"code": "DEMO_EXPIRED", "feedback_token": ...}` payload). Completed the test's mocking and assertion; no production code change. Fixes #533.
+
 ## [v4.7.0] - 2026-06-22
 
 ### Added

--- a/backend/tests/test_auth_routes.py
+++ b/backend/tests/test_auth_routes.py
@@ -121,15 +121,21 @@ class TestAuthMe:
         token = create_access_token("testuser", _TEST_SETTINGS)
 
         with patch("app.dependencies.decode_token", return_value={"sub": "testuser", "type": "access"}), \
-             patch("app.dependencies.User") as MockUser:
+             patch("app.dependencies.User") as MockUser, \
+             patch("app.models.demo.DemoApplication") as MockDemoApp:
             MockUser.find_one = AsyncMock(return_value=user)
+            # get_current_user looks up the demo application to surface the
+            # end-of-trial feedback token; the lookup must be mocked or the
+            # Beanie query field access raises before the 403 is returned.
+            MockDemoApp.find_one = AsyncMock(return_value=None)
             resp = await client.get(
                 "/api/auth/me",
                 cookies={"access_token": token},
             )
 
         assert resp.status_code == 403
-        assert resp.json()["detail"] == "DEMO_EXPIRED"
+        # detail is a structured payload: {"code": ..., "feedback_token": ...}
+        assert resp.json()["detail"]["code"] == "DEMO_EXPIRED"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`tests/test_auth_routes.py::TestAuthMe::test_me_demo_locked_user_blocked` fails on a clean checkout of `main` — it is the only failing test in `make backend-ci`, and because Backend Tests is a required check it currently blocks every open PR.

The test had not been updated when `get_current_user` was extended (commit `d008debc`) to look up the `DemoApplication` for the end-of-trial feedback token. It mocked neither the new dependency nor the new response shape, so it broke in two ways:

1. It patches `User.find_one` but not the `DemoApplication` lookup, so evaluating the Beanie query expression `DemoApplication.user_id == user.user_id` raised `AttributeError: user_id` before the 403 was ever returned.
2. It still asserted `resp.json()["detail"] == "DEMO_EXPIRED"`, but the handler now returns a structured `detail` of `{"code": "DEMO_EXPIRED", "feedback_token": ...}`.

This is a **test-only** change — production behavior is unaffected (the same query pattern works in `app/routers/auth.py` with Beanie initialized).

## Changes

- `tests/test_auth_routes.py`: mock `DemoApplication.find_one` in the locked-demo `/auth/me` test and assert against `detail["code"]`.
- `CHANGELOG.md`: note under Unreleased → Fixed.

## Test Plan

- [x] `uv run pytest tests/test_auth_routes.py` passes (33 passed, 3 skipped) on py3.11 and py3.12
- [x] The previously-failing test now passes; no production code changed
- [x] Updated `CHANGELOG.md`

## Related Issues

Closes #533