### PR TITLE
feat(feedback): What's Working positive-feedback surface

### DIFF
--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -20,7 +20,7 @@ from app.models.user_config import UserModelConfig
 from app.models.chat import ChatMessage, FileAttachment, UrlAttachment, ChatConversation
 from app.models.activity import ActivityEvent
 from app.models.library import LibraryFolder, LibraryItem, Library
-from app.models.feedback import ChatFeedback, ExtractionQualityRecord
+from app.models.feedback import ChatFeedback, ExtractionQualityRecord, ProductFeedback
 from app.models.verification import VerificationRequest, VerifiedItemMetadata, VerifiedCollection
 from app.models.office import IntakeConfig, WorkItem
 from app.models.automation import Automation
@@ -82,6 +82,7 @@ ALL_MODELS = [
     Library,
     ChatFeedback,
     ExtractionQualityRecord,
+    ProductFeedback,
     VerificationRequest,
     VerifiedItemMetadata,
     VerifiedCollection,

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -16,7 +16,7 @@ from app.exceptions import AppError
 from app.middleware.csrf import CSRFMiddleware
 from app.observability import init_sentry
 from app.rate_limit import limiter
-from app.routers import activity, admin, audit, auth, automations, browser_automation, certification, chat, config, credentials, demo, documents, extractions, feedback, feedback_prompt, files, folders, graph_webhooks, knowledge, library, mgmt, notifications, office, optimizer_inbox, organizations, projects, reviews, spaces, support, teams, telemetry, verification, workflows
+from app.routers import activity, admin, audit, auth, automations, browser_automation, certification, chat, config, credentials, demo, documents, extractions, feedback, feedback_admin, feedback_prompt, files, folders, graph_webhooks, knowledge, library, mgmt, notifications, office, optimizer_inbox, organizations, projects, reviews, spaces, support, teams, telemetry, verification, workflows
 
 
 @lru_cache
@@ -211,6 +211,7 @@ app.include_router(chat.router, prefix="/api/chat", tags=["chat"])
 app.include_router(activity.router, prefix="/api/activity", tags=["activity"])
 app.include_router(library.router, prefix="/api/library", tags=["library"])
 app.include_router(feedback.router, prefix="/api/feedback", tags=["feedback"])
+app.include_router(feedback_admin.router, prefix="/api/feedback/admin", tags=["feedback-admin"])
 app.include_router(verification.router, prefix="/api/verification", tags=["verification"])
 app.include_router(office.router, prefix="/api/office", tags=["office"])
 app.include_router(automations.router, prefix="/api/automations", tags=["automations"])

--- a/backend/app/models/feedback.py
+++ b/backend/app/models/feedback.py
@@ -41,3 +41,36 @@ class ExtractionQualityRecord(Document):
 
     class Settings:
         name = "extraction_quality_record"
+
+
+class ProductFeedback(Document):
+    """Free-form, non-negative product feedback that isn't tied to a single
+    chat message or extraction — a user telling us what's working, or an idea.
+
+    Negatives deliberately stay on the support-ticket rails (they need triage,
+    assignment, and a status that can close). This collection is the home for
+    positive/idea signal so it stops dying write-only: the "What's Working"
+    admin surface reads it alongside thumbs-up chat feedback and high extraction
+    star ratings.
+    """
+
+    # "positive" = something worked well; "idea" = a suggestion offered warmly,
+    # not a defect report. No "negative" — that path creates a support ticket.
+    sentiment: str = "positive"
+    message: str
+    # Where it was captured, so the admin feed can group by surface and we can
+    # add new capture points without schema churn (e.g. "support_panel").
+    source: str = "support_panel"
+    # Optional feature attribution when the surface knows it (e.g. "chat",
+    # "extraction"). Free-form on purpose — capture points vary.
+    feature: Optional[str] = None
+    user_id: Optional[str] = None
+    team_id: Optional[str] = None
+    created_at: datetime.datetime = Field(default_factory=datetime.datetime.utcnow)
+
+    class Settings:
+        name = "product_feedback"
+        indexes = [
+            "sentiment",
+            [("created_at", -1)],
+        ]

--- a/backend/app/routers/feedback.py
+++ b/backend/app/routers/feedback.py
@@ -6,7 +6,7 @@ from typing import Optional
 
 from app.dependencies import get_current_user
 from app.models.user import User
-from app.models.feedback import ChatFeedback, ExtractionQualityRecord
+from app.models.feedback import ChatFeedback, ExtractionQualityRecord, ProductFeedback
 
 router = APIRouter()
 
@@ -85,6 +85,35 @@ async def _maybe_trigger_kb_shadow_run(kb_uuid: str, user_id: str) -> None:
         logging.getLogger(__name__).warning(
             "Shadow-run trigger failed for kb=%s", kb_uuid, exc_info=True,
         )
+
+
+class ProductFeedbackRequest(BaseModel):
+    message: str = Field(min_length=1, max_length=4000)
+    # Only non-negative sentiments ride this path — a problem belongs on a
+    # support ticket (triage, assignment, a status that closes), not here.
+    sentiment: str = "positive"
+    source: str = "support_panel"
+    feature: Optional[str] = None
+
+
+@router.post("/product")
+async def submit_product_feedback(
+    req: ProductFeedbackRequest, user: User = Depends(get_current_user)
+):
+    """Capture free-form positive / idea feedback. Deliberately does NOT create
+    a support ticket, so praise never enters the triage queue or triggers the
+    ticket email/Teams fan-out. It surfaces in the 'What's Working' admin feed."""
+    sentiment = req.sentiment if req.sentiment in ("positive", "idea") else "positive"
+    record = ProductFeedback(
+        message=req.message.strip(),
+        sentiment=sentiment,
+        source=req.source,
+        feature=req.feature,
+        user_id=user.user_id,
+        team_id=str(user.current_team) if user.current_team else None,
+    )
+    await record.insert()
+    return {"complete": True}
 
 
 @router.post("/chat")

--- a/backend/app/routers/feedback_admin.py
+++ b/backend/app/routers/feedback_admin.py
@@ -1,0 +1,145 @@
+"""Admin read surface for positive feedback — the "What's Working" feed.
+
+Positive signal used to be write-only: chat thumbs-up, high extraction star
+ratings, and (now) ProductFeedback all landed in Mongo and were never read by a
+human. This router is the read side that gives that signal a home. It unifies
+three sources into one reverse-chronological feed plus a small stats rollup, so
+support agents can finally see what users love — the mirror image of the
+thumbs-down path that already drives KB optimization.
+
+Support users / admins only, mirroring ``/api/support/stats``.
+"""
+
+import datetime
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+
+from app.dependencies import get_current_user
+from app.models.feedback import ChatFeedback, ExtractionQualityRecord, ProductFeedback
+from app.models.user import User
+from app.services import support_service
+
+router = APIRouter()
+
+# A star rating at or above this counts as positive signal for the feed.
+POSITIVE_STAR_THRESHOLD = 4
+
+
+async def _require_support(user: User) -> None:
+    if not await support_service.is_support_user(user):
+        raise HTTPException(status_code=403, detail="Not authorized")
+
+
+def _item(source: str, sentiment: str, message: Optional[str], feature: Optional[str],
+          user_id: Optional[str], created_at: datetime.datetime) -> dict:
+    return {
+        "source": source,
+        "sentiment": sentiment,
+        "message": message,
+        "feature": feature,
+        "user_id": user_id,
+        "created_at": created_at.isoformat() if created_at else None,
+        "_sort": created_at or datetime.datetime.min,
+    }
+
+
+@router.get("/positive")
+async def list_positive_feedback(
+    user: User = Depends(get_current_user),
+    limit: int = Query(50, ge=1, le=200),
+    source: Optional[str] = Query(None, description="chat | extraction | product"),
+):
+    """Unified reverse-chronological feed of positive feedback across sources.
+
+    - chat: thumbs-up ChatFeedback that carries a comment (bare up-votes have
+      no words to show, so they inflate stats, not the feed).
+    - extraction: ExtractionQualityRecord at or above the star threshold.
+    - product: every ProductFeedback (already positive/idea by construction).
+    """
+    await _require_support(user)
+
+    # Over-fetch per source, merge, then trim — a per-source limit can't know
+    # the global chronological cut-off ahead of the merge.
+    items: list[dict] = []
+
+    if source in (None, "chat"):
+        chats = await (
+            ChatFeedback.find(ChatFeedback.rating == "up")
+            .sort("-created_at")
+            .limit(limit)
+            .to_list()
+        )
+        for c in chats:
+            if c.comment and c.comment.strip():
+                items.append(_item("chat", "positive", c.comment, "chat",
+                                   c.user_id, c.created_at))
+
+    if source in (None, "extraction"):
+        extractions = await (
+            ExtractionQualityRecord.find(
+                ExtractionQualityRecord.star_rating >= POSITIVE_STAR_THRESHOLD
+            )
+            .sort("-created_at")
+            .limit(limit)
+            .to_list()
+        )
+        for e in extractions:
+            label = f"{e.star_rating}★ — {e.pdf_title}"
+            msg = f"{label}: {e.comment}" if (e.comment and e.comment.strip()) else label
+            items.append(_item("extraction", "positive", msg, "extraction",
+                               e.user_id, e.created_at))
+
+    if source in (None, "product"):
+        products = await (
+            ProductFeedback.find()
+            .sort("-created_at")
+            .limit(limit)
+            .to_list()
+        )
+        for p in products:
+            items.append(_item("product", p.sentiment, p.message, p.feature,
+                               p.user_id, p.created_at))
+
+    items.sort(key=lambda i: i["_sort"], reverse=True)
+    trimmed = items[:limit]
+    for i in trimmed:
+        i.pop("_sort", None)
+    return {"items": trimmed, "count": len(trimmed)}
+
+
+@router.get("/stats")
+async def positive_feedback_stats(user: User = Depends(get_current_user)):
+    """Rollup for the 'What's Working' header: how much positive signal there
+    is, where it comes from, and the chat thumbs-up rate (the one sentiment
+    metric we already trend elsewhere)."""
+    await _require_support(user)
+
+    week_ago = datetime.datetime.utcnow() - datetime.timedelta(days=7)
+
+    chat_up = await ChatFeedback.find(ChatFeedback.rating == "up").count()
+    chat_down = await ChatFeedback.find(ChatFeedback.rating == "down").count()
+    extraction_positive = await ExtractionQualityRecord.find(
+        ExtractionQualityRecord.star_rating >= POSITIVE_STAR_THRESHOLD
+    ).count()
+    product_total = await ProductFeedback.find().count()
+
+    product_week = await ProductFeedback.find(
+        ProductFeedback.created_at >= week_ago
+    ).count()
+    chat_up_week = await ChatFeedback.find(
+        ChatFeedback.rating == "up", ChatFeedback.created_at >= week_ago
+    ).count()
+
+    total_chat = chat_up + chat_down
+    thumbs_up_rate = round(chat_up / total_chat, 3) if total_chat else None
+
+    return {
+        "by_source": {
+            "chat": chat_up,
+            "extraction": extraction_positive,
+            "product": product_total,
+        },
+        "thumbs_up_rate": thumbs_up_rate,
+        "positive_last_7_days": product_week + chat_up_week,
+    }

--- a/backend/tests/test_feedback_routes.py
+++ b/backend/tests/test_feedback_routes.py
@@ -1,0 +1,134 @@
+"""Coverage for the positive-feedback surface: admin-gating on the read feed
+and the off-ticket ProductFeedback write path."""
+
+import secrets
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.config import Settings
+from app.utils.security import create_access_token
+
+_TEST_SETTINGS = Settings(jwt_secret_key="test-secret-key", environment="development")
+
+
+def _make_user(user_id: str = "testuser", *, is_admin: bool = False, current_team=None):
+    user = MagicMock()
+    user.id = "fake-id"
+    user.user_id = user_id
+    user.email = f"{user_id}@example.com"
+    user.name = "Test User"
+    user.is_admin = is_admin
+    user.current_team = current_team
+    user.is_demo_user = False
+    user.token_version = 0
+    user.demo_status = None
+    return user
+
+
+def _auth(user_id: str = "testuser"):
+    token = create_access_token(user_id, _TEST_SETTINGS)
+    csrf = secrets.token_urlsafe(32)
+    return {"access_token": token, "csrf_token": csrf}, {"X-CSRF-Token": csrf}
+
+
+@pytest.fixture
+async def client():
+    with patch("app.main.init_db", new_callable=AsyncMock):
+        from app.main import app
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        ) as ac:
+            yield ac
+
+
+def _patch_auth(user):
+    """Context managers that make get_current_user resolve to ``user``."""
+    return (
+        patch("app.dependencies.decode_token", return_value={"sub": user.user_id, "type": "access"}),
+        patch("app.dependencies.User"),
+    )
+
+
+class TestPositiveFeedbackFeedAuthz:
+    @pytest.mark.asyncio
+    async def test_feed_forbidden_for_non_support(self, client):
+        user = _make_user("viewer")
+        cookies, headers = _auth("viewer")
+        patch_decode, patch_user = _patch_auth(user)
+        with (
+            patch_decode,
+            patch_user as MockUser,
+            patch("app.routers.feedback_admin.support_service.is_support_user",
+                  new=AsyncMock(return_value=False)),
+        ):
+            MockUser.find_one = AsyncMock(return_value=user)
+            resp = await client.get("/api/feedback/admin/positive", cookies=cookies, headers=headers)
+        assert resp.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_stats_forbidden_for_non_support(self, client):
+        user = _make_user("viewer")
+        cookies, headers = _auth("viewer")
+        patch_decode, patch_user = _patch_auth(user)
+        with (
+            patch_decode,
+            patch_user as MockUser,
+            patch("app.routers.feedback_admin.support_service.is_support_user",
+                  new=AsyncMock(return_value=False)),
+        ):
+            MockUser.find_one = AsyncMock(return_value=user)
+            resp = await client.get("/api/feedback/admin/stats", cookies=cookies, headers=headers)
+        assert resp.status_code == 403
+
+
+class TestProductFeedbackWrite:
+    @pytest.mark.asyncio
+    async def test_product_feedback_inserts_without_ticket(self, client):
+        user = _make_user("author")
+        cookies, headers = _auth("author")
+        patch_decode, patch_user = _patch_auth(user)
+        instance = MagicMock()
+        instance.insert = AsyncMock()
+        with (
+            patch_decode,
+            patch_user as MockUser,
+            patch("app.routers.feedback.ProductFeedback", return_value=instance) as MockPF,
+        ):
+            MockUser.find_one = AsyncMock(return_value=user)
+            resp = await client.post(
+                "/api/feedback/product",
+                json={"message": "The extraction saved me an hour!", "sentiment": "positive"},
+                cookies=cookies, headers=headers,
+            )
+        assert resp.status_code == 200
+        assert resp.json() == {"complete": True}
+        instance.insert.assert_awaited_once()
+        # It is a ProductFeedback, never a SupportTicket — praise stays off the queue.
+        MockPF.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_negative_sentiment_is_coerced_to_positive(self, client):
+        """A negative sentiment must never ride this path — it is coerced, so
+        the off-ticket collection only ever holds positive/idea signal."""
+        user = _make_user("author")
+        cookies, headers = _auth("author")
+        patch_decode, patch_user = _patch_auth(user)
+        instance = MagicMock()
+        instance.insert = AsyncMock()
+        with (
+            patch_decode,
+            patch_user as MockUser,
+            patch("app.routers.feedback.ProductFeedback", return_value=instance) as MockPF,
+        ):
+            MockUser.find_one = AsyncMock(return_value=user)
+            resp = await client.post(
+                "/api/feedback/product",
+                json={"message": "this is broken", "sentiment": "negative"},
+                cookies=cookies, headers=headers,
+            )
+        assert resp.status_code == 200
+        assert MockPF.call_args.kwargs["sentiment"] == "positive"

--- a/frontend/src/api/feedback.ts
+++ b/frontend/src/api/feedback.ts
@@ -24,3 +24,47 @@ export async function submitChatFeedback(data: {
     body: JSON.stringify(data),
   })
 }
+
+// Free-form positive / idea feedback that is NOT a support ticket — it never
+// enters the triage queue. Backs the support-panel "something that's working"
+// affordance.
+export async function submitProductFeedback(data: {
+  message: string
+  sentiment?: 'positive' | 'idea'
+  source?: string
+  feature?: string
+}): Promise<{ complete: boolean }> {
+  return apiFetch('/api/feedback/product', {
+    method: 'POST',
+    body: JSON.stringify(data),
+  })
+}
+
+export type PositiveFeedbackItem = {
+  source: 'chat' | 'extraction' | 'product'
+  sentiment: string
+  message: string | null
+  feature: string | null
+  user_id: string | null
+  created_at: string | null
+}
+
+export type PositiveFeedbackStats = {
+  by_source: { chat: number; extraction: number; product: number }
+  thumbs_up_rate: number | null
+  positive_last_7_days: number
+}
+
+export function listPositiveFeedback(
+  source?: 'chat' | 'extraction' | 'product',
+  limit = 50,
+): Promise<{ items: PositiveFeedbackItem[]; count: number }> {
+  const params = new URLSearchParams()
+  params.set('limit', String(limit))
+  if (source) params.set('source', source)
+  return apiFetch(`/api/feedback/admin/positive?${params}`)
+}
+
+export function getPositiveFeedbackStats(): Promise<PositiveFeedbackStats> {
+  return apiFetch('/api/feedback/admin/stats')
+}

--- a/frontend/src/components/chat/ChatMessage.tsx
+++ b/frontend/src/components/chat/ChatMessage.tsx
@@ -114,16 +114,18 @@ export function ChatMessage({ message, messageIndex, conversationUuid, streaming
         rating,
       })
     } catch { /* ignore */ }
-    if (rating === 'down') setShowComment(true)
+    // Invite a comment for BOTH sentiments — positive feedback is worth capturing,
+    // not just complaints. The prompt copy flips with the rating below.
+    if (!commentSent) setShowComment(true)
   }
 
   const handleSubmitComment = async () => {
-    if (!comment.trim()) return
+    if (!comment.trim() || !feedback) return
     try {
       await submitChatFeedback({
         conversation_uuid: conversationUuid,
         message_index: messageIndex,
-        rating: 'down',
+        rating: feedback,
         comment: comment.trim(),
       })
       setCommentSent(true)
@@ -332,7 +334,7 @@ export function ChatMessage({ message, messageIndex, conversationUuid, streaming
             </button>
           </div>}
 
-          {/* Comment form for negative feedback */}
+          {/* Comment form — shown after either thumbs-up or thumbs-down */}
           {!isStreamingProp && showComment && !commentSent && (
             <div style={{
               marginTop: 8, display: 'flex', gap: 8, alignItems: 'flex-start',
@@ -342,8 +344,8 @@ export function ChatMessage({ message, messageIndex, conversationUuid, streaming
                 value={comment}
                 onChange={e => setComment(e.target.value)}
                 onKeyDown={e => { if (e.key === 'Enter') handleSubmitComment() }}
-                placeholder="What went wrong? (optional)"
-                aria-label="What went wrong? (optional)"
+                placeholder={feedback === 'up' ? 'What worked well? (optional)' : 'What went wrong? (optional)'}
+                aria-label={feedback === 'up' ? 'What worked well? (optional)' : 'What went wrong? (optional)'}
                 style={{
                   flex: 1, padding: '6px 10px', borderRadius: 6,
                   border: '1px solid #d1d5db', fontSize: 13,

--- a/frontend/src/components/support/SupportChatPanel.tsx
+++ b/frontend/src/components/support/SupportChatPanel.tsx
@@ -7,6 +7,7 @@ import {
   Circle,
   Clock,
   Eye,
+  Heart,
   Loader2,
   Lock,
   MessageSquare,
@@ -14,6 +15,7 @@ import {
   Pencil,
   Plus,
   Send,
+  Sparkles,
   Upload,
   UserPlus,
   X,
@@ -22,6 +24,7 @@ import { useAuth } from '../../hooks/useAuth'
 import { useToast } from '../../contexts/ToastContext'
 import { useConfirm } from '../shared/useConfirm'
 import * as supportApi from '../../api/support'
+import { submitProductFeedback } from '../../api/feedback'
 import type { SupportTicket, SupportTicketSummary } from '../../types/support'
 
 const MAX_ATTACHMENT_BYTES = 10 * 1024 * 1024
@@ -145,7 +148,7 @@ const CLASSIFICATION_LABELS = {
 // Views
 // ---------------------------------------------------------------------------
 
-type View = 'list' | 'new' | 'chat'
+type View = 'list' | 'new' | 'chat' | 'praise'
 
 function TicketListView({
   tickets,
@@ -154,6 +157,7 @@ function TicketListView({
   currentUserId,
   onSelect,
   onNew,
+  onPraise,
 }: {
   tickets: SupportTicketSummary[]
   loading: boolean
@@ -161,6 +165,7 @@ function TicketListView({
   currentUserId: string
   onSelect: (uuid: string) => void
   onNew: () => void
+  onPraise: () => void
 }) {
   const open = tickets.filter((t) => t.status !== 'closed')
   const closed = tickets.filter((t) => t.status === 'closed')
@@ -287,17 +292,135 @@ function TicketListView({
         )}
       </div>
 
-      {!isSupportAgent && tickets.length > 0 && (
-        <div className="border-t p-3">
+      {!isSupportAgent && (
+        <div className="space-y-2 border-t p-3">
+          {tickets.length > 0 && (
+            <button
+              onClick={onNew}
+              className="flex w-full items-center justify-center gap-1.5 rounded-lg bg-blue-600 px-3 py-2 text-sm font-medium text-white hover:bg-blue-700"
+            >
+              <Plus className="h-4 w-4" />
+              New Ticket
+            </button>
+          )}
           <button
-            onClick={onNew}
-            className="flex w-full items-center justify-center gap-1.5 rounded-lg bg-blue-600 px-3 py-2 text-sm font-medium text-white hover:bg-blue-700"
+            onClick={onPraise}
+            className="flex w-full items-center justify-center gap-1.5 rounded-lg border border-pink-200 bg-pink-50 px-3 py-2 text-sm font-medium text-pink-700 hover:bg-pink-100"
           >
-            <Plus className="h-4 w-4" />
-            New Ticket
+            <Heart className="h-4 w-4" />
+            Something working well?
           </button>
         </div>
       )}
+    </div>
+  )
+}
+
+// Off-ticket positive feedback. Deliberately NOT a support ticket: praise and
+// ideas shouldn't enter the triage queue or fire the ticket notification
+// fan-out. Writes to ProductFeedback and surfaces in the "What's Working" feed.
+function PraiseView({ onBack }: { onBack: () => void }) {
+  const [sentiment, setSentiment] = useState<'positive' | 'idea'>('positive')
+  const [message, setMessage] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+  const [sent, setSent] = useState(false)
+  const { toast } = useToast()
+
+  const handleSubmit = async () => {
+    if (!message.trim()) return
+    setSubmitting(true)
+    try {
+      await submitProductFeedback({
+        message: message.trim(),
+        sentiment,
+        source: 'support_panel',
+      })
+      setSent(true)
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Failed to send feedback'
+      toast(msg, 'error')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  if (sent) {
+    return (
+      <div className="flex flex-1 flex-col">
+        <div className="flex items-center gap-2 border-b px-4 py-2">
+          <span className="text-sm font-medium text-gray-900">Thank you</span>
+        </div>
+        <div className="flex flex-1 flex-col items-center justify-center gap-3 px-6 text-center">
+          <Heart className="h-10 w-10 text-pink-500" />
+          <p className="text-sm font-medium text-gray-900">This makes our day.</p>
+          <p className="text-xs text-gray-500">
+            Thanks for taking a moment to tell us what&rsquo;s working — it genuinely helps.
+          </p>
+          <button
+            onClick={onBack}
+            className="mt-2 rounded-lg bg-gray-900 px-4 py-2 text-sm font-medium text-white hover:bg-gray-800"
+          >
+            Done
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-1 flex-col overflow-hidden">
+      <div className="flex items-center gap-2 border-b px-4 py-2">
+        <button type="button" onClick={onBack} aria-label="Back" className="rounded p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-600">
+          <ArrowLeft className="h-4 w-4" />
+        </button>
+        <span className="text-sm font-medium text-gray-900">Share what&rsquo;s working</span>
+      </div>
+      <div className="flex-1 overflow-y-auto space-y-3 p-4">
+        <p className="text-xs text-gray-500">
+          Something you love, or an idea to make it even better? We&rsquo;d love to hear it — this
+          isn&rsquo;t a ticket, just a note to the team.
+        </p>
+        <div className="flex gap-2">
+          {([['positive', 'Something I love'], ['idea', 'An idea']] as const).map(([val, label]) => {
+            const active = sentiment === val
+            return (
+              <button
+                key={val}
+                type="button"
+                onClick={() => setSentiment(val)}
+                className={`flex-1 rounded-lg border px-3 py-2 text-sm font-medium ${
+                  active
+                    ? 'border-pink-300 bg-pink-50 text-pink-700'
+                    : 'border-gray-300 bg-white text-gray-600 hover:bg-gray-50'
+                }`}
+              >
+                {val === 'positive' ? <Heart className="mr-1 inline h-3.5 w-3.5" /> : <Sparkles className="mr-1 inline h-3.5 w-3.5" />}
+                {label}
+              </button>
+            )
+          })}
+        </div>
+        <textarea
+          value={message}
+          onChange={(e) => setMessage(e.target.value)}
+          rows={5}
+          autoFocus
+          className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-pink-400 focus:outline-none focus:ring-2 focus:ring-pink-300"
+          placeholder={sentiment === 'positive'
+            ? 'What worked well for you?'
+            : 'What would make Vandalizer better?'}
+        />
+      </div>
+      <div className="border-t p-3">
+        <button
+          onClick={handleSubmit}
+          disabled={submitting || !message.trim()}
+          className="flex w-full items-center justify-center gap-1.5 rounded-lg bg-pink-600 px-3 py-2 text-sm font-medium text-white hover:bg-pink-700 disabled:opacity-50"
+        >
+          {submitting ? <Loader2 className="h-4 w-4 animate-spin" /> : <Heart className="h-4 w-4" />}
+          Send
+        </button>
+      </div>
     </div>
   )
 }
@@ -380,7 +503,7 @@ function NewTicketView({
             value={subject}
             onChange={(e) => setSubject(e.target.value)}
             className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
-            placeholder="Brief summary of your issue"
+            placeholder="Brief summary — a problem, or something you'd like"
             autoFocus
           />
         </div>
@@ -418,7 +541,7 @@ function NewTicketView({
             onChange={(e) => setMessage(e.target.value)}
             rows={4}
             className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
-            placeholder="Describe your issue..."
+            placeholder="Tell us what's happening, or what you'd like to see..."
           />
         </div>
         <div>
@@ -1405,7 +1528,12 @@ export function SupportChatPanel({
             setView('chat')
           }}
           onNew={() => setView('new')}
+          onPraise={() => setView('praise')}
         />
+      )}
+
+      {view === 'praise' && (
+        <PraiseView onBack={() => setView('list')} />
       )}
 
       {view === 'new' && (

--- a/frontend/src/pages/SupportCenter.tsx
+++ b/frontend/src/pages/SupportCenter.tsx
@@ -2,18 +2,22 @@ import { useEffect, useState, useCallback, useRef } from 'react'
 import { Navigate, useNavigate, useSearch } from '@tanstack/react-router'
 import {
   ArrowLeft, Check, MessageSquare, Send, Plus, Paperclip, Pencil, X, Loader2, Link2, Tag,
-  Eye, UserPlus, Search, Flag, Lock, Layers,
+  Eye, UserPlus, Search, Flag, Lock, Layers, Heart, Sparkles,
 } from 'lucide-react'
 import { PageLayout } from '../components/layout/PageLayout'
 import { useAuth } from '../hooks/useAuth'
 import { useToast } from '../contexts/ToastContext'
 import { useConfirm } from '../components/shared/useConfirm'
 import * as supportApi from '../api/support'
+import {
+  listPositiveFeedback, getPositiveFeedbackStats,
+  type PositiveFeedbackItem, type PositiveFeedbackStats,
+} from '../api/feedback'
 import type {
   SupportTicket, SupportTicketSummary, SupportAttachment,
 } from '../types/support'
 
-type View = 'list' | 'new' | 'chat'
+type View = 'list' | 'new' | 'chat' | 'whats_working'
 type StatusFilter = 'all' | 'open' | 'in_progress' | 'closed'
 type PriorityFilter = 'all' | 'low' | 'normal' | 'high'
 type ClassificationFilter = 'all' | 'bug' | 'enhancement' | 'feature_request'
@@ -51,6 +55,11 @@ const CLASSIFICATION_LABELS: Record<string, string> = {
 }
 
 type Stats = { total: number; open: number; in_progress: number; closed: number }
+
+const statCardStyle = (color: string): React.CSSProperties => ({
+  flex: 1, padding: '16px 20px', background: '#fff', borderRadius: 'var(--ui-radius, 12px)',
+  border: '1px solid #e5e7eb', borderLeft: `4px solid ${color}`,
+})
 
 export default function SupportCenter() {
   const { user } = useAuth()
@@ -158,7 +167,11 @@ export default function SupportCenter() {
           currentUserId={user.user_id}
           onNew={() => setView('new')}
           onSelect={openTicket}
+          onWhatsWorking={() => setView('whats_working')}
         />
+      )}
+      {view === 'whats_working' && (
+        <WhatsWorkingView onBack={() => setView('list')} />
       )}
       {view === 'new' && (
         <NewTicketView
@@ -181,6 +194,142 @@ export default function SupportCenter() {
 }
 
 // ---------------------------------------------------------------------------
+// What's Working — the read home for positive signal (chat thumbs-up with a
+// comment, high extraction star ratings, and off-ticket ProductFeedback). The
+// mirror of the ticket queue: these never needed triage, they just never had a
+// place anyone looked.
+// ---------------------------------------------------------------------------
+
+const FEEDBACK_SOURCE_META: Record<string, { label: string; color: string }> = {
+  chat: { label: 'Chat', color: '#3b82f6' },
+  extraction: { label: 'Extraction', color: '#8b5cf6' },
+  product: { label: 'Shared', color: '#ec4899' },
+}
+
+function WhatsWorkingView({ onBack }: { onBack: () => void }) {
+  const { toast } = useToast()
+  const [items, setItems] = useState<PositiveFeedbackItem[]>([])
+  const [stats, setStats] = useState<PositiveFeedbackStats | null>(null)
+  const [sourceFilter, setSourceFilter] = useState<'all' | 'chat' | 'extraction' | 'product'>('all')
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+    const src = sourceFilter === 'all' ? undefined : sourceFilter
+    Promise.all([listPositiveFeedback(src, 100), getPositiveFeedbackStats()])
+      .then(([feed, s]) => {
+        if (cancelled) return
+        setItems(feed.items)
+        setStats(s)
+      })
+      .catch(() => { if (!cancelled) toast('Failed to load feedback', 'error') })
+      .finally(() => { if (!cancelled) setLoading(false) })
+    return () => { cancelled = true }
+  }, [sourceFilter, toast])
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 20 }}>
+      {/* Header */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+        <button type="button" onClick={onBack} aria-label="Back to tickets"
+          style={{ border: 'none', background: 'none', cursor: 'pointer', padding: 4, color: '#6b7280' }}>
+          <ArrowLeft size={20} />
+        </button>
+        <Heart size={20} color="#ec4899" />
+        <div>
+          <h1 style={{ margin: 0, fontSize: 20, fontWeight: 700 }}>What&rsquo;s Working</h1>
+          <p style={{ margin: '2px 0 0', fontSize: 13, color: '#6b7280' }}>
+            The positive signal users leave — praise, high ratings, and ideas.
+          </p>
+        </div>
+      </div>
+
+      {/* Stats cards */}
+      {stats && (
+        <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap' }}>
+          <div style={statCardStyle('#ec4899')}>
+            <div style={{ fontSize: 24, fontWeight: 700, color: '#ec4899' }}>{stats.positive_last_7_days}</div>
+            <div style={{ fontSize: 13, color: '#6b7280' }}>Positive · last 7 days</div>
+          </div>
+          <div style={statCardStyle('#22c55e')}>
+            <div style={{ fontSize: 24, fontWeight: 700, color: '#22c55e' }}>
+              {stats.thumbs_up_rate == null ? '—' : `${Math.round(stats.thumbs_up_rate * 100)}%`}
+            </div>
+            <div style={{ fontSize: 13, color: '#6b7280' }}>Chat thumbs-up rate</div>
+          </div>
+          <div style={statCardStyle('#3b82f6')}>
+            <div style={{ fontSize: 24, fontWeight: 700, color: '#3b82f6' }}>{stats.by_source.chat}</div>
+            <div style={{ fontSize: 13, color: '#6b7280' }}>Chat up-votes</div>
+          </div>
+          <div style={statCardStyle('#8b5cf6')}>
+            <div style={{ fontSize: 24, fontWeight: 700, color: '#8b5cf6' }}>{stats.by_source.extraction}</div>
+            <div style={{ fontSize: 13, color: '#6b7280' }}>Great extractions</div>
+          </div>
+        </div>
+      )}
+
+      {/* Source filter */}
+      <div style={{ display: 'flex', gap: 8 }}>
+        {(['all', 'chat', 'extraction', 'product'] as const).map((s) => {
+          const active = sourceFilter === s
+          const label = s === 'all' ? 'All' : FEEDBACK_SOURCE_META[s].label
+          return (
+            <button key={s} type="button" onClick={() => setSourceFilter(s)}
+              style={{
+                padding: '6px 12px', borderRadius: 999, fontSize: 13, fontWeight: 600,
+                cursor: 'pointer', border: `1px solid ${active ? '#ec4899' : '#e5e7eb'}`,
+                background: active ? '#fdf2f8' : '#fff', color: active ? '#be185d' : '#6b7280',
+              }}>
+              {label}
+            </button>
+          )
+        })}
+      </div>
+
+      {/* Feed */}
+      <div style={{ background: '#fff', border: '1px solid #e5e7eb', borderRadius: 'var(--ui-radius, 12px)', overflow: 'hidden' }}>
+        {loading ? (
+          <div style={{ padding: 40, textAlign: 'center', color: '#9ca3af' }}>
+            <Loader2 size={20} style={{ animation: 'spin 1s linear infinite' }} />
+          </div>
+        ) : items.length === 0 ? (
+          <div style={{ padding: 40, textAlign: 'center', color: '#9ca3af', fontSize: 14 }}>
+            <Sparkles size={24} style={{ margin: '0 auto 8px', display: 'block', opacity: 0.5 }} />
+            No positive feedback yet. As users leave praise and high ratings, it lands here.
+          </div>
+        ) : (
+          items.map((it, i) => {
+            const meta = FEEDBACK_SOURCE_META[it.source] ?? { label: it.source, color: '#6b7280' }
+            return (
+              <div key={i} style={{
+                padding: '14px 20px', borderBottom: i < items.length - 1 ? '1px solid #f3f4f6' : 'none',
+                display: 'flex', gap: 12, alignItems: 'flex-start',
+              }}>
+                <span style={{
+                  flexShrink: 0, marginTop: 2, padding: '2px 8px', borderRadius: 999, fontSize: 11,
+                  fontWeight: 600, background: `${meta.color}18`, color: meta.color,
+                }}>
+                  {it.sentiment === 'idea' ? 'Idea' : meta.label}
+                </span>
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div style={{ fontSize: 14, color: '#111827', whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
+                    {it.message}
+                  </div>
+                  <div style={{ fontSize: 12, color: '#9ca3af', marginTop: 4 }}>
+                    {timeAgo(it.created_at)}
+                  </div>
+                </div>
+              </div>
+            )
+          })
+        )}
+      </div>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
 // List view — full queue with stats, status filter, and requester-aware rows
 // ---------------------------------------------------------------------------
 
@@ -190,7 +339,7 @@ function ListView({
   classificationFilter, onClassificationFilterChange,
   tagFilter, onTagFilterChange, allTags,
   searchInput, onSearchInputChange, activeSearch,
-  currentUserId, onNew, onSelect,
+  currentUserId, onNew, onSelect, onWhatsWorking,
 }: {
   tickets: SupportTicketSummary[]
   stats: Stats | null
@@ -210,6 +359,7 @@ function ListView({
   currentUserId: string
   onNew: () => void
   onSelect: (uuid: string) => void
+  onWhatsWorking: () => void
 }) {
   const hasFilters =
     statusFilter !== 'open' || priorityFilter !== 'all' ||
@@ -221,10 +371,6 @@ function ListView({
     onTagFilterChange('')
     onSearchInputChange('')
   }
-  const statCardStyle = (color: string): React.CSSProperties => ({
-    flex: 1, padding: '16px 20px', background: '#fff', borderRadius: 'var(--ui-radius, 12px)',
-    border: '1px solid #e5e7eb', borderLeft: `4px solid ${color}`,
-  })
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 20 }}>
@@ -239,16 +385,29 @@ function ListView({
             </p>
           </div>
         </div>
-        <button
-          onClick={onNew}
-          style={{
-            display: 'inline-flex', alignItems: 'center', gap: 6,
-            padding: '8px 14px', borderRadius: 'var(--ui-radius, 12px)', border: 'none',
-            background: '#2563eb', color: '#fff', fontSize: 14, fontWeight: 600, cursor: 'pointer',
-          }}
-        >
-          <Plus size={16} /> New Ticket
-        </button>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <button
+            onClick={onWhatsWorking}
+            style={{
+              display: 'inline-flex', alignItems: 'center', gap: 6,
+              padding: '8px 14px', borderRadius: 'var(--ui-radius, 12px)',
+              border: '1px solid #e5e7eb', background: '#fff',
+              color: '#374151', fontSize: 14, fontWeight: 600, cursor: 'pointer',
+            }}
+          >
+            <Heart size={16} color="#ec4899" /> What&rsquo;s Working
+          </button>
+          <button
+            onClick={onNew}
+            style={{
+              display: 'inline-flex', alignItems: 'center', gap: 6,
+              padding: '8px 14px', borderRadius: 'var(--ui-radius, 12px)', border: 'none',
+              background: '#2563eb', color: '#fff', fontSize: 14, fontWeight: 600, cursor: 'pointer',
+            }}
+          >
+            <Plus size={16} /> New Ticket
+          </button>
+        </div>
       </div>
 
       {/* Stats cards */}


### PR DESCRIPTION
## Why

Vandalizer only listened for pain. Chat thumbs-**down** probed for a comment and could trigger a KB optimization run; thumbs-**up** and high extraction star ratings were stored write-only with **no reader and no follow-up**. The only place that ever invited "what works well" was a one-shot end-of-trial survey field. This gives positive/idea feedback a real home — while keeping problems on the support-ticket rails where they belong.

## Design rule

**Positives ride off-ticket; only problems create tickets.** Praise and ideas must never enter the triage queue or fire the ticket email/Teams fan-out (a compliment can't "close"). Future feedback work should preserve this split.

## What's in it

**Phase 1 — positive signal gets a home (the keystone)**
- New `ProductFeedback` model (`product_feedback` collection, sentiment `positive`|`idea`), registered in Beanie init.
- New `feedback_admin` router at `/api/feedback/admin`, support/admin-gated like `/support/stats`. `/positive` unifies **three sources** — chat thumbs-up *with a comment*, `ExtractionQualityRecord` ≥4★, and `ProductFeedback` — plus a `/stats` rollup (thumbs-up rate, last-7-days count).
- **"What's Working" tab** in `SupportCenter.tsx`.

**Phase 2 — symmetric capture in chat**
- Thumbs-**up** now opens the comment box too (*"What worked well?"*); `handleSubmitComment` carries the actual rating instead of a hardcoded `'down'`. No backend change — the endpoint already accepted comments on up-votes.

**Phase 3 — off-ticket praise**
- `POST /api/feedback/product` writes `ProductFeedback` and never creates a ticket (negative sentiment coerced out). A *"Something working well?"* affordance + `PraiseView` in the support panel; ticket-form copy reframed off bug-only.

## Verification
- frontend `tsc --noEmit` + `eslint` (changed files): clean
- backend `ruff` (changed files): clean; `import app.main`: OK
- `tests/test_feedback_routes.py`: 4/4 pass (admin-gating 403s + product write / sentiment coercion)

## Scope held deliberately
Read-surface only (no weekly digest/notification wiring) and no gamification — the audience is professionals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
