### PR TITLE
fix(validation): score workflow stability on check-consistency, not text similarity

### DIFF
--- a/backend/app/services/workflow_service.py
+++ b/backend/app/services/workflow_service.py
@@ -2978,15 +2978,34 @@ async def _build_result(
 
     quality_score = min(100.0, max(0.0, quality_score_raw))
 
-    # -- Stability score (how consistent are the actual outputs?) --
-    # This measures output-to-output similarity, not evaluator consistency.
-    stability_score_val = None
-    if stability_data and stability_data.get("stability_score") is not None:
-        stability_score_val = stability_data["stability_score"] * 100  # convert 0-1 → 0-100
-
-    # Evaluator consistency is kept as a diagnostic signal
+    # Evaluator consistency: how consistently each check's verdict held across
+    # runs (1.0 = the check reached the same PASS/FAIL every run). Computed for
+    # every run and used below as the substance-level stability signal.
     consistencies = [c.get("consistency", 1.0) for c in checks if c["status"] != "SKIP"]
     avg_evaluator_consistency = sum(consistencies) / len(consistencies) if consistencies else 0.0
+
+    # -- Stability score (how consistent is the SUBSTANCE across runs?) --
+    # Prefer substance-level stability over raw output text-similarity. A
+    # synthesizing workflow legitimately rewords its prose run-to-run, so text
+    # similarity runs low (~45-60%) even when every fact and every check verdict
+    # is identical — scoring on it systematically under-grades correct
+    # workflows (a perfect-quality prose deliverable is capped at ~C). Preference
+    # order: structured field-level stability (value-level, most precise) →
+    # evaluator/check-verdict consistency → text similarity (last resort). The
+    # raw text similarity is still reported in stability_detail either way.
+    stability_score_val = None
+    stability_basis = None
+    if num_runs > 1:
+        field_stability = (stability_data or {}).get("structured_field_stability")
+        if isinstance(field_stability, (int, float)):
+            stability_score_val = field_stability * 100
+            stability_basis = "structured_field_stability"
+        elif consistencies:
+            stability_score_val = avg_evaluator_consistency * 100
+            stability_basis = "evaluator_consistency"
+        elif stability_data and stability_data.get("stability_score") is not None:
+            stability_score_val = stability_data["stability_score"] * 100
+            stability_basis = "text_similarity"
 
     # -- Combined score --
     if stability_score_val is not None:
@@ -3046,6 +3065,7 @@ async def _build_result(
         "score": round(score, 1),
         "quality_score": round(quality_score, 1),
         "stability_score": round(stability_score_val, 1) if stability_score_val is not None else None,
+        "stability_basis": stability_basis,
         "stability_detail": stability_data,
         "check_pass_rate": round(check_pass_rate, 4),
         "weighted_pass_rate": round(weighted_pass_rate, 4),

--- a/backend/tests/test_workflow_service.py
+++ b/backend/tests/test_workflow_service.py
@@ -552,6 +552,88 @@ class TestBuildResult:
         assert result["grade"] == "F"
         assert result["check_pass_rate"] == 0.0
 
+    @patch("app.services.quality_service.persist_validation_run", new_callable=AsyncMock)
+    async def test_multirun_stability_uses_check_consistency_not_text(self, mock_persist):
+        """A correct, check-consistent prose workflow whose wording varies
+        run-to-run scores on verdict consistency, not raw text-similarity."""
+        from app.services.workflow_service import _build_result
+
+        checks = [
+            {"check_id": "c1", "name": "Check 1", "status": "PASS", "detail": "ok", "consistency": 1.0},
+            {"check_id": "c2", "name": "Check 2", "status": "PASS", "detail": "ok", "consistency": 1.0},
+        ]
+        # Facts identical but reworded each run -> low text similarity, but the
+        # checks pass consistently every run.
+        stability_data = {
+            "stability_score": 0.45,
+            "text_similarity": 0.45,
+            "structured_field_stability": None,
+        }
+        result = await _build_result(
+            checks, "wf-id", {"name": "Test", "user_id": "u1"},
+            num_runs=3, stability_data=stability_data,
+        )
+        assert result["stability_basis"] == "evaluator_consistency"
+        assert result["stability_score"] == 100.0
+        # quality 100 * 0.6 + stability 100 * 0.4 = 100 (was ~78/C under text-sim).
+        assert result["score"] == 100.0
+        assert result["grade"] == "A"
+        # raw text similarity is still reported for diagnostics.
+        assert result["stability_detail"]["text_similarity"] == 0.45
+
+    @patch("app.services.quality_service.persist_validation_run", new_callable=AsyncMock)
+    async def test_multirun_prefers_structured_field_stability(self, mock_persist):
+        from app.services.workflow_service import _build_result
+
+        checks = [
+            {"check_id": "c1", "name": "Check 1", "status": "PASS", "detail": "ok", "consistency": 1.0},
+        ]
+        stability_data = {
+            "stability_score": 0.40,
+            "text_similarity": 0.40,
+            "structured_field_stability": 0.90,
+        }
+        result = await _build_result(
+            checks, "wf-id", {"name": "Test", "user_id": "u1"},
+            num_runs=2, stability_data=stability_data,
+        )
+        assert result["stability_basis"] == "structured_field_stability"
+        assert result["stability_score"] == 90.0
+        assert result["score"] == pytest.approx(96.0)  # 100*0.6 + 90*0.4
+        assert result["grade"] == "A"
+
+    @patch("app.services.quality_service.persist_validation_run", new_callable=AsyncMock)
+    async def test_multirun_flaky_check_lowers_stability(self, mock_persist):
+        """A check that flips verdict across runs lowers consistency, which now
+        legitimately lowers the stability term."""
+        from app.services.workflow_service import _build_result
+
+        checks = [
+            {"check_id": "c1", "name": "Check 1", "status": "PASS", "detail": "ok", "consistency": 1.0},
+            {"check_id": "c2", "name": "Check 2", "status": "PASS", "detail": "ok", "consistency": 2 / 3},
+        ]
+        stability_data = {"stability_score": 0.5, "text_similarity": 0.5, "structured_field_stability": None}
+        result = await _build_result(
+            checks, "wf-id", {"name": "Test", "user_id": "u1"},
+            num_runs=3, stability_data=stability_data,
+        )
+        assert result["stability_basis"] == "evaluator_consistency"
+        assert result["stability_score"] == pytest.approx(83.3, abs=0.1)  # (1.0 + 0.667)/2
+        assert result["grade"] == "A"  # 100*0.6 + 83.3*0.4 = 93.3
+
+    @patch("app.services.quality_service.persist_validation_run", new_callable=AsyncMock)
+    async def test_single_run_unaffected(self, mock_persist):
+        """Single-run scoring is unchanged: quality only, no stability term."""
+        from app.services.workflow_service import _build_result
+
+        checks = [
+            {"check_id": "c1", "name": "Check 1", "status": "PASS", "detail": "ok", "consistency": 1.0},
+        ]
+        result = await _build_result(checks, "wf-id", {"name": "Test", "user_id": "u1"}, num_runs=1)
+        assert result["stability_basis"] is None
+        assert result["score"] == 100.0
+        assert result["grade"] == "A"
+
 
 # ---------------------------------------------------------------------------
 # _parse_json_array


### PR DESCRIPTION
## Problem

The workflow **Validate** combined score (2+ runs) is:

```
score = 0.6 * quality_score + 0.4 * stability_score     # _build_result
```

but `stability_score` was **raw output text-similarity across runs** (`stability_detail.text_similarity`; `structured_field_stability` is `null` for prose outputs, so the blend collapses to text-similarity).

A workflow that *synthesizes* a prose deliverable legitimately **rewords itself run-to-run**, so text-similarity sits at ~45–60% even when **every fact and every check verdict is identical**. Because that's 40% of the grade, a perfect-quality prose workflow is hard-capped:

| Stability (text-sim) | Max score at quality=100 | Best grade |
|---|---|---|
| 45% | 78 | C |
| 62% | 85 | B |
| 75% | 90 | A |

Surfaced while re-validating the catalog workflows — e.g. NOA Summary had **4/4 checks passing 3/3 (consistency 1.0)** and correct output, but 45% text-similarity → **78, graded C**. The metric was punishing paraphrase, not measuring correctness.

## Fix

`_build_result` now derives the stability term from **substance-level** signals instead of surface text:

1. `structured_field_stability` (value-level, most precise) when available, else
2. **evaluator / check-verdict consistency** (`avg_evaluator_consistency`) — "do the same checks reach the same PASS/FAIL across runs," which was already computed and kept *only as a diagnostic*, else
3. raw text-similarity as a last-resort fallback.

Raw text-similarity is still reported in `stability_detail`, and a new `stability_basis` field records which signal drove the score. **Single-run scoring is unchanged.**

With the fix, NOA Summary scores `100*0.6 + 100*0.4 = 100 → A`, the honest grade for output whose facts are perfect and whose checks are stable. A genuinely flaky workflow (checks flipping across runs) still loses stability points, because consistency drops.

## Tests

Adds multi-run cases to `TestBuildResult`: consistency-based scoring, field-stability preference, a flaky-check case that legitimately lowers stability, and a single-run-unchanged guard. Existing single-run tests are unaffected.

> Local note: couldn't run the suite in this environment (no local venv / uv; the prod image ships without pytest+tests), so both files were syntax-checked and every assertion hand-verified against the formula. CI will run `make backend-ci`.

## Follow-up (not in this PR)

The same `0.6*quality + 0.4*text-stability` pattern likely exists in the extraction and KB validation paths (`extraction_validation_service.py`, `kb_validation_service.py`). Worth a follow-up to apply the same substance-stability fix there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
