### PR TITLE
fix(kb): don't drop table rows when the splitter breaks before a table

### DIFF
--- a/backend/app/services/document_manager.py
+++ b/backend/app/services/document_manager.py
@@ -200,7 +200,11 @@ def _split_text_with_offsets(
         if end >= text_length:
             break
 
-        next_start = max(start + step, end - chunk_overlap)
+        # Never jump past ``end``: when the break above pulled ``end`` back
+        # (e.g. to a table start), ``start + step`` can overshoot it and the
+        # skipped region would never be emitted into any chunk — table rows
+        # were silently dropped from ingestion.
+        next_start = min(max(start + step, end - chunk_overlap), end)
         if next_start <= start:
             next_start = end
         # Don't let the overlap restart mid-row: snap to the start of the row

--- a/backend/tests/test_document_pipeline.py
+++ b/backend/tests/test_document_pipeline.py
@@ -312,6 +312,22 @@ class TestTableAwareChunking:
         # First chunk should end before the table rather than slicing into it.
         assert "| Item" not in chunks[0][0]
 
+    def test_break_before_table_never_drops_rows(self):
+        from app.services.document_manager import _split_text_with_offsets
+
+        # Regression: when the break-before-table path pulled ``end`` back to
+        # the table start, the next window still jumped a full step past it,
+        # so the header and first data rows were emitted into no chunk at all.
+        # Sweep the table start across the window to cover every break path.
+        for pad in range(400, 1000, 7):
+            prose = ("Narrative context sentence about grant awards. " * 25)[:pad]
+            table = _docx_style_table(30)
+            text = f"{prose.strip()}\n{table}"
+            joined = "\n".join(c for c, _ in _split_text_with_offsets(text, 1000, 200))
+            for i in range(30):
+                row = f"| Item {i} | {100 + i} | {200 + i} |"
+                assert row in joined, f"pad={pad}: row dropped from ingestion: {row!r}"
+
     def test_non_table_text_is_undedecorated_and_offset_exact(self):
         from app.services.document_manager import _split_text_with_offsets
 


### PR DESCRIPTION
## Summary

Support ticket ("KBs now TOO constrained") triage found a regression in the table-aware chunking from #549: when the splitter pulls a chunk's `end` back to a table start (or to a row boundary inside a long table), the next window start — `max(start + step, end - chunk_overlap)` — can overshoot `end` by up to `step - chunk_size/2` chars. Everything in that gap (the table header and first data rows) is emitted into **no chunk at all**, so those facts never reach ChromaDB and cannot be retrieved. The out-of-scope grounding prompt then honestly reports them as not in the KB.

Any table starting between 50% and 80% of a chunk window loses its first rows. Confirmed reproducible; the pre-#549 splitter did not lose these rows.

## Fix

Clamp the next window start so it never skips past the previous chunk's end:

```python
next_start = min(max(start + step, end - chunk_overlap), end)
```

When `end` wasn't pulled back the clamp is a no-op, so normal prose chunking is byte-identical. When it was, the next chunk starts exactly at the break instead of past it — no gap, and the existing header-decoration still gives continuation chunks their column context.

## Test

`test_break_before_table_never_drops_rows` sweeps a table's start position across the whole chunk window (86 positions) and asserts every data row lands in some chunk. Fails on unfixed HEAD, passes with the fix. `test_document_pipeline.py` (29), `test_kb_retrieval.py` + `test_knowledge_base_tasks.py` (48), and ruff are green.

## Deployment note — re-ingest required

The fix only changes future ingestion. **Every KB ingested on a post-#549 build (since Jul 8) is missing table rows in ChromaDB** until re-ingested via `POST /knowledge/{uuid}/reingest`. After deploy: re-ingest the reporter's KB and enumerate KBs created since Jul 8 on dev instances.

🤖 Generated with [Claude Code](https://claude.com/claude-code)