### PR TITLE
fix(crawler): make Allowed Domains path-aware so crawls can be scoped to a subdirectory

### DIFF
--- a/backend/app/schemas/knowledge.py
+++ b/backend/app/schemas/knowledge.py
@@ -47,7 +47,7 @@ class AddUrlsRequest(BaseModel):
     urls: list[str]
     crawl_enabled: bool = False
     max_crawl_pages: int = 5
-    allowed_domains: str = ""  # comma-separated
+    allowed_domains: str = ""  # comma-separated hosts, optionally with path prefixes (example.com/irb)
 
 
 class KBSourceResponse(BaseModel):

--- a/backend/app/services/knowledge_service.py
+++ b/backend/app/services/knowledge_service.py
@@ -933,18 +933,13 @@ async def _crawl_from_source(
     parent_fetched: WebFetchResult,
 ) -> int:
     """BFS crawl from parent URL, creating child sources. Returns count added."""
-    from urllib.parse import urlparse
+    from app.utils.crawl_scope import parse_crawl_scope, url_in_crawl_scope
 
     max_pages = max(1, min(max_pages, 50))
 
-    # Build allowed domain set
-    parent_domain = urlparse(parent.url).netloc.lower()
-    domain_set: set[str] = {parent_domain}
-    if allowed_domains:
-        for d in allowed_domains.split(","):
-            d = d.strip().lower()
-            if d:
-                domain_set.add(d)
+    # Explicit allowed-domains entries (which may carry path prefixes) define
+    # the scope; blank falls back to the parent URL's whole domain.
+    scope = parse_crawl_scope(allowed_domains, parent.url)
 
     parent_normalized = _normalize_crawl_url(parent.url)
     visited: set[str] = {parent_normalized}
@@ -955,13 +950,11 @@ async def _crawl_from_source(
     seed_links = _crawlable_links(parent_fetched, parent.url)
     logger.info(f"Crawl: found {len(seed_links)} links on parent page {parent.url}")
     for link in seed_links:
-        if link not in visited:
-            parsed = urlparse(link)
-            if parsed.netloc.lower() in domain_set:
-                queue.append(link)
-                visited.add(link)
+        if link not in visited and url_in_crawl_scope(link, scope):
+            queue.append(link)
+            visited.add(link)
 
-    logger.info(f"Crawl: {len(queue)} same-domain links queued (max_pages={max_pages}, domains={domain_set})")
+    logger.info(f"Crawl: {len(queue)} in-scope links queued (max_pages={max_pages}, scope={scope})")
 
     crawled_urls: list[str] = []
 
@@ -993,11 +986,9 @@ async def _crawl_from_source(
         # Extract more links from this page for BFS
         if child_fetched and added < max_pages:
             for link in _crawlable_links(child_fetched, url):
-                if link not in visited:
-                    parsed = urlparse(link)
-                    if parsed.netloc.lower() in domain_set:
-                        queue.append(link)
-                        visited.add(link)
+                if link not in visited and url_in_crawl_scope(link, scope):
+                    queue.append(link)
+                    visited.add(link)
 
     # Update parent with crawled URL list
     parent.crawled_urls = crawled_urls

--- a/backend/app/services/workflow_engine.py
+++ b/backend/app/services/workflow_engine.py
@@ -16,7 +16,7 @@ import threading
 import zipfile
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import NoReturn
-from urllib.parse import urljoin, urlparse
+from urllib.parse import urljoin
 
 import httpx
 from bs4 import BeautifulSoup
@@ -688,10 +688,10 @@ class CrawlerNode(Node):
             return {"output": f"Blocked URL: {e}", "input": inputs.get("output"), "step_name": self.name}
 
         from app.utils.bot_challenge import looks_like_bot_challenge
+        from app.utils.crawl_scope import parse_crawl_scope, url_in_crawl_scope
 
         self.report_progress(f"Crawling from {start_url}")
-        parsed_start = urlparse(start_url)
-        allowed = {d.strip() for d in allowed_domains.split(",") if d.strip()} if allowed_domains else {parsed_start.netloc}
+        scope = parse_crawl_scope(allowed_domains, start_url)
 
         visited = set()
         to_visit = [start_url]
@@ -732,8 +732,7 @@ class CrawlerNode(Node):
                 soup = BeautifulSoup(resp.text, "html.parser")
                 for link in soup.find_all("a", href=True):
                     abs_url = urljoin(url, link["href"])
-                    parsed = urlparse(abs_url)
-                    if parsed.netloc in allowed and abs_url not in visited:
+                    if url_in_crawl_scope(abs_url, scope) and abs_url not in visited:
                         try:
                             validate_outbound_url(abs_url)
                             to_visit.append(abs_url)

--- a/backend/app/utils/crawl_scope.py
+++ b/backend/app/utils/crawl_scope.py
@@ -1,0 +1,51 @@
+"""Crawl-scope matching shared by the KB crawler and the workflow CrawlerNode.
+
+An allowed-domains entry may be a bare hostname ("example.com"), a hostname
+with a path prefix ("example.com/irb"), or a full URL
+("https://example.com/irb/"). A path prefix restricts the crawl to that
+section of the site. Matching is segment-aware: "example.com/irb" matches
+/irb and /irb/apply but not /irb-archive.
+"""
+
+from urllib.parse import urlparse
+
+# (hostname, path_prefix) — path_prefix is "" for whole-domain rules
+ScopeRule = tuple[str, str]
+
+
+def parse_crawl_scope(allowed_domains: str, start_url: str) -> list[ScopeRule]:
+    """Parse a comma-separated allowed-domains setting into scope rules.
+
+    Explicit entries define the entire scope — the start URL's domain is NOT
+    implicitly included, so a single path-qualified entry can narrow the crawl
+    below the domain level. When no usable entries are given, the scope
+    defaults to the start URL's whole domain.
+    """
+    rules: list[ScopeRule] = []
+    for entry in (allowed_domains or "").split(","):
+        entry = entry.strip()
+        if not entry:
+            continue
+        if "://" not in entry:
+            # Bare "example.com/path" parses as all-path; force a netloc split.
+            entry = "//" + entry
+        parsed = urlparse(entry)
+        if not parsed.netloc:
+            continue
+        rules.append((parsed.netloc.lower(), parsed.path.rstrip("/")))
+    if not rules:
+        rules.append((urlparse(start_url).netloc.lower(), ""))
+    return rules
+
+
+def url_in_crawl_scope(url: str, rules: list[ScopeRule]) -> bool:
+    """True if url's hostname matches a rule and its path is under the rule's prefix."""
+    parsed = urlparse(url)
+    host = parsed.netloc.lower()
+    path = parsed.path or "/"
+    for rule_host, rule_path in rules:
+        if host != rule_host:
+            continue
+        if not rule_path or path == rule_path or path.startswith(rule_path + "/"):
+            return True
+    return False

--- a/backend/tests/test_crawl_scope.py
+++ b/backend/tests/test_crawl_scope.py
@@ -1,0 +1,75 @@
+"""Unit tests for crawl-scope parsing and matching (app.utils.crawl_scope).
+
+The allowed-domains setting accepts bare hostnames, hostnames with path
+prefixes, and full URLs. Explicit entries define the entire scope; blank
+falls back to the start URL's domain.
+"""
+
+from app.utils.crawl_scope import parse_crawl_scope, url_in_crawl_scope
+
+
+START = "https://www.suu.edu/irb/"
+
+
+def test_blank_defaults_to_start_domain():
+    scope = parse_crawl_scope("", START)
+    assert scope == [("www.suu.edu", "")]
+    assert url_in_crawl_scope("https://www.suu.edu/academics", scope)
+    assert not url_in_crawl_scope("https://other.edu/irb", scope)
+
+
+def test_bare_hostname_entry_allows_whole_domain():
+    scope = parse_crawl_scope("docs.example.com", START)
+    assert url_in_crawl_scope("https://docs.example.com/any/page", scope)
+    assert not url_in_crawl_scope("https://example.com/any/page", scope)
+
+
+def test_explicit_entries_replace_start_domain():
+    # A restrictive entry must actually restrict — the start URL's domain is
+    # not implicitly kept in scope (the silent no-op from the ticket).
+    scope = parse_crawl_scope("www.grants.gov", "https://www.usda.gov/x")
+    assert url_in_crawl_scope("https://www.grants.gov/learn", scope)
+    assert not url_in_crawl_scope("https://www.usda.gov/policies", scope)
+
+
+def test_path_entry_scopes_to_subdirectory():
+    scope = parse_crawl_scope("www.suu.edu/irb", START)
+    assert url_in_crawl_scope("https://www.suu.edu/irb", scope)
+    assert url_in_crawl_scope("https://www.suu.edu/irb/", scope)
+    assert url_in_crawl_scope("https://www.suu.edu/irb/apply", scope)
+    assert not url_in_crawl_scope("https://www.suu.edu/", scope)
+    assert not url_in_crawl_scope("https://www.suu.edu/admissions", scope)
+
+
+def test_path_match_is_segment_aware():
+    scope = parse_crawl_scope("www.suu.edu/irb", START)
+    assert not url_in_crawl_scope("https://www.suu.edu/irb-archive", scope)
+    assert not url_in_crawl_scope("https://www.suu.edu/irbs/old", scope)
+
+
+def test_full_url_entry_with_scheme_and_trailing_slash():
+    # Exactly what the ticket reporter typed into the field.
+    scope = parse_crawl_scope("https://www.suu.edu/irb/", START)
+    assert scope == [("www.suu.edu", "/irb")]
+    assert url_in_crawl_scope("https://www.suu.edu/irb/forms", scope)
+    assert not url_in_crawl_scope("https://www.suu.edu/admissions", scope)
+
+
+def test_multiple_entries_and_whitespace():
+    scope = parse_crawl_scope(" www.suu.edu/irb , docs.example.com ,, ", START)
+    assert url_in_crawl_scope("https://www.suu.edu/irb/faq", scope)
+    assert url_in_crawl_scope("https://docs.example.com/guide", scope)
+    assert not url_in_crawl_scope("https://www.suu.edu/athletics", scope)
+
+
+def test_hostname_match_is_case_insensitive_path_is_not():
+    scope = parse_crawl_scope("WWW.SUU.EDU/Forms", START)
+    assert url_in_crawl_scope("https://www.suu.edu/Forms/consent", scope)
+    assert not url_in_crawl_scope("https://www.suu.edu/forms/consent", scope)
+
+
+def test_unparseable_entry_falls_back_to_start_domain():
+    # An entry with no recoverable hostname is dropped; with nothing left,
+    # the scope defaults to the start domain rather than allowing everything.
+    scope = parse_crawl_scope("/just-a-path", START)
+    assert scope == [("www.suu.edu", "")]

--- a/backend/tests/test_kb_crawl.py
+++ b/backend/tests/test_kb_crawl.py
@@ -131,7 +131,7 @@ async def test_pdf_parent_respects_allowed_domains_and_max_pages():
                       AsyncMock(return_value=None)):
         added = await knowledge_service._crawl_from_source(
             parent, MagicMock(uuid="kb-1"), max_pages=2,
-            allowed_domains="www.grants.gov", parent_fetched=fetched,
+            allowed_domains="www.usda.gov, www.grants.gov", parent_fetched=fetched,
         )
 
     # grants.gov is allowed via allowed_domains; max_pages=2 stops before /c.
@@ -139,6 +139,58 @@ async def test_pdf_parent_respects_allowed_domains_and_max_pages():
     assert [c.url for c in children] == [
         "https://www.usda.gov/a",
         "https://www.grants.gov/b",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_explicit_allowed_domains_replace_parent_domain():
+    """An allowed-domains entry defines the whole scope — it no longer
+    silently unions with the parent's domain (the ticket's no-op case)."""
+    parent = _make_parent("https://www.usda.gov/x/terms.pdf")
+    fetched = _pdf_result(parent.url, [
+        "https://www.usda.gov/a",
+        "https://www.grants.gov/b",
+    ])
+    cls, children = _mock_source_cls()
+
+    with patch.object(knowledge_service, "KnowledgeBaseSource", cls), \
+         patch.object(knowledge_service, "_ingest_url_source",
+                      AsyncMock(return_value=None)):
+        added = await knowledge_service._crawl_from_source(
+            parent, MagicMock(uuid="kb-1"), max_pages=5,
+            allowed_domains="www.grants.gov", parent_fetched=fetched,
+        )
+
+    assert added == 1
+    assert [c.url for c in children] == ["https://www.grants.gov/b"]
+
+
+@pytest.mark.asyncio
+async def test_path_qualified_allowed_domain_scopes_crawl_to_subdirectory():
+    """A full URL with a path in Allowed domains restricts the crawl to that
+    section of the site (support ticket: suu.edu/irb pulled in all of suu.edu)."""
+    parent = _make_parent("https://www.suu.edu/irb/")
+    parent_fetched = _html_result(parent.url, """
+        <a href="/irb/apply">Apply</a>
+        <a href="/irb/forms/consent">Consent</a>
+        <a href="/irb-archive/2019">Archive</a>
+        <a href="/admissions">Admissions</a>
+        <a href="https://www.suu.edu/">Home</a>
+    """)
+    cls, children = _mock_source_cls()
+
+    with patch.object(knowledge_service, "KnowledgeBaseSource", cls), \
+         patch.object(knowledge_service, "_ingest_url_source",
+                      AsyncMock(return_value=None)):
+        added = await knowledge_service._crawl_from_source(
+            parent, MagicMock(uuid="kb-1"), max_pages=10,
+            allowed_domains="https://www.suu.edu/irb", parent_fetched=parent_fetched,
+        )
+
+    assert added == 2
+    assert [c.url for c in children] == [
+        "https://www.suu.edu/irb/apply",
+        "https://www.suu.edu/irb/forms/consent",
     ]
 
 

--- a/frontend/src/components/knowledge/AddUrlsModal.tsx
+++ b/frontend/src/components/knowledge/AddUrlsModal.tsx
@@ -118,7 +118,7 @@ export function AddUrlsModal({ onSubmit, onClose }: AddUrlsModalProps) {
                 type="text"
                 value={allowedDomains}
                 onChange={e => setAllowedDomains(e.target.value)}
-                placeholder="example.com, docs.example.com"
+                placeholder="example.com, example.com/section"
                 style={{
                   width: '100%', padding: '6px 8px', fontSize: 13, fontFamily: 'inherit',
                   backgroundColor: '#2a2a2a', color: '#e5e5e5',
@@ -126,7 +126,8 @@ export function AddUrlsModal({ onSubmit, onClose }: AddUrlsModalProps) {
                 }}
               />
               <div style={{ fontSize: 11, color: '#666' }}>
-                Comma-separated. Defaults to the same domain as the URL.
+                Comma-separated. Include a path (e.g. example.com/irb) to limit the crawl
+                to that section of the site. Defaults to the same domain as the URL.
               </div>
             </div>
           </div>

--- a/frontend/src/components/knowledge/OptimizationResults.tsx
+++ b/frontend/src/components/knowledge/OptimizationResults.tsx
@@ -94,7 +94,7 @@ export function OptimizationResults({
     {
       id: 'default',
       label: kbLabels.yourSettings,
-      score: holdoutHeadline ? run.holdout_default_score : run.baseline_default_score,
+      score: holdoutHeadline ? run.holdout_default_score ?? null : run.baseline_default_score,
       color: '#3b82f6',
     },
     { id: 'optimized', label: kbLabels.tuned, score: run.optimized_score, color: '#22c55e', emphasised: true },

--- a/frontend/src/components/workspace/WorkflowEditorPanel.tsx
+++ b/frontend/src/components/workspace/WorkflowEditorPanel.tsx
@@ -3533,7 +3533,7 @@ function TaskEditModal({ task, selectedDocUuids, workflow, workflowId, onClose, 
                     type="text"
                     value={getTextValue('allowed_domains')}
                     onChange={e => setTextValue('allowed_domains', e.target.value)}
-                    placeholder="example.com, docs.example.com"
+                    placeholder="example.com, example.com/section"
                     style={{
                       width: '100%', padding: '8px 12px', fontSize: 13,
                       fontFamily: 'inherit', border: '1px solid #d1d5db', borderRadius: 6,
@@ -3541,7 +3541,8 @@ function TaskEditModal({ task, selectedDocUuids, workflow, workflowId, onClose, 
                     }}
                   />
                   <div style={{ fontSize: 11, color: '#6b7280', marginTop: 4 }}>
-                    Comma-separated list. Defaults to the starting URL's domain.
+                    Comma-separated list. Include a path (e.g. example.com/docs) to limit
+                    the crawl to that section. Defaults to the starting URL's domain.
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
## Problem

Support ticket: setting Allowed Domains to `https://www.suu.edu/irb` on a crawl-enabled KB URL still pulled in pages from all of suu.edu.

Two stacked issues in `_crawl_from_source`:

1. **No path scoping existed.** The filter compared only `urlparse(link).netloc` against a hostname set, so there was no way to restrict a crawl below the domain level.
2. **A path-qualified entry was a silent no-op.** `https://www.suu.edu/irb` was added verbatim to the hostname set (where it could never match), and the parent URL's domain was unconditionally added anyway — the field could only ever widen a crawl, never narrow it.

## Fix

- New shared helper `backend/app/utils/crawl_scope.py`: entries may be bare hostnames (`example.com`), hosts with path prefixes (`example.com/irb`), or full URLs (`https://www.suu.edu/irb/`). Path matching is segment-aware — `/irb` matches `/irb/apply` but not `/irb-archive`.
- Explicit entries now define the whole scope instead of unioning with the parent domain, so a restrictive entry actually restricts. Blank still defaults to the parent URL's domain (unchanged).
- Used in both crawl paths: the KB crawler (`knowledge_service._crawl_from_source`) and the workflow `CrawlerNode`, which had the same hostname-only filter (and gains case-insensitive hostname matching).
- Updated Allowed domains placeholder/helper text in `AddUrlsModal` and the CrawlerNode config in `WorkflowEditorPanel` to document path scoping. (The browser-automation allowed-domains field is a different feature and is untouched.)

## Behavior change

Users who previously entered a second domain expecting "parent domain + extra" now need to list the parent domain explicitly — the helper text always described allowlist semantics, but existing crawl-enabled sources that re-crawl with a lone extra domain will now exclude the parent domain.

## Testing

- New `tests/test_crawl_scope.py` (9 tests): ticket scenario, segment-aware prefixes, scheme/trailing-slash handling, case sensitivity, fallback when no entry parses.
- `tests/test_kb_crawl.py`: updated the union-semantics test to list both domains; added tests that an explicit entry excludes the parent domain and an end-to-end SUU-IRB subdirectory crawl through the BFS.
- 257 knowledge/KB tests + 184 workflow/crawl tests pass; ruff clean; frontend `tsc -b` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)