### PR TITLE
feat(extraction): per-field source tracking — click a value to see where it came from

### DIFF
--- a/backend/app/routers/extractions.py
+++ b/backend/app/routers/extractions.py
@@ -973,19 +973,33 @@ async def run_extraction_sync(request: Request, req: RunExtractionSyncRequest, u
                 model=req.model,
                 extraction_config_override=req.extraction_config_override,
                 combined_context=req.combined_context,
+                capture_sources=True,
             )
         await activity_service.activity_finish(activity.id, ActivityStatus.COMPLETED)
+        # Split the per-field source sidecar out of each entity so `results`
+        # keeps its historical flat {field: value} shape. `sources` stays
+        # index-aligned with `results`.
+        from app.services.extraction_sources import SOURCE_KEY
+        sources: list[dict] = []
+        for entity in results:
+            if isinstance(entity, dict):
+                sources.append(entity.pop(SOURCE_KEY, None) or {})
+            else:
+                sources.append({})
         # Merge all result entities into a single normalized map so the
         # activity rail can restore results when the user reopens the run.
         normalized: dict = {}
-        for entity in results:
+        merged_sources: dict = {}
+        for entity, entity_sources in zip(results, sources):
             if isinstance(entity, dict):
                 normalized.update(entity)
+                merged_sources.update(entity_sources)
         await activity_service.activity_update(
             activity.id,
             documents_touched=len(document_uuids),
             result_snapshot={
                 "normalized": normalized,
+                "sources": merged_sources,
                 "document_uuids": document_uuids,
                 "search_set_uuid": req.search_set_uuid,
             },
@@ -995,7 +1009,7 @@ async def run_extraction_sync(request: Request, req: RunExtractionSyncRequest, u
         from app.tasks.quality_tasks import auto_validate_extraction
         auto_validate_extraction.delay(req.search_set_uuid, user.user_id, req.model)
 
-        return {"results": results}
+        return {"results": results, "sources": sources}
     except Exception as e:
         await activity_service.activity_finish(
             activity.id, ActivityStatus.FAILED, error=str(e),

--- a/backend/app/services/extraction_engine.py
+++ b/backend/app/services/extraction_engine.py
@@ -17,6 +17,7 @@ from pydantic import BaseModel, ConfigDict, Field, create_model, model_validator
 from pydantic_ai import Agent, BinaryContent, NativeOutput
 
 from app.models.system_config import DEFAULT_EXTRACTION_CONFIG, _deep_merge
+from app.services.extraction_sources import SOURCE_KEY, resolve_entity_sources
 from app.services.llm_service import (
     build_thinking_model_settings,
     create_chat_agent,
@@ -122,6 +123,8 @@ class ExtractionEngine:
         doc_texts: list[str] | None = None,
         field_metadata: list[dict] | None = None,
         doc_file_paths: list[str] | None = None,
+        capture_sources: bool = False,
+        doc_metadata: list[dict] | None = None,
     ) -> list:
         """Run extraction. Returns list of entity dicts.
 
@@ -134,6 +137,12 @@ class ExtractionEngine:
             doc_texts: Pre-loaded document texts.
             field_metadata: Per-field metadata (is_optional, enum_values) from search set items.
             doc_file_paths: File paths for image-based extraction (used when use_images is enabled).
+            capture_sources: Also ask the LLM for a verbatim supporting passage
+                per field, verified against the document text and attached to
+                each entity under ``SOURCE_KEY``.
+            doc_metadata: Index-aligned with doc_texts; per-doc
+                ``{"uuid", "title", "text_markers"}`` used to resolve source
+                passages to pages. Only consulted when capture_sources is set.
         """
         # Normalize keys
         if isinstance(extract_keys, str):
@@ -160,20 +169,31 @@ class ExtractionEngine:
                 content = self._load_file_content(file_path, model_supports_pdf)
                 if content is not None:
                     doc_results = self._extract_document(
-                        content, key_chunks, model, extraction_cfg, use_repetition, meta_map
+                        content, key_chunks, model, extraction_cfg, use_repetition, meta_map,
+                        capture_sources=capture_sources,
                     )
-                    all_results.extend(doc_results)
                 else:
                     # Fallback to OCR text if file can't be loaded for images
+                    doc_results = []
                     texts = doc_texts or []
                     if idx < len(texts) and texts[idx]:
                         logger.warning(
                             "Image loading failed for %s, falling back to text", file_path
                         )
                         doc_results = self._extract_document(
-                            texts[idx], key_chunks, model, extraction_cfg, use_repetition, meta_map
+                            texts[idx], key_chunks, model, extraction_cfg, use_repetition, meta_map,
+                            capture_sources=capture_sources,
                         )
-                        all_results.extend(doc_results)
+                if doc_results and capture_sources:
+                    # Verify quotes against the doc's extracted text even in
+                    # image mode — an unverifiable quote stays verified=False.
+                    texts = doc_texts or []
+                    self._resolve_sources(
+                        doc_results,
+                        texts[idx] if idx < len(texts) else "",
+                        (doc_metadata or []), idx,
+                    )
+                all_results.extend(doc_results)
             return all_results
 
         # Text-based extraction (default path)
@@ -185,13 +205,21 @@ class ExtractionEngine:
             return []
 
         all_results = []
-        for doc_text in texts:
+        for idx, doc_text in enumerate(texts):
             doc_results = self._extract_document(
-                doc_text, key_chunks, model, extraction_cfg, use_repetition, meta_map
+                doc_text, key_chunks, model, extraction_cfg, use_repetition, meta_map,
+                capture_sources=capture_sources,
             )
+            if doc_results and capture_sources:
+                self._resolve_sources(doc_results, doc_text, (doc_metadata or []), idx)
             all_results.extend(doc_results)
 
         return all_results
+
+    @staticmethod
+    def _resolve_sources(entities: list, doc_text: str, doc_metadata: list[dict], idx: int) -> None:
+        meta = doc_metadata[idx] if idx < len(doc_metadata) else {}
+        resolve_entity_sources(entities, doc_text or "", meta or {})
 
     def build_from_documents(self, doc_texts: list[str], model: str) -> dict | None:
         """Generate extraction entities from document text using LLM."""
@@ -361,13 +389,14 @@ class ExtractionEngine:
         self, content: ExtractionContent, key_chunks: list[list[str]],
         model: str, cfg: dict, use_repetition: bool,
         meta_map: dict[str, dict] | None = None,
+        capture_sources: bool = False,
     ) -> list:
         doc_results = []
         for chunk_keys in key_chunks:
             if use_repetition:
-                chunk_result = self._extract_with_consensus(content, chunk_keys, model, cfg, meta_map)
+                chunk_result = self._extract_with_consensus(content, chunk_keys, model, cfg, meta_map, capture_sources)
             else:
-                chunk_result = self._dispatch_extraction(content, chunk_keys, model, cfg, meta_map)
+                chunk_result = self._dispatch_extraction(content, chunk_keys, model, cfg, meta_map, capture_sources)
             doc_results.extend(chunk_result)
 
         if len(key_chunks) > 1:
@@ -378,7 +407,7 @@ class ExtractionEngine:
     # Dispatch layer (unified for text and multimodal)
     # ------------------------------------------------------------------
 
-    def _dispatch_extraction(self, content: ExtractionContent, keys: list[str], model_name: str, config: dict, meta_map: dict[str, dict] | None = None) -> list:
+    def _dispatch_extraction(self, content: ExtractionContent, keys: list[str], model_name: str, config: dict, meta_map: dict[str, dict] | None = None, capture_sources: bool = False) -> list:
         mode = config.get("mode", "two_pass")
         prompt_variant = config.get("prompt_variant", "default")
 
@@ -387,30 +416,32 @@ class ExtractionEngine:
             thinking = one_pass.get("thinking", True)
             structured = one_pass.get("structured", True)
             pass_model = one_pass.get("model", "") or model_name
-            return self._execute_single_pass(content, keys, pass_model, thinking, structured, meta_map, prompt_variant)
+            return self._execute_single_pass(content, keys, pass_model, thinking, structured, meta_map, prompt_variant, capture_sources)
 
         # two_pass (default)
         two_pass = config.get("two_pass", {})
         pass_1_cfg = two_pass.get("pass_1", {})
         pass_2_cfg = two_pass.get("pass_2", {})
-        return self._execute_two_pass(content, keys, model_name, pass_1_cfg, pass_2_cfg, meta_map, prompt_variant)
+        return self._execute_two_pass(content, keys, model_name, pass_1_cfg, pass_2_cfg, meta_map, prompt_variant, capture_sources)
 
     def _execute_single_pass(
         self, content: ExtractionContent, keys: list[str], model_name: str,
         thinking: bool, structured: bool,
         meta_map: dict[str, dict] | None = None,
         prompt_variant: str = "default",
+        capture_sources: bool = False,
     ) -> list:
         if structured:
-            return self._extract_structured(content, keys, model_name, thinking_override=thinking, meta_map=meta_map, prompt_variant=prompt_variant)
+            return self._extract_structured(content, keys, model_name, thinking_override=thinking, meta_map=meta_map, prompt_variant=prompt_variant, capture_sources=capture_sources)
         else:
-            return self._extract_fallback_json(content, keys, model_name, thinking_override=thinking, meta_map=meta_map, prompt_variant=prompt_variant)
+            return self._extract_fallback_json(content, keys, model_name, thinking_override=thinking, meta_map=meta_map, prompt_variant=prompt_variant, capture_sources=capture_sources)
 
     def _execute_two_pass(
         self, content: ExtractionContent, keys: list[str], model_name: str,
         pass_1_cfg: dict, pass_2_cfg: dict,
         meta_map: dict[str, dict] | None = None,
         prompt_variant: str = "default",
+        capture_sources: bool = False,
     ) -> list:
         p1_model = pass_1_cfg.get("model", "") or model_name
         p1_thinking = pass_1_cfg.get("thinking", True)
@@ -422,9 +453,9 @@ class ExtractionEngine:
 
         # Pass 1
         if p1_structured:
-            draft = self._extract_structured(content, keys, p1_model, thinking_override=p1_thinking, meta_map=meta_map, prompt_variant=prompt_variant)
+            draft = self._extract_structured(content, keys, p1_model, thinking_override=p1_thinking, meta_map=meta_map, prompt_variant=prompt_variant, capture_sources=capture_sources)
         else:
-            draft = self._extract_fallback_json(content, keys, p1_model, thinking_override=p1_thinking, meta_map=meta_map, prompt_variant=prompt_variant)
+            draft = self._extract_fallback_json(content, keys, p1_model, thinking_override=p1_thinking, meta_map=meta_map, prompt_variant=prompt_variant, capture_sources=capture_sources)
 
         draft_hint = self._build_draft_hint(draft)
 
@@ -436,6 +467,11 @@ class ExtractionEngine:
         else:
             p2_content = content
 
+        # When pass 2 only sees the draft summary (multimodal refinement),
+        # any "verbatim passage" it returned would be copied from the draft,
+        # not the document — rely on pass 1's quotes instead.
+        p2_capture = capture_sources and p2_content is content
+
         if p2_structured:
             final = self._extract_structured(
                 p2_content, keys, p2_model,
@@ -444,11 +480,32 @@ class ExtractionEngine:
                 allow_fallback=False,
                 meta_map=meta_map,
                 prompt_variant=prompt_variant,
+                capture_sources=p2_capture,
             )
         else:
-            final = self._extract_fallback_json(p2_content, keys, p2_model, thinking_override=p2_thinking, meta_map=meta_map, prompt_variant=prompt_variant)
+            final = self._extract_fallback_json(p2_content, keys, p2_model, thinking_override=p2_thinking, meta_map=meta_map, prompt_variant=prompt_variant, capture_sources=p2_capture)
 
+        if capture_sources and final and draft:
+            self._backfill_sources(final, draft)
         return final or draft or []
+
+    @staticmethod
+    def _backfill_sources(final: list, draft: list) -> None:
+        """Fill final entities' missing per-field quotes from the draft pass."""
+        draft_sources: dict = {}
+        for entity in draft:
+            if isinstance(entity, dict) and isinstance(entity.get(SOURCE_KEY), dict):
+                for field, src in entity[SOURCE_KEY].items():
+                    draft_sources.setdefault(field, src)
+        if not draft_sources:
+            return
+        for entity in final:
+            if not isinstance(entity, dict):
+                continue
+            sidecar = entity.setdefault(SOURCE_KEY, {})
+            for field, src in draft_sources.items():
+                if field in entity and field not in sidecar:
+                    sidecar[field] = src
 
     @staticmethod
     def _format_draft_as_text(draft: dict, keys: list[str]) -> str:
@@ -476,6 +533,12 @@ class ExtractionEngine:
         for item in results:
             if isinstance(item, dict):
                 for k, v in item.items():
+                    if k == SOURCE_KEY:
+                        if isinstance(v, dict):
+                            sidecar = merged.setdefault(SOURCE_KEY, {})
+                            for field, src in v.items():
+                                sidecar.setdefault(field, src)
+                        continue
                     if k not in merged or merged[k] in (None, "", [], {}):
                         merged[k] = v
         return [merged] if merged else []
@@ -484,24 +547,51 @@ class ExtractionEngine:
     # Repetition / Consensus
     # ------------------------------------------------------------------
 
-    def _extract_with_consensus(self, content: ExtractionContent, keys: list[str], model_name: str, config: dict, meta_map: dict[str, dict] | None = None) -> list:
+    def _extract_with_consensus(self, content: ExtractionContent, keys: list[str], model_name: str, config: dict, meta_map: dict[str, dict] | None = None, capture_sources: bool = False) -> list:
         with ThreadPoolExecutor(max_workers=2) as executor:
-            future_1 = executor.submit(self._dispatch_extraction, content, keys, model_name, config, meta_map)
-            future_2 = executor.submit(self._dispatch_extraction, content, keys, model_name, config, meta_map)
+            future_1 = executor.submit(self._dispatch_extraction, content, keys, model_name, config, meta_map, capture_sources)
+            future_2 = executor.submit(self._dispatch_extraction, content, keys, model_name, config, meta_map, capture_sources)
             result_1 = future_1.result()
             result_2 = future_2.result()
 
-        norm_1 = self._normalize_to_dict(result_1)
-        norm_2 = self._normalize_to_dict(result_2)
+        # Quotes legitimately vary between replicates, so the source sidecar
+        # must not participate in the agreement check or the vote.
+        norm_1 = self._strip_sources(self._normalize_to_dict(result_1))
+        norm_2 = self._strip_sources(self._normalize_to_dict(result_2))
 
         if norm_1 == norm_2:
             return result_1 if result_1 else result_2
 
-        result_3 = self._dispatch_extraction(content, keys, model_name, config, meta_map)
-        norm_3 = self._normalize_to_dict(result_3)
+        result_3 = self._dispatch_extraction(content, keys, model_name, config, meta_map, capture_sources)
+        norm_3 = self._strip_sources(self._normalize_to_dict(result_3))
 
         consensus = self._majority_vote(keys, [norm_1, norm_2, norm_3])
+        if capture_sources:
+            sidecar = self._sidecar_for_consensus(
+                consensus, [norm_1, norm_2, norm_3],
+                [self._normalize_to_dict(r) for r in (result_1, result_2, result_3)],
+            )
+            if sidecar:
+                consensus[SOURCE_KEY] = sidecar
         return [consensus]
+
+    @staticmethod
+    def _strip_sources(entity: dict) -> dict:
+        return {k: v for k, v in entity.items() if k != SOURCE_KEY}
+
+    @staticmethod
+    def _sidecar_for_consensus(consensus: dict, norms: list[dict], fulls: list[dict]) -> dict:
+        """Per field, take the quote from a replicate that voted with the winner."""
+        sidecar: dict = {}
+        for field, value in consensus.items():
+            for norm, full in zip(norms, fulls):
+                if norm.get(field) != value:
+                    continue
+                src = (full.get(SOURCE_KEY) or {}).get(field) if isinstance(full.get(SOURCE_KEY), dict) else None
+                if src:
+                    sidecar[field] = src
+                    break
+        return sidecar
 
     def _normalize_to_dict(self, results: list) -> dict:
         if not results:
@@ -537,15 +627,17 @@ class ExtractionEngine:
         if not draft_entities:
             return None
         if isinstance(draft_entities, dict):
-            return draft_entities
+            return self._strip_sources(draft_entities) or None
         if isinstance(draft_entities, list):
             if len(draft_entities) == 1 and isinstance(draft_entities[0], dict):
-                return draft_entities[0]
+                return self._strip_sources(draft_entities[0]) or None
             merged = {}
             for entity in draft_entities:
                 if not isinstance(entity, dict):
                     continue
                 for key, value in entity.items():
+                    if key == SOURCE_KEY:
+                        continue
                     if key in merged:
                         continue
                     if value in (None, "", [], {}):
@@ -675,6 +767,7 @@ class ExtractionEngine:
         allow_fallback: bool = True,
         meta_map: dict[str, dict] | None = None,
         prompt_variant: str = "default",
+        capture_sources: bool = False,
     ) -> list:
         # Build dynamic Pydantic model
         field_definitions = {}
@@ -710,9 +803,22 @@ class ExtractionEngine:
             **field_definitions,
         )
 
+        # Source quotes reuse the same safe-key/alias mapping but are always
+        # plain strings (a verbatim passage, even for enum fields).
+        DynamicSources = create_model(
+            "DynamicSources",
+            __config__=ConfigDict(extra="allow", populate_by_name=True),
+            **{
+                safe_key: (Optional[str], Field(default=None, alias=defn[1].alias))
+                for safe_key, defn in field_definitions.items()
+            },
+        )
+
         class ExtractionModel(BaseModel):
             model_config = ConfigDict(extra="allow")
             entities: List[DynamicEntity]
+            if capture_sources:
+                sources: Optional[List[DynamicSources]] = None
 
             @model_validator(mode="before")
             @classmethod
@@ -738,6 +844,17 @@ class ExtractionEngine:
 
         source_label = self._describe_content(content)
         system_prompt = _resolve_prompt(prompt_variant, source_label)
+        if capture_sources:
+            # Appended as a separate clause — the variant prompts themselves
+            # are pinned to the optimizer's tuned baselines (see PROMPT_VARIANTS).
+            system_prompt += (
+                " Additionally return a 'sources' key: a list aligned one-to-one with 'entities', "
+                "where each item maps the same field names to the exact contiguous passage from the "
+                "document that the field's value came from — copied character-for-character, including "
+                "punctuation and capitalization, at most a few hundred characters (the sentence or line "
+                "containing the value). For yes/no or judgment fields, give the passage that best supports "
+                "the answer. Use null when a field was not found. Never paraphrase these passages."
+            )
         system_prompt += self._get_domain_supplement()
 
         try:
@@ -783,6 +900,15 @@ class ExtractionEngine:
                 elif isinstance(entity, dict):
                     raw_entities.append(entity)
 
+            if capture_sources:
+                raw_sources = []
+                for src in getattr(result.output, "sources", None) or []:
+                    if hasattr(src, "model_dump"):
+                        raw_sources.append(src.model_dump(by_alias=True))
+                    elif isinstance(src, dict):
+                        raw_sources.append(src)
+                self._attach_source_quotes(raw_entities, raw_sources)
+
             return self._filter_empty_entities(raw_entities)
 
         except Exception as e:
@@ -790,15 +916,36 @@ class ExtractionEngine:
             if ("output validation" in error_msg or "retries" in error_msg.lower()
                     or "validation error" in error_msg.lower()):
                 if allow_fallback:
-                    return self._extract_fallback_json(content, keys, model_name, thinking_override=thinking_override, meta_map=meta_map, prompt_variant=prompt_variant)
+                    return self._extract_fallback_json(content, keys, model_name, thinking_override=thinking_override, meta_map=meta_map, prompt_variant=prompt_variant, capture_sources=capture_sources)
                 return []
             return []
+
+    @staticmethod
+    def _attach_source_quotes(entities: list, sources: list) -> None:
+        """Attach raw per-field quotes as the SOURCE_KEY sidecar, index-aligned."""
+        for i, entity in enumerate(entities):
+            if not isinstance(entity, dict):
+                continue
+            src = sources[i] if i < len(sources) else (sources[0] if len(sources) == 1 else None)
+            if not isinstance(src, dict):
+                continue
+            sidecar = {
+                field: {"quote": quote.strip()}
+                for field, quote in src.items()
+                if isinstance(quote, str) and quote.strip() and field in entity
+            }
+            if sidecar:
+                entity[SOURCE_KEY] = sidecar
 
     def _filter_empty_entities(self, entities: list) -> list:
         def is_non_empty(e: dict) -> bool:
             if not isinstance(e, dict) or not e:
                 return False
-            return any(v not in (None, "", [], {}) for v in e.values())
+            return any(
+                v not in (None, "", [], {})
+                for k, v in e.items()
+                if k != SOURCE_KEY
+            )
         return [e for e in entities if is_non_empty(e)]
 
     # ------------------------------------------------------------------
@@ -813,6 +960,7 @@ class ExtractionEngine:
         thinking_override: Optional[bool] = None,
         meta_map: dict[str, dict] | None = None,
         prompt_variant: str = "default",
+        capture_sources: bool = False,
     ) -> list:
         try:
             source_label = self._describe_content(content)
@@ -826,6 +974,15 @@ class ExtractionEngine:
             system_prompt += (
                 " Return ONLY valid JSON, no markdown formatting, no code blocks, no explanations."
             )
+            if capture_sources:
+                system_prompt += (
+                    ' Also include a "_sources" key in the JSON object: an object mapping each '
+                    "field name to the exact contiguous passage from the document that the "
+                    "field's value came from — copied character-for-character, at most a few "
+                    "hundred characters. For yes/no or judgment fields, give the passage that "
+                    "best supports the answer. Use null when a field was not found. Never "
+                    "paraphrase these passages."
+                )
             system_prompt += self._get_domain_supplement()
 
             chat_agent = create_chat_agent(
@@ -847,6 +1004,14 @@ class ExtractionEngine:
                 parsed = json.loads(output.strip())
                 if isinstance(parsed, dict):
                     entity = {key: parsed.get(key) for key in keys}
+                    if capture_sources and isinstance(parsed.get("_sources"), dict):
+                        sidecar = {
+                            field: {"quote": quote.strip()}
+                            for field, quote in parsed["_sources"].items()
+                            if isinstance(quote, str) and quote.strip() and field in entity
+                        }
+                        if sidecar:
+                            entity[SOURCE_KEY] = sidecar
                     return [entity]
                 elif isinstance(parsed, list):
                     return parsed

--- a/backend/app/services/extraction_sources.py
+++ b/backend/app/services/extraction_sources.py
@@ -1,0 +1,160 @@
+"""Per-field source tracking for extractions.
+
+The extraction engine asks the LLM for a verbatim supporting passage per
+field (stored under ``SOURCE_KEY`` on each entity dict). This module then
+verifies each passage against the document text it was extracted from and
+resolves the page it appears on via the document's ``text_markers``
+(see ``SmartDocument.text_markers`` / ``document_readers.extract_text_with_markers``).
+
+A passage that cannot be located in the document — even after unicode
+normalization — is marked ``verified: False``, which the frontend surfaces
+as "no source found": both a traceability gap and a hallucination signal.
+
+Pure string/offset logic only; no DB or LLM access, safe to import anywhere.
+"""
+
+from typing import Optional
+
+# Reserved sidecar key on entity dicts: {field_name: source dict}. Every
+# consumer that iterates entity items must skip it (normalize_results,
+# draft hints, consensus votes, chunk merges).
+SOURCE_KEY = "_field_sources"
+
+# 1:1-or-expanding character folds applied to both document text and quotes
+# before matching. LLM output routinely differs from PDF text layers by
+# smart quotes, dash variants, NBSP, and ligatures.
+_CHAR_MAP = {
+    # curly quotes -> straight
+    "\u2018": "'", "\u2019": "'", "\u201a": "'", "\u201b": "'",
+    "\u201c": '"', "\u201d": '"', "\u201e": '"',
+    # hyphen/dash variants -> "-"
+    "\u2010": "-", "\u2011": "-", "\u2012": "-", "\u2013": "-",
+    "\u2014": "-", "\u2015": "-", "\u2212": "-",
+    # NBSP / figure / thin / narrow no-break space -> " "
+    "\u00a0": " ", "\u2007": " ", "\u2009": " ", "\u202f": " ",
+    # ligatures
+    "\ufb01": "fi", "\ufb02": "fl",
+}
+
+# Zero-width / joining characters dropped entirely: soft hyphen, BOM,
+# zero-width space / non-joiner / joiner.
+_DROP_CHARS = {"\u00ad", "\ufeff", "\u200b", "\u200c", "\u200d"}
+
+
+def normalize_with_map(text: str) -> tuple[str, list[int]]:
+    """Lowercase + fold + whitespace-collapse *text*.
+
+    Returns ``(normalized, index_map)`` where ``index_map[i]`` is the offset
+    in the original text of the character that produced ``normalized[i]``,
+    so matches in normalized space can be projected back to real offsets.
+    """
+    out: list[str] = []
+    index_map: list[int] = []
+    last_was_space = True  # trims leading whitespace
+    for i, ch in enumerate(text):
+        if ch in _DROP_CHARS:
+            continue
+        folded = _CHAR_MAP.get(ch, ch)
+        for c in folded:
+            if c.isspace():
+                if last_was_space:
+                    continue
+                out.append(" ")
+                index_map.append(i)
+                last_was_space = True
+            else:
+                out.append(c.lower())
+                index_map.append(i)
+                last_was_space = False
+    if out and out[-1] == " ":
+        out.pop()
+        index_map.pop()
+    return "".join(out), index_map
+
+
+def find_quote_offset(doc_text: str, quote: str,
+                      normalized: tuple[str, list[int]] | None = None) -> Optional[int]:
+    """Locate *quote* in *doc_text*, returning the original char offset.
+
+    Tries an exact match first, then a normalized match. Pass a pre-built
+    ``normalize_with_map(doc_text)`` result via *normalized* to amortize the
+    normalization cost across many quotes in the same document.
+    """
+    if not doc_text or not quote:
+        return None
+    idx = doc_text.find(quote)
+    if idx != -1:
+        return idx
+
+    norm_doc, index_map = normalized if normalized is not None else normalize_with_map(doc_text)
+    norm_quote, _ = normalize_with_map(quote)
+    if not norm_quote:
+        return None
+    nidx = norm_doc.find(norm_quote)
+    if nidx == -1:
+        return None
+    return index_map[nidx]
+
+
+def page_for_offset(offset: int, markers: list[dict]) -> Optional[int]:
+    """Page number of the most recent ``kind: "page"`` marker at or before *offset*."""
+    page: Optional[int] = None
+    for m in markers or []:
+        if m.get("char_offset", 0) > offset:
+            break
+        if m.get("kind") == "page":
+            value = m.get("value")
+            if isinstance(value, int):
+                page = value
+    return page
+
+
+def _doc_for_offset(offset: int, doc_spans: list[dict]) -> Optional[dict]:
+    for span in doc_spans or []:
+        if span.get("start", 0) <= offset < span.get("end", 0):
+            return span
+    return None
+
+
+def resolve_entity_sources(entities: list, doc_text: str, doc_meta: dict) -> None:
+    """Verify and locate each entity's raw source quotes, in place.
+
+    The engine attaches ``entity[SOURCE_KEY] = {field: {"quote": str}}``.
+    This fills each entry out to::
+
+        {"quote", "page", "document_uuid", "document_title", "verified"}
+
+    *doc_meta* carries ``uuid``, ``title``, ``text_markers``, and (for
+    combined-context runs over a merged text) optional ``doc_spans`` —
+    ``[{"start", "end", "uuid", "title"}]`` — used to attribute an offset to
+    the document that contributed it.
+    """
+    markers = doc_meta.get("text_markers") or []
+    doc_spans = doc_meta.get("doc_spans") or []
+    normalized = normalize_with_map(doc_text) if doc_text else ("", [])
+
+    for entity in entities:
+        if not isinstance(entity, dict):
+            continue
+        sidecar = entity.get(SOURCE_KEY)
+        if not isinstance(sidecar, dict):
+            continue
+        for field, src in list(sidecar.items()):
+            quote = src.get("quote") if isinstance(src, dict) else None
+            if isinstance(quote, str):
+                quote = quote.strip() or None
+            offset = find_quote_offset(doc_text, quote, normalized) if quote else None
+            doc_uuid = doc_meta.get("uuid")
+            doc_title = doc_meta.get("title")
+            if offset is not None and doc_spans:
+                span = _doc_for_offset(offset, doc_spans)
+                if span:
+                    doc_uuid = span.get("uuid")
+                    doc_title = span.get("title")
+            sidecar[field] = {
+                "quote": quote,
+                "page": page_for_offset(offset, markers) if offset is not None else None,
+                "document_uuid": doc_uuid,
+                "document_title": doc_title,
+                "verified": offset is not None,
+            }

--- a/backend/app/services/search_set_service.py
+++ b/backend/app/services/search_set_service.py
@@ -498,8 +498,14 @@ async def run_extraction_sync(
     model: str | None = None,
     extraction_config_override: dict | None = None,
     combined_context: bool = False,
+    capture_sources: bool = False,
 ) -> list:
-    """Run extraction synchronously via asyncio.to_thread."""
+    """Run extraction synchronously via asyncio.to_thread.
+
+    With ``capture_sources``, each returned entity carries a
+    ``SOURCE_KEY`` sidecar mapping field names to the verified verbatim
+    passage + page the value came from (see ``extraction_sources``).
+    """
     keys = await get_extraction_keys(search_set_uuid)
     if not keys:
         logger.warning(
@@ -541,9 +547,15 @@ async def run_extraction_sync(
 
     doc_texts: list[str] = []
     doc_file_paths: list[str] = []
+    doc_metadata: list[dict] = []
     empty_text_docs: list[str] = []
     for doc_uuid in document_uuids:
         doc = await SmartDocument.find_one(SmartDocument.uuid == doc_uuid)
+        doc_metadata.append({
+            "uuid": doc_uuid,
+            "title": doc.title if doc else None,
+            "text_markers": (doc.text_markers if doc else None) or [],
+        })
         if doc and doc.raw_text:
             doc_texts.append(doc.raw_text)
         else:
@@ -568,10 +580,37 @@ async def run_extraction_sync(
     if not any(doc_texts) and not any(doc_file_paths):
         return []
 
-    # Combined context: merge all documents into a single text for extraction
+    # Combined context: merge all documents into a single text for extraction.
+    # Markers and per-doc spans are re-offset into the merged text so source
+    # passages still resolve to the right page and document.
     if combined_context and len(doc_texts) > 1:
-        merged = "\n\n---\n\n".join(t for t in doc_texts if t)
-        doc_texts = [merged]
+        sep = "\n\n---\n\n"
+        merged_parts: list[str] = []
+        merged_markers: list[dict] = []
+        doc_spans: list[dict] = []
+        cursor = 0
+        for text, meta in zip(doc_texts, doc_metadata):
+            if not text:
+                continue
+            if merged_parts:
+                cursor += len(sep)
+            for m in meta.get("text_markers") or []:
+                merged_markers.append({**m, "char_offset": m.get("char_offset", 0) + cursor})
+            doc_spans.append({
+                "start": cursor,
+                "end": cursor + len(text),
+                "uuid": meta.get("uuid"),
+                "title": meta.get("title"),
+            })
+            merged_parts.append(text)
+            cursor += len(text)
+        doc_texts = [sep.join(merged_parts)]
+        doc_metadata = [{
+            "uuid": None,
+            "title": None,
+            "text_markers": merged_markers,
+            "doc_spans": doc_spans,
+        }]
         doc_file_paths = []  # image mode not supported for combined
 
     # Resolve model
@@ -603,5 +642,7 @@ async def run_extraction_sync(
         extraction_config_override=combined_override or None,
         field_metadata=field_metadata,
         doc_file_paths=doc_file_paths,
+        capture_sources=capture_sources,
+        doc_metadata=doc_metadata,
     )
     return result

--- a/backend/app/tasks/extraction_tasks.py
+++ b/backend/app/tasks/extraction_tasks.py
@@ -38,6 +38,10 @@ def normalize_results(results, expected_keys: list[str] | None = None) -> dict[s
             if not isinstance(item, dict):
                 continue
             for k, v in item.items():
+                # Reserved source-tracking sidecar (dict-valued — unhashable,
+                # and not a field value anyway).
+                if k == "_field_sources":
+                    continue
                 if v in (None, "", [], {}):
                     continue
                 if v in seen[k]:

--- a/backend/tests/test_extraction_sources.py
+++ b/backend/tests/test_extraction_sources.py
@@ -1,0 +1,251 @@
+"""Tests for per-field extraction source tracking.
+
+Covers the pure resolution logic in ``extraction_sources`` and the engine's
+sidecar plumbing (capture, merge, draft, consensus, filtering).
+"""
+
+from unittest.mock import MagicMock, patch
+
+from app.services.extraction_engine import ExtractionEngine
+from app.services.extraction_sources import (
+    SOURCE_KEY,
+    find_quote_offset,
+    normalize_with_map,
+    page_for_offset,
+    resolve_entity_sources,
+)
+from app.tasks.extraction_tasks import normalize_results
+
+
+# ---------------------------------------------------------------------------
+# normalize_with_map / find_quote_offset
+# ---------------------------------------------------------------------------
+
+class TestNormalization:
+    def test_lowercase_and_whitespace_collapse(self):
+        norm, idx_map = normalize_with_map("  Hello\n\n  World  ")
+        assert norm == "hello world"
+        assert len(idx_map) == len(norm)
+        # 'h' maps back to the original 'H'
+        assert idx_map[0] == 2
+
+    def test_smart_quotes_and_dashes_fold(self):
+        norm, _ = normalize_with_map("“terms” — and ‘conditions’")
+        assert norm == '"terms" - and \'conditions\''
+
+    def test_ligature_expansion_keeps_map_aligned(self):
+        norm, idx_map = normalize_with_map("eﬀective" if False else "ﬁnal")
+        assert norm == "final"
+        # both expanded chars map to the ligature's original index
+        assert idx_map[0] == idx_map[1] == 0
+
+    def test_exact_match_wins(self):
+        doc = "Effective December 31, 2025"
+        assert find_quote_offset(doc, "December 31") == 10
+
+    def test_normalized_match(self):
+        doc = "the award’s terms—fully"
+        assert find_quote_offset(doc, "the award's terms-fully") == 0
+
+    def test_no_match_returns_none(self):
+        assert find_quote_offset("some document text", "absent passage") is None
+        assert find_quote_offset("", "quote") is None
+        assert find_quote_offset("doc", "") is None
+
+
+# ---------------------------------------------------------------------------
+# page_for_offset / resolve_entity_sources
+# ---------------------------------------------------------------------------
+
+MARKERS = [
+    {"char_offset": 0, "kind": "page", "value": 1},
+    {"char_offset": 100, "kind": "page", "value": 2},
+    {"char_offset": 200, "kind": "page", "value": 3},
+]
+
+
+class TestPageResolution:
+    def test_page_for_offset(self):
+        assert page_for_offset(0, MARKERS) == 1
+        assert page_for_offset(150, MARKERS) == 2
+        assert page_for_offset(500, MARKERS) == 3
+        assert page_for_offset(5, []) is None
+
+    def test_non_page_markers_ignored(self):
+        markers = [{"char_offset": 0, "kind": "sheet", "value": "Sheet1"}]
+        assert page_for_offset(10, markers) is None
+
+    def test_resolve_verified_and_unverified(self):
+        doc = "a" * 120 + "Cost sharing is required for this award." + "b" * 60
+        entities = [{
+            "Cost Sharing": "Yes",
+            SOURCE_KEY: {
+                "Cost Sharing": {"quote": "Cost sharing is required for this award."},
+                "Award Number": {"quote": "not actually in the document"},
+            },
+        }]
+        resolve_entity_sources(entities, doc, {"uuid": "U1", "title": "T&C", "text_markers": MARKERS})
+        src = entities[0][SOURCE_KEY]["Cost Sharing"]
+        assert src == {
+            "quote": "Cost sharing is required for this award.",
+            "page": 2,
+            "document_uuid": "U1",
+            "document_title": "T&C",
+            "verified": True,
+        }
+        missing = entities[0][SOURCE_KEY]["Award Number"]
+        assert missing["verified"] is False
+        assert missing["page"] is None
+
+    def test_resolve_combined_doc_spans(self):
+        doc = "first document text" + "\n\n---\n\n" + "second document text"
+        spans = [
+            {"start": 0, "end": 19, "uuid": "D1", "title": "One"},
+            {"start": 26, "end": 46, "uuid": "D2", "title": "Two"},
+        ]
+        entities = [{
+            "F": "v",
+            SOURCE_KEY: {"F": {"quote": "second document"}},
+        }]
+        resolve_entity_sources(entities, doc, {"uuid": None, "title": None,
+                                               "text_markers": [], "doc_spans": spans})
+        src = entities[0][SOURCE_KEY]["F"]
+        assert src["verified"] is True
+        assert src["document_uuid"] == "D2"
+        assert src["document_title"] == "Two"
+
+
+# ---------------------------------------------------------------------------
+# Engine sidecar plumbing
+# ---------------------------------------------------------------------------
+
+def _engine():
+    return ExtractionEngine(system_config_doc={})
+
+
+class TestEngineSidecarHelpers:
+    def test_merge_chunk_results_merges_sidecars(self):
+        merged = _engine()._merge_chunk_results([
+            {"A": "1", SOURCE_KEY: {"A": {"quote": "qa"}}},
+            {"B": "2", SOURCE_KEY: {"B": {"quote": "qb"}}},
+        ])
+        assert merged == [{"A": "1", "B": "2",
+                           SOURCE_KEY: {"A": {"quote": "qa"}, "B": {"quote": "qb"}}}]
+
+    def test_draft_hint_strips_sidecar(self):
+        hint = _engine()._build_draft_hint([{"A": "1", SOURCE_KEY: {"A": {"quote": "qa"}}}])
+        assert hint == {"A": "1"}
+
+    def test_filter_drops_sidecar_only_entities(self):
+        assert _engine()._filter_empty_entities([{SOURCE_KEY: {"A": {"quote": "q"}}}]) == []
+        kept = _engine()._filter_empty_entities([{"A": "1", SOURCE_KEY: {"A": {"quote": "q"}}}])
+        assert len(kept) == 1
+
+    def test_attach_source_quotes(self):
+        entities = [{"A": "1", "B": None}]
+        ExtractionEngine._attach_source_quotes(entities, [{"A": " qa ", "B": None, "C": "orphan"}])
+        assert entities[0][SOURCE_KEY] == {"A": {"quote": "qa"}}
+
+    def test_backfill_sources_from_draft(self):
+        final = [{"A": "1", "B": "2", SOURCE_KEY: {"A": {"quote": "final-a"}}}]
+        draft = [{"A": "1", "B": "2", SOURCE_KEY: {"A": {"quote": "draft-a"}, "B": {"quote": "draft-b"}}}]
+        ExtractionEngine._backfill_sources(final, draft)
+        assert final[0][SOURCE_KEY]["A"] == {"quote": "final-a"}  # final wins
+        assert final[0][SOURCE_KEY]["B"] == {"quote": "draft-b"}  # backfilled
+
+    def test_sidecar_for_consensus_takes_agreeing_replicate(self):
+        consensus = {"A": "1"}
+        norms = [{"A": "2"}, {"A": "1"}, {"A": "1"}]
+        fulls = [
+            {"A": "2", SOURCE_KEY: {"A": {"quote": "wrong"}}},
+            {"A": "1", SOURCE_KEY: {"A": {"quote": "right"}}},
+            {"A": "1"},
+        ]
+        sidecar = ExtractionEngine._sidecar_for_consensus(consensus, norms, fulls)
+        assert sidecar == {"A": {"quote": "right"}}
+
+
+class TestNormalizeResultsSkipsSidecar:
+    def test_sidecar_ignored(self):
+        results = [{"A": "1", SOURCE_KEY: {"A": {"quote": "q"}}}]
+        normalized = normalize_results(results)
+        assert normalized == {"A": "1"}
+
+
+# ---------------------------------------------------------------------------
+# End-to-end (mocked LLM): capture_sources through extract()
+# ---------------------------------------------------------------------------
+
+def _make_structured_result_with_sources(entities_data, sources_data):
+    mock = MagicMock()
+
+    class FakeDump:
+        def __init__(self, data):
+            self._data = data
+
+        def model_dump(self, by_alias=False):
+            return self._data
+
+    class FakeOutput:
+        def __init__(self, entities, sources):
+            self.entities = [FakeDump(e) for e in entities]
+            self.sources = [FakeDump(s) for s in sources]
+
+    mock.output = FakeOutput(entities_data, sources_data)
+    usage = MagicMock()
+    usage.request_tokens = 10
+    usage.response_tokens = 5
+    mock.usage.return_value = usage
+    return mock
+
+
+class TestExtractWithCaptureSources:
+    @patch("app.services.extraction_engine.Agent")
+    @patch("app.services.extraction_engine.get_agent_model")
+    def test_capture_resolves_page_and_verification(self, mock_get_model, mock_agent_cls):
+        doc_text = "x" * 110 + "Effective December 31, 2025." + "y" * 40
+        mock_agent = mock_agent_cls.return_value
+        mock_agent.run_sync.return_value = _make_structured_result_with_sources(
+            [{"Effective Date": "December 31, 2025", "Award Number": "AB-123"}],
+            [{"Effective Date": "Effective December 31, 2025.",
+              "Award Number": "hallucinated passage"}],
+        )
+
+        engine = ExtractionEngine(system_config_doc={})
+        results = engine.extract(
+            ["Effective Date", "Award Number"],
+            doc_texts=[doc_text],
+            model="test-model",
+            extraction_config_override={"mode": "one_pass",
+                                        "one_pass": {"structured": True}},
+            capture_sources=True,
+            doc_metadata=[{"uuid": "DOC1", "title": "USDA T&C", "text_markers": MARKERS}],
+        )
+
+        assert len(results) == 1
+        sidecar = results[0][SOURCE_KEY]
+        assert sidecar["Effective Date"]["verified"] is True
+        assert sidecar["Effective Date"]["page"] == 2
+        assert sidecar["Effective Date"]["document_uuid"] == "DOC1"
+        assert sidecar["Award Number"]["verified"] is False
+
+        # The system prompt asked for sources
+        system_prompt = mock_agent_cls.call_args.kwargs.get("system_prompt", "")
+        assert "'sources'" in system_prompt
+
+    @patch("app.services.extraction_engine.Agent")
+    @patch("app.services.extraction_engine.get_agent_model")
+    def test_no_capture_keeps_prompt_and_results_clean(self, mock_get_model, mock_agent_cls):
+        mock_agent = mock_agent_cls.return_value
+        mock_agent.run_sync.return_value = _make_structured_result_with_sources(
+            [{"A": "1"}], [],
+        )
+        engine = ExtractionEngine(system_config_doc={})
+        results = engine.extract(
+            ["A"], doc_texts=["some text"], model="test-model",
+            extraction_config_override={"mode": "one_pass",
+                                        "one_pass": {"structured": True}},
+        )
+        assert results == [{"A": "1"}]
+        system_prompt = mock_agent_cls.call_args.kwargs.get("system_prompt", "")
+        assert "'sources'" not in system_prompt

--- a/frontend/src/api/extractions.ts
+++ b/frontend/src/api/extractions.ts
@@ -91,6 +91,20 @@ export function suggestFields(documentUuids: string[], model?: string) {
 
 // Run extraction
 
+// Where an extracted value came from, as traced by the backend: the verbatim
+// passage the LLM cited, verified against the document text and resolved to a
+// page via the document's text markers. `verified: false` means the passage
+// could not be found in the document — the value may not be reliable.
+export interface ExtractionFieldSource {
+  quote: string | null
+  page: number | null
+  document_uuid: string | null
+  document_title: string | null
+  verified: boolean
+}
+
+export type ExtractionSourceMap = Record<string, ExtractionFieldSource>
+
 export function runExtractionSync(data: {
   search_set_uuid: string
   document_uuids: string[]
@@ -98,7 +112,8 @@ export function runExtractionSync(data: {
   extraction_config_override?: Record<string, unknown>
   combined_context?: boolean
 }, signal?: AbortSignal) {
-  return apiFetch<{ results: unknown[] }>('/api/extractions/run-sync', {
+  // `sources` is index-aligned with `results` (per-field source map per entity).
+  return apiFetch<{ results: unknown[]; sources?: ExtractionSourceMap[] }>('/api/extractions/run-sync', {
     method: 'POST',
     body: JSON.stringify(data),
     signal,

--- a/frontend/src/components/files/DocumentViewer.tsx
+++ b/frontend/src/components/files/DocumentViewer.tsx
@@ -5,6 +5,7 @@ import { pollStatus, retryExtraction } from '../../api/documents'
 import { SpreadsheetViewer } from './SpreadsheetViewer'
 import { DocumentSearchBar, useFindInDocumentHotkey } from './DocumentSearchBar'
 import { stageCopy } from '../../utils/processingStatus'
+import { normalizeWithMap } from '../../utils/textMatch'
 import DOMPurify from 'dompurify'
 import { marked } from 'marked'
 import * as pdfjsLib from 'pdfjs-dist/legacy/build/pdf.mjs'
@@ -15,6 +16,10 @@ pdfjsLib.GlobalWorkerOptions.workerSrc = pdfjsWorker
 interface DocumentViewerProps {
   docUuid: string
   highlightTerms?: string[]
+  // 1-based page hint for highlightTerms (extraction source tracking). Used
+  // to prefer matches on that page, and to still jump the viewer there when
+  // the passage can't be text-matched at all.
+  highlightPage?: number | null
   onClearHighlights?: () => void
   processing?: boolean
   taskStatus?: string | null
@@ -112,7 +117,7 @@ function highlightHtmlSearch(root: HTMLElement, query: string): number {
   return count
 }
 
-export function DocumentViewer({ docUuid, highlightTerms = [], onClearHighlights, processing, taskStatus }: DocumentViewerProps) {
+export function DocumentViewer({ docUuid, highlightTerms = [], highlightPage = null, onClearHighlights, processing, taskStatus }: DocumentViewerProps) {
   const [zoom, setZoom] = useState(2) // index into ZOOM_LEVELS, default 100%
   const [isPdf, setIsPdf] = useState<boolean | null>(null) // null = loading
   const [isSpreadsheet, setIsSpreadsheet] = useState(false)
@@ -127,6 +132,9 @@ export function DocumentViewer({ docUuid, highlightTerms = [], onClearHighlights
   const renderingRef = useRef(false)
   const [totalHighlights, setTotalHighlights] = useState(0)
   const [currentHighlight, setCurrentHighlight] = useState(0)
+  // True when highlight terms were requested but nothing matched — drives
+  // the explicit "not found" feedback instead of silently doing nothing.
+  const [highlightMiss, setHighlightMiss] = useState(false)
 
   // In-document find (Cmd/Ctrl+F)
   const rootRef = useRef<HTMLDivElement>(null)
@@ -162,6 +170,9 @@ export function DocumentViewer({ docUuid, highlightTerms = [], onClearHighlights
     }
     return highlightTerms
   }, [searchOpen, searchQuery, highlightTerms])
+
+  // Page hint only applies to extraction-driven highlights, not the find bar.
+  const effectivePage = searchOpen ? null : highlightPage
 
   // Detect file type, then route to the right loader.
   //
@@ -334,11 +345,11 @@ export function DocumentViewer({ docUuid, highlightTerms = [], onClearHighlights
   // Re-apply highlights when terms change
   useEffect(() => {
     if (isPdf !== true || !pdfDocRef.current) return
-    applyHighlights(pdfDocRef.current, effectiveTerms).catch(err => {
+    applyHighlights(pdfDocRef.current, effectiveTerms, effectivePage).catch(err => {
       console.error('[DocumentViewer] applyHighlights failed:', err)
     })
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [effectiveTerms])
+  }, [effectiveTerms, effectivePage])
 
   const renderAllPages = useCallback(async (doc: pdfjsLib.PDFDocumentProxy) => {
     if (renderingRef.current) return
@@ -400,13 +411,13 @@ export function DocumentViewer({ docUuid, highlightTerms = [], onClearHighlights
 
     // Apply highlights after rendering
     if (effectiveTerms.length > 0) {
-      applyHighlights(doc, effectiveTerms).catch(err => {
+      applyHighlights(doc, effectiveTerms, effectivePage).catch(err => {
         console.error('[DocumentViewer] applyHighlights failed:', err)
       })
     }
-  }, [zoomLevel, effectiveTerms])
+  }, [zoomLevel, effectiveTerms, effectivePage])
 
-  const applyHighlights = useCallback(async (doc: pdfjsLib.PDFDocumentProxy, terms: string[]) => {
+  const applyHighlights = useCallback(async (doc: pdfjsLib.PDFDocumentProxy, terms: string[], preferPage: number | null = null) => {
     const container = containerRef.current
     if (!container) return
 
@@ -416,6 +427,7 @@ export function DocumentViewer({ docUuid, highlightTerms = [], onClearHighlights
     if (terms.length === 0) {
       setTotalHighlights(0)
       setCurrentHighlight(0)
+      setHighlightMiss(false)
       return
     }
 
@@ -430,6 +442,9 @@ export function DocumentViewer({ docUuid, highlightTerms = [], onClearHighlights
     type CharRef = { itemIdx: number; localIdx: number } | null
 
     let matchCount = 0
+    // First match found on the hinted page — becomes the initial scroll
+    // target so a common value doesn't land the user on the wrong occurrence.
+    let preferredMatchIdx = -1
 
     for (let i = 1; i <= doc.numPages; i++) {
       const page = await doc.getPage(i)
@@ -460,21 +475,24 @@ export function DocumentViewer({ docUuid, highlightTerms = [], onClearHighlights
           concat += ' '
         }
       }
-      const concatLower = concat.toLowerCase()
+      // Match in normalized space (case, unicode quotes/dashes, whitespace
+      // runs) and project hits back onto real char positions, so verbatim
+      // passages match even when the LLM and the PDF text layer disagree on
+      // punctuation encoding.
+      const { norm: concatNorm, map: normMap } = normalizeWithMap(concat)
 
       for (const term of terms) {
         if (!term) continue
-        // Collapse internal whitespace in the search term so multi-word values
-        // match regardless of exactly where the PDF broke the runs.
-        const termLower = term.toLowerCase().replace(/\s+/g, ' ').trim()
-        if (!termLower) continue
+        const needle = normalizeWithMap(term).norm
+        if (!needle) continue
 
         let from = 0
-        while (from < concatLower.length) {
-          const matchStart = concatLower.indexOf(termLower, from)
-          if (matchStart === -1) break
-          const matchEnd = matchStart + termLower.length
-          from = matchStart + 1
+        while (from < concatNorm.length) {
+          const normStart = concatNorm.indexOf(needle, from)
+          if (normStart === -1) break
+          from = normStart + 1
+          const matchStart = normMap[normStart]
+          const matchEnd = normMap[normStart + needle.length - 1] + 1
 
           // Gather the span of each item that is covered by this match.
           const perItem = new Map<number, { start: number; end: number }>()
@@ -531,6 +549,9 @@ export function DocumentViewer({ docUuid, highlightTerms = [], onClearHighlights
             overlay.appendChild(hl)
           }
 
+          if (preferPage != null && i === preferPage && preferredMatchIdx === -1) {
+            preferredMatchIdx = matchCount
+          }
           matchCount++
         }
       }
@@ -586,13 +607,36 @@ export function DocumentViewer({ docUuid, highlightTerms = [], onClearHighlights
 
     setTotalHighlights(matchCount)
     if (matchCount > 0) {
-      setCurrentHighlight(0)
+      setHighlightMiss(false)
+      const initialIdx = preferredMatchIdx >= 0 ? preferredMatchIdx : 0
+      setCurrentHighlight(initialIdx)
       // Double rAF ensures DOM layout is complete before scrolling
       requestAnimationFrame(() => {
-        requestAnimationFrame(() => scrollToHighlightByIndex(0))
+        requestAnimationFrame(() => scrollToHighlightByIndex(initialIdx))
       })
+    } else {
+      // Nothing matched: say so instead of doing nothing, and at least jump
+      // to the source page when we know it.
+      setHighlightMiss(true)
+      if (preferPage != null) {
+        requestAnimationFrame(() => {
+          requestAnimationFrame(() => scrollToPage(preferPage))
+        })
+      }
     }
   }, [zoomLevel])
+
+  const scrollToPage = (pageNum: number) => {
+    const container = containerRef.current
+    if (!container) return
+    const wrapper = container.querySelector(`[data-page-num="${pageNum}"]`) as HTMLElement | null
+    const scrollParent = container.parentElement
+    if (!wrapper || !scrollParent) return
+    const targetRect = wrapper.getBoundingClientRect()
+    const parentRect = scrollParent.getBoundingClientRect()
+    const scrollTop = scrollParent.scrollTop + (targetRect.top - parentRect.top) - 20
+    scrollParent.scrollTo({ top: Math.max(0, scrollTop), behavior: 'smooth' })
+  }
 
   const scrollToHighlightByIndex = (index: number) => {
     const container = containerRef.current
@@ -658,19 +702,21 @@ export function DocumentViewer({ docUuid, highlightTerms = [], onClearHighlights
   }, [])
 
   // Re-apply DOCX highlights when the query changes or the rendered HTML
-  // is replaced (e.g. text re-poll after processing).
+  // is replaced (e.g. text re-poll after processing). effectiveTerms covers
+  // both the find bar and extraction-driven highlights.
   useEffect(() => {
     if (!isDocx) return
     const root = docxContentRef.current
     if (!root) return
-    const q = searchOpen ? searchQuery : ''
+    const q = effectiveTerms[0] ?? ''
     const count = highlightHtmlSearch(root, q)
     setDocxMatchCount(count)
     setDocxCurrentMatch(0)
+    setHighlightMiss(!!q && count === 0)
     if (count > 0) {
       requestAnimationFrame(() => scrollDocxMatch(0))
     }
-  }, [isDocx, searchOpen, searchQuery, docxText, scrollDocxMatch])
+  }, [isDocx, effectiveTerms, docxText, scrollDocxMatch])
 
   const goToDocxMatch = useCallback((direction: 'next' | 'prev') => {
     if (docxMatchCount === 0) return
@@ -815,6 +861,33 @@ export function DocumentViewer({ docUuid, highlightTerms = [], onClearHighlights
             onClose={closeSearch}
             autoFocus
           />
+        )}
+        {!searchOpen && highlightMiss && highlightTerms.length > 0 && (
+          <div
+            role="status"
+            aria-live="polite"
+            style={{
+              display: 'flex', alignItems: 'center', gap: 8,
+              padding: '8px 12px', fontSize: 13, color: '#92400e',
+              backgroundColor: '#fffbeb', borderBottom: '1px solid #fde68a',
+              flexShrink: 0,
+            }}
+          >
+            <AlertCircle size={15} style={{ flexShrink: 0 }} />
+            <span style={{ flex: 1, overflow: 'hidden', whiteSpace: 'nowrap', textOverflow: 'ellipsis' }}>
+              &ldquo;{highlightTerms[0]}&rdquo; not found in this document
+            </span>
+            {onClearHighlights && (
+              <button
+                type="button"
+                onClick={onClearHighlights}
+                aria-label="Dismiss"
+                style={{ background: 'none', border: 'none', cursor: 'pointer', color: '#92400e', display: 'flex', padding: 2 }}
+              >
+                <X size={15} />
+              </button>
+            )}
+          </div>
         )}
         <div style={{
           flex: 1, overflow: 'auto', backgroundColor: '#fff', position: 'relative',
@@ -1031,8 +1104,9 @@ export function DocumentViewer({ docUuid, highlightTerms = [], onClearHighlights
       }}>
         <div ref={containerRef} style={{ paddingBottom: 20 }} />
 
-        {/* Highlight navigation bar */}
-        {!searchOpen && totalHighlights > 0 && (
+        {/* Highlight navigation bar — also shown in a "not found" state so a
+            failed source lookup gives explicit feedback instead of nothing. */}
+        {!searchOpen && (totalHighlights > 0 || (highlightMiss && highlightTerms.length > 0)) && (
           <div style={{
             position: 'sticky',
             bottom: 12,
@@ -1051,50 +1125,66 @@ export function DocumentViewer({ docUuid, highlightTerms = [], onClearHighlights
             boxShadow: '0 2px 12px rgba(0,0,0,0.12)',
             zIndex: 100,
           }}>
-            <button
-              type="button"
-              onClick={() => goToHighlight('prev')}
+            {totalHighlights > 0 && (
+              <button
+                type="button"
+                onClick={() => goToHighlight('prev')}
+                style={{
+                  ...btnStyle,
+                  width: 34, height: 34,
+                  border: 'none',
+                  background: 'none',
+                }}
+                title="Previous highlight"
+                aria-label="Previous highlight"
+              >
+                <ChevronLeft size={18} />
+              </button>
+            )}
+            <div
+              role="status"
+              aria-live="polite"
               style={{
-                ...btnStyle,
-                width: 34, height: 34,
-                border: 'none',
-                background: 'none',
+                flex: 1,
+                textAlign: 'center',
+                fontSize: 14,
+                color: '#374151',
+                overflow: 'hidden',
+                whiteSpace: 'nowrap',
+                textOverflow: 'ellipsis',
               }}
-              title="Previous highlight"
-              aria-label="Previous highlight"
             >
-              <ChevronLeft size={18} />
-            </button>
-            <div style={{
-              flex: 1,
-              textAlign: 'center',
-              fontSize: 14,
-              color: '#374151',
-              overflow: 'hidden',
-              whiteSpace: 'nowrap',
-              textOverflow: 'ellipsis',
-            }}>
               <span style={{ fontWeight: 700 }}>
                 &ldquo;{effectiveTerms[0]}&rdquo;
               </span>
-              <span style={{ marginLeft: 6, color: '#6b7280', fontWeight: 400 }}>
-                {currentHighlight + 1} of {totalHighlights}
-              </span>
+              {totalHighlights > 0 ? (
+                <span style={{ marginLeft: 6, color: '#6b7280', fontWeight: 400 }}>
+                  {currentHighlight + 1} of {totalHighlights}
+                </span>
+              ) : (
+                <span style={{ marginLeft: 6, color: '#b45309', fontWeight: 500 }}>
+                  {effectivePage != null
+                    ? `passage not matched — showing page ${effectivePage}`
+                    : 'not found in this document'}
+                </span>
+              )}
             </div>
-            <button
-              type="button"
-              onClick={() => goToHighlight('next')}
-              style={{
-                ...btnStyle,
-                width: 34, height: 34,
-                border: 'none',
-                background: 'none',
-              }}
-              title="Next highlight"
-              aria-label="Next highlight"
-            >
-              <ChevronRight size={18} />
-            </button>
+            {totalHighlights > 0 && (
+              <button
+                type="button"
+                onClick={() => goToHighlight('next')}
+                style={{
+                  ...btnStyle,
+                  width: 34, height: 34,
+                  border: 'none',
+                  background: 'none',
+                }}
+                title="Next highlight"
+                aria-label="Next highlight"
+              >
+                <ChevronRight size={18} />
+              </button>
+            )}
             {onClearHighlights && (
               <button
                 type="button"

--- a/frontend/src/components/workspace/ActivityRail.tsx
+++ b/frontend/src/components/workspace/ActivityRail.tsx
@@ -145,7 +145,11 @@ export function ActivityRail() {
         const initialResults = normalized && typeof normalized === 'object' && Object.keys(normalized).length > 0
           ? Object.fromEntries(Object.entries(normalized).map(([k, v]) => [k, v === null ? 'N/A' : String(v)]))
           : undefined
-        openExtraction(activity.search_set_uuid, initialResults)
+        const snapSources = activity.result_snapshot?.sources as import('../../api/extractions').ExtractionSourceMap | undefined
+        const initialSources = snapSources && typeof snapSources === 'object' && Object.keys(snapSources).length > 0
+          ? snapSources
+          : undefined
+        openExtraction(activity.search_set_uuid, initialResults, initialSources)
       }
     },
     [setActiveRightTab, setLoadConversationId, openWorkflow, openExtraction, closeWorkflow, closeExtraction, closeAutomation],

--- a/frontend/src/components/workspace/ExtractionEditorPanel.tsx
+++ b/frontend/src/components/workspace/ExtractionEditorPanel.tsx
@@ -34,7 +34,7 @@ import {
 } from '../../api/extractions'
 import { RunHistoryTab } from './RunHistoryTab'
 import { ApiError } from '../../api/client'
-import type { ValidationV2Result, QualityHistoryRun, ValidationSource, ExtractionRunHistoryEntry } from '../../api/extractions'
+import type { ValidationV2Result, QualityHistoryRun, ValidationSource, ExtractionRunHistoryEntry, ExtractionFieldSource, ExtractionSourceMap } from '../../api/extractions'
 import { DocumentPickerDialog } from '../shared/DocumentPickerDialog'
 import { VerificationSubmitModal } from '../library/VerificationSubmitModal'
 import { ExtractionAutovalidatePanel } from '../extractions/ExtractionAutovalidatePanel'
@@ -103,7 +103,7 @@ interface ExtractionConfig {
 
 export function ExtractionEditorPanel() {
   const queryClient = useQueryClient()
-  const { openExtractionId, extractionOpenSignal, openExtraction, closeExtraction, selectedDocUuids, selectedDocNames, setHighlightTerms, bumpActivitySignal, consumeExtractionResults, activeProjectUuid, activeProjectRootFolder } = useWorkspace()
+  const { openExtractionId, extractionOpenSignal, openExtraction, closeExtraction, selectedDocUuids, selectedDocNames, setHighlightTerms, viewDocument, bumpActivitySignal, consumeExtractionResults, activeProjectUuid, activeProjectRootFolder } = useWorkspace()
   const { toast } = useToast()
   const { user } = useAuth()
   const shareLink = useShareLink()
@@ -116,11 +116,14 @@ export function ExtractionEditorPanel() {
   const [newTerm, setNewTerm] = useState('')
   const [running, setRunning] = useState(false)
   const [resultSets, setResultSets] = useState<Record<string, string>[]>([])
+  // Per-field source info, index-aligned with resultSets.
+  const [resultSourceSets, setResultSourceSets] = useState<ExtractionSourceMap[]>([])
   const [resultDocNames, setResultDocNames] = useState<string[]>([])
   const [activeResultIdx, setActiveResultIdx] = useState(0)
   const [combinedContext, setCombinedContext] = useState(false)
 
   const results = resultSets[activeResultIdx] ?? {}
+  const resultSources = resultSourceSets[activeResultIdx] ?? {}
   const [attachingTemplate, setAttachingTemplate] = useState(false)
   const [generatingTemplate, setGeneratingTemplate] = useState(false)
   const [exportingPdf, setExportingPdf] = useState(false)
@@ -169,7 +172,8 @@ export function ExtractionEditorPanel() {
     if (!openExtractionId) return
     setLoading(true)
     const pending = consumeExtractionResults()
-    setResultSets(pending ? [pending] : [])
+    setResultSets(pending ? [pending.values] : [])
+    setResultSourceSets(pending ? [pending.sources ?? {}] : [])
     setResultDocNames([])
     setActiveResultIdx(0)
     setActiveTab('design')
@@ -260,18 +264,21 @@ export function ExtractionEditorPanel() {
         document_uuids: docUuids,
         combined_context: combinedContext,
       })
-      // Build result sets — one per entity object returned
+      // Build result sets — one per entity object returned. `sources` from
+      // the backend is index-aligned with `results`.
       const sets: Record<string, string>[] = []
+      const srcSets: ExtractionSourceMap[] = []
       if (resp.results && resp.results.length > 0) {
-        for (const entity of resp.results) {
+        resp.results.forEach((entity, i) => {
           if (typeof entity === 'object' && entity !== null) {
             const map: Record<string, string> = {}
             for (const [k, v] of Object.entries(entity as Record<string, unknown>)) {
               map[k] = v === null ? 'N/A' : String(v)
             }
             sets.push(map)
+            srcSets.push(resp.sources?.[i] ?? {})
           }
-        }
+        })
       }
       const finalSets = sets.length > 0 ? sets : [{}]
       if (sets.length === 0) {
@@ -280,6 +287,7 @@ export function ExtractionEditorPanel() {
         toast('Extraction finished but returned no values — see the History tab for details', 'info')
       }
       setResultSets(finalSets)
+      setResultSourceSets(sets.length > 0 ? srcSets : [{}])
       setResultDocNames(finalSets.map((_, i) => runDocNames[i] ?? `Result ${i + 1}`))
       setActiveResultIdx(0)
     } catch (err) {
@@ -289,12 +297,13 @@ export function ExtractionEditorPanel() {
         // land here instead of only in the History tab.
         const run = await recoverRunFromHistory(openExtractionId)
         if (run?.status === 'completed') {
-          const snap = run.result_snapshot as { normalized?: Record<string, unknown> } | undefined
+          const snap = run.result_snapshot as { normalized?: Record<string, unknown>; sources?: ExtractionSourceMap } | undefined
           const map: Record<string, string> = {}
           for (const [k, v] of Object.entries(snap?.normalized ?? {})) {
             map[k] = v === null ? 'N/A' : String(v)
           }
           setResultSets([map])
+          setResultSourceSets([snap?.sources ?? {}])
           // The history snapshot merges all documents into one value map, so
           // a multi-doc run recovers as a single combined result set.
           setResultDocNames([docUuids.length > 1 ? `Combined (${docUuids.length} docs)` : runDocNames[0] ?? 'Result 1'])
@@ -311,6 +320,38 @@ export function ExtractionEditorPanel() {
       setRunning(false)
       bumpActivitySignal()
     }
+  }
+
+  // --- Click-to-source ---
+  // Clicking a value copies it and shows where in the document it came from.
+  // With source tracking, that means the verified verbatim passage on its
+  // page; without it (older runs), fall back to a plain text search.
+  const handleValueClick = (field: string, value: string) => {
+    navigator.clipboard.writeText(value)
+      .then(() => toast('Copied to clipboard', 'success'))
+      .catch(() => toast('Failed to copy to clipboard', 'error'))
+
+    const src: ExtractionFieldSource | undefined = resultSources[field]
+    if (src && src.verified && src.quote) {
+      const highlight = { terms: [src.quote], page: src.page ?? null }
+      if (src.document_uuid) {
+        // Routes through the open-document request so this works even when
+        // the source document isn't the one currently in the viewer.
+        viewDocument(src.document_uuid, src.document_title ?? 'Document', highlight)
+      } else {
+        setHighlightTerms(highlight.terms, highlight.page)
+      }
+      return
+    }
+    if (src) {
+      // The backend couldn't trace this answer back to the document text.
+      setHighlightTerms([])
+      toast("No source found — this value couldn't be traced back to the document, so double-check it before relying on it", 'info')
+      return
+    }
+    // Legacy run without source data — search for the value's own wording,
+    // minus any markdown emphasis the model wrapped it in.
+    setHighlightTerms([value.replace(/^[\s*_`]+|[\s*_`]+$/g, '')])
   }
 
   // --- Export ---
@@ -763,7 +804,8 @@ export function ExtractionEditorPanel() {
           onUpdateItem={update}
           onReorder={reorder}
           searchSetUuid={openExtractionId ?? undefined}
-          onHighlightValue={setHighlightTerms}
+          onValueClick={handleValueClick}
+          sources={resultSources}
           resultSets={resultSets}
           activeResultIdx={activeResultIdx}
           onSetActiveResultIdx={setActiveResultIdx}
@@ -1069,7 +1111,8 @@ function DesignTab({
   onUpdateItem,
   onReorder,
   searchSetUuid,
-  onHighlightValue,
+  onValueClick,
+  sources,
   resultSets,
   activeResultIdx,
   onSetActiveResultIdx,
@@ -1089,12 +1132,12 @@ function DesignTab({
   onUpdateItem: (id: string, data: { searchphrase?: string; title?: string; is_optional?: boolean; enum_values?: string[] }) => void
   onReorder: (itemIds: string[]) => void
   searchSetUuid?: string
-  onHighlightValue: (terms: string[]) => void
+  onValueClick: (field: string, value: string) => void
+  sources: ExtractionSourceMap
   resultSets: Record<string, string>[]
   activeResultIdx: number
   onSetActiveResultIdx: (idx: number) => void
 }) {
-  const { toast } = useToast()
   const [dragIdx, setDragIdx] = useState<number | null>(null)
   const [overIdx, setOverIdx] = useState<number | null>(null)
   const [editingId, setEditingId] = useState<string | null>(null)
@@ -1546,39 +1589,68 @@ function DesignTab({
                     <X style={{ width: 14, height: 14 }} aria-hidden="true" />
                   </button>
                 </div>
-                {resultVal !== undefined && (
-                  <div
-                    onClick={() => {
-                      if (resultVal && resultVal !== 'N/A') {
-                        onHighlightValue([resultVal])
-                        navigator.clipboard.writeText(resultVal)
-                          .then(() => toast('Copied to clipboard', 'success'))
-                          .catch(() => toast('Failed to copy to clipboard', 'error'))
-                      }
-                    }}
-                    style={{
-                      marginTop: 4,
-                      marginLeft: 42,
-                      fontSize: 13,
-                      fontWeight: 600,
-                      color: '#202124',
-                      cursor: resultVal && resultVal !== 'N/A' ? 'pointer' : 'default',
-                      borderRadius: 4,
-                      padding: '2px 4px',
-                      transition: 'background-color 0.15s',
-                    }}
-                    onMouseEnter={e => {
-                      if (resultVal && resultVal !== 'N/A')
-                        (e.currentTarget as HTMLElement).style.backgroundColor = '#fef9c3'
-                    }}
-                    onMouseLeave={e => {
-                      (e.currentTarget as HTMLElement).style.backgroundColor = 'transparent'
-                    }}
-                    title={resultVal && resultVal !== 'N/A' ? 'Click to highlight in PDF' : undefined}
-                  >
-                    {resultVal}
-                  </div>
-                )}
+                {resultVal !== undefined && (() => {
+                  const src = sources[item.searchphrase]
+                  const clickable = !!resultVal && resultVal !== 'N/A'
+                  const hasSource = !!src?.verified && !!src?.quote
+                  const noSource = !!src && !hasSource
+                  const clickTitle = !clickable
+                    ? undefined
+                    : hasSource
+                      ? `Click to show the source passage${src?.page != null ? ` (page ${src.page})` : ''}`
+                      : noSource
+                        ? 'No source found for this value — click to copy'
+                        : 'Click to highlight in PDF'
+                  return (
+                    <div
+                      onClick={() => {
+                        if (clickable) onValueClick(item.searchphrase, resultVal)
+                      }}
+                      style={{
+                        marginTop: 4,
+                        marginLeft: 42,
+                        fontSize: 13,
+                        fontWeight: 600,
+                        color: '#202124',
+                        cursor: clickable ? 'pointer' : 'default',
+                        borderRadius: 4,
+                        padding: '2px 4px',
+                        transition: 'background-color 0.15s',
+                      }}
+                      onMouseEnter={e => {
+                        if (clickable)
+                          (e.currentTarget as HTMLElement).style.backgroundColor = '#fef9c3'
+                      }}
+                      onMouseLeave={e => {
+                        (e.currentTarget as HTMLElement).style.backgroundColor = 'transparent'
+                      }}
+                      title={clickTitle}
+                    >
+                      {resultVal}
+                      {clickable && hasSource && src?.page != null && (
+                        <span style={{
+                          marginLeft: 6, fontSize: 10, fontWeight: 500, color: '#1d4ed8',
+                          background: '#eff6ff', borderRadius: 3, padding: '1px 4px',
+                          whiteSpace: 'nowrap',
+                        }}>
+                          p. {src.page}
+                        </span>
+                      )}
+                      {clickable && noSource && (
+                        <span
+                          title="This value couldn't be traced back to the document — double-check it before relying on it"
+                          style={{
+                            marginLeft: 6, fontSize: 10, fontWeight: 500, color: '#92400e',
+                            background: '#fef3c7', borderRadius: 3, padding: '1px 4px',
+                            whiteSpace: 'nowrap',
+                          }}
+                        >
+                          no source
+                        </span>
+                      )}
+                    </div>
+                  )
+                })()}
                 {expandedSettingsId === item.id && (
                   <div id={`field-settings-${item.id}`} style={{
                     marginTop: 6,

--- a/frontend/src/components/workspace/LeftPanel.tsx
+++ b/frontend/src/components/workspace/LeftPanel.tsx
@@ -14,7 +14,7 @@ import { addDocumentsToKB } from '../../api/knowledge'
 import type { Folder } from '../../types/document'
 
 export function LeftPanel() {
-  const { setSelectedDocUuids, setSelectedDocNames, setSelectedFolderUuids, highlightTerms, setHighlightTerms, setProcessingDoc, setSelectedDocsProcessing, viewDocumentRequest, clearViewDocumentRequest, focusChat, openWorkflow, activeProjectRootFolder, activeProjectTitle, activeProjectTeamId } = useWorkspace()
+  const { setSelectedDocUuids, setSelectedDocNames, setSelectedFolderUuids, highlightTerms, highlightPage, setHighlightTerms, setProcessingDoc, setSelectedDocsProcessing, viewDocumentRequest, clearViewDocumentRequest, focusChat, openWorkflow, activeProjectRootFolder, activeProjectTitle, activeProjectTeamId } = useWorkspace()
   const { toast } = useToast()
   // Folder targeted by the workflow / KB picker modals (null = closed).
   const [workflowPickerFolder, setWorkflowPickerFolder] = useState<Folder | null>(null)
@@ -106,13 +106,19 @@ export function LeftPanel() {
     [setSelectedDocsProcessing],
   )
 
-  // Open a document when requested from another panel (e.g. validation tab)
+  // Open a document when requested from another panel (e.g. validation tab).
+  // A request may carry its own highlight (extraction source tracking) —
+  // apply it instead of the default clear, so the terms survive the open.
   useEffect(() => {
     if (viewDocumentRequest) {
       setViewingDoc({ uuid: viewDocumentRequest.uuid, title: viewDocumentRequest.title })
       setSelectedDocUuids([viewDocumentRequest.uuid])
       setSelectedDocNames({ [viewDocumentRequest.uuid]: viewDocumentRequest.title })
-      setHighlightTerms([])
+      if (viewDocumentRequest.highlight) {
+        setHighlightTerms(viewDocumentRequest.highlight.terms, viewDocumentRequest.highlight.page)
+      } else {
+        setHighlightTerms([])
+      }
       clearViewDocumentRequest()
     }
   }, [viewDocumentRequest, clearViewDocumentRequest, setSelectedDocUuids, setSelectedDocNames, setHighlightTerms])
@@ -309,6 +315,7 @@ export function LeftPanel() {
           <DocumentViewer
             docUuid={viewingDoc.uuid}
             highlightTerms={highlightTerms}
+            highlightPage={highlightPage}
             onClearHighlights={() => setHighlightTerms([])}
             processing={viewingDoc.processing}
             taskStatus={viewingDoc.taskStatus}

--- a/frontend/src/contexts/WorkspaceContext.tsx
+++ b/frontend/src/contexts/WorkspaceContext.tsx
@@ -1,9 +1,24 @@
 import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
 import { useNavigate, useSearch } from '@tanstack/react-router'
 import { useTeams } from '../hooks/useTeams'
+import type { ExtractionSourceMap } from '../api/extractions'
 
 type RightTab = 'assistant' | 'library'
 export type WorkspaceMode = 'chat' | 'files' | 'automations' | 'knowledge' | 'projects'
+
+// Cross-panel "open this document" request; `highlight` optionally carries
+// terms + page to apply once the viewer opens (extraction source tracking),
+// instead of the default highlight-clearing behavior.
+export interface ViewDocumentRequest {
+  uuid: string
+  title: string
+  highlight?: { terms: string[]; page: number | null }
+}
+
+export interface PendingExtractionResults {
+  values: Record<string, string>
+  sources?: ExtractionSourceMap
+}
 
 // ---------------------------------------------------------------------------
 // 1. Navigation Context — URL-synced panels, mode, tab
@@ -24,9 +39,9 @@ interface NavigationContextValue {
   // runs of the same workflow in the Activity rail).
   workflowOpenSignal: number
   openExtractionId: string | null
-  openExtraction: (uuid: string, initialResults?: Record<string, string>) => void
+  openExtraction: (uuid: string, initialResults?: Record<string, string>, initialSources?: ExtractionSourceMap) => void
   closeExtraction: () => void
-  consumeExtractionResults: () => Record<string, string> | null
+  consumeExtractionResults: () => PendingExtractionResults | null
   // Same as workflowOpenSignal, for the extraction panel.
   extractionOpenSignal: number
   openAutomationId: string | null
@@ -111,11 +126,15 @@ interface UIStateContextValue {
   panelSplit: number
   setPanelSplit: (pct: number, skipPersist?: boolean) => void
   highlightTerms: string[]
-  setHighlightTerms: (terms: string[]) => void
+  // Page hint for the current highlight terms (1-based, from extraction
+  // source tracking) — lets the viewer jump to the right page even when the
+  // passage itself can't be text-matched.
+  highlightPage: number | null
+  setHighlightTerms: (terms: string[], page?: number | null) => void
   activitySignal: number
   bumpActivitySignal: () => void
-  viewDocumentRequest: { uuid: string; title: string } | null
-  viewDocument: (uuid: string, title: string) => void
+  viewDocumentRequest: ViewDocumentRequest | null
+  viewDocument: (uuid: string, title: string, highlight?: ViewDocumentRequest['highlight']) => void
   clearViewDocumentRequest: () => void
 }
 
@@ -233,7 +252,14 @@ export function WorkspaceProvider({ children }: { children: ReactNode }) {
   const [newChatSignal, setNewChatSignal] = useState(0)
   const [focusChatSignal, setFocusChatSignal] = useState(0)
   const [pendingChatMessage, setPendingChatMessage] = useState<PendingChatMessage | null>(null)
-  const [highlightTerms, setHighlightTerms] = useState<string[]>([])
+  const [highlightTerms, _setHighlightTerms] = useState<string[]>([])
+  const [highlightPage, setHighlightPage] = useState<number | null>(null)
+  // Terms and their page hint always move together — a stale page from a
+  // previous highlight must never survive a new set/clear.
+  const setHighlightTerms = useCallback((terms: string[], page?: number | null) => {
+    _setHighlightTerms(terms)
+    setHighlightPage(page ?? null)
+  }, [])
   const [activitySignal, setActivitySignal] = useState(0)
   const [processingDoc, setProcessingDoc] = useState<{ title: string; status: string | null } | null>(null)
   const [selectedDocsProcessing, _setSelectedDocsProcessing] = useState<Array<{ uuid: string; title: string; status: string | null }>>([])
@@ -259,8 +285,8 @@ export function WorkspaceProvider({ children }: { children: ReactNode }) {
   const [activeProjectRootFolder, setActiveProjectRootFolder] = useState<string | null>(null)
   const [activeProjectTeamId, setActiveProjectTeamId] = useState<string | null>(null)
   const [activeProjectRole, setActiveProjectRole] = useState<string | null>(null)
-  const [viewDocumentRequest, setViewDocumentRequest] = useState<{ uuid: string; title: string } | null>(null)
-  const pendingExtractionResultsRef = useRef<Record<string, string> | null>(null)
+  const [viewDocumentRequest, setViewDocumentRequest] = useState<ViewDocumentRequest | null>(null)
+  const pendingExtractionResultsRef = useRef<PendingExtractionResults | null>(null)
   const pendingWorkflowSessionRef = useRef<string | null>(null)
   const [workflowOpenSignal, setWorkflowOpenSignal] = useState(0)
   const [extractionOpenSignal, setExtractionOpenSignal] = useState(0)
@@ -309,13 +335,15 @@ export function WorkspaceProvider({ children }: { children: ReactNode }) {
     return s
   }, [])
 
-  const openExtraction = useCallback((uuid: string, initialResults?: Record<string, string>) => {
-    pendingExtractionResultsRef.current = initialResults ?? null
+  const openExtraction = useCallback((uuid: string, initialResults?: Record<string, string>, initialSources?: ExtractionSourceMap) => {
+    pendingExtractionResultsRef.current = initialResults
+      ? { values: initialResults, sources: initialSources }
+      : null
     setExtractionOpenSignal(prev => prev + 1)
     updateSearch((prev) => ({ ...prev, extraction: uuid, workflow: undefined, automation: undefined }))
   }, [updateSearch])
 
-  const consumeExtractionResults = useCallback((): Record<string, string> | null => {
+  const consumeExtractionResults = useCallback((): PendingExtractionResults | null => {
     const r = pendingExtractionResultsRef.current
     pendingExtractionResultsRef.current = null
     return r
@@ -349,7 +377,7 @@ export function WorkspaceProvider({ children }: { children: ReactNode }) {
     setActiveProjectRootFolder(null)
     setActiveProjectTeamId(null)
     setActiveProjectRole(null)
-  }, [updateSearch])
+  }, [updateSearch, setHighlightTerms])
 
   // ── Chat callbacks ──────────────────────────────────────────────────────
 
@@ -607,8 +635,8 @@ export function WorkspaceProvider({ children }: { children: ReactNode }) {
     }
   }, [])
 
-  const viewDocument = useCallback((uuid: string, title: string) => {
-    setViewDocumentRequest({ uuid, title })
+  const viewDocument = useCallback((uuid: string, title: string, highlight?: ViewDocumentRequest['highlight']) => {
+    setViewDocumentRequest({ uuid, title, highlight })
   }, [])
 
   const clearViewDocumentRequest = useCallback(() => {
@@ -666,14 +694,15 @@ export function WorkspaceProvider({ children }: { children: ReactNode }) {
     selectedFolderUuids, setSelectedFolderUuids,
     railDocked, toggleRailDocked,
     panelSplit, setPanelSplit,
-    highlightTerms, setHighlightTerms,
+    highlightTerms, highlightPage, setHighlightTerms,
     activitySignal, bumpActivitySignal,
     viewDocumentRequest, viewDocument, clearViewDocumentRequest,
   }), [
     selectedDocUuids, selectedDocNames, selectedFolderUuids,
     railDocked, toggleRailDocked,
     panelSplit, setPanelSplit,
-    highlightTerms, activitySignal, bumpActivitySignal,
+    highlightTerms, highlightPage, setHighlightTerms,
+    activitySignal, bumpActivitySignal,
     viewDocumentRequest, viewDocument, clearViewDocumentRequest,
   ])
 

--- a/frontend/src/utils/textMatch.test.ts
+++ b/frontend/src/utils/textMatch.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import { normalizeWithMap } from './textMatch'
+
+describe('normalizeWithMap', () => {
+  it('lowercases and collapses whitespace, mapping back to source offsets', () => {
+    const { norm, map } = normalizeWithMap('  Hello\n\n  World  ')
+    expect(norm).toBe('hello world')
+    expect(map).toHaveLength(norm.length)
+    expect(map[0]).toBe(2) // 'h' -> original 'H'
+  })
+
+  it('folds smart quotes and dash variants', () => {
+    const { norm } = normalizeWithMap('“terms” — and ‘conditions’')
+    expect(norm).toBe('"terms" - and \'conditions\'')
+  })
+
+  it('expands ligatures while keeping the map aligned', () => {
+    const { norm, map } = normalizeWithMap('ﬁnal')
+    expect(norm).toBe('final')
+    expect(map[0]).toBe(0)
+    expect(map[1]).toBe(0) // both expanded chars map to the ligature
+    expect(map).toHaveLength(5)
+  })
+
+  it('folds non-breaking spaces to plain spaces', () => {
+    const { norm } = normalizeWithMap('December 31, 2025')
+    expect(norm).toBe('december 31, 2025')
+  })
+
+  it('drops soft hyphens and zero-width characters', () => {
+    const { norm } = normalizeWithMap('co­operative​ plan')
+    expect(norm).toBe('cooperative plan')
+  })
+
+  it('lets an LLM-quoted passage match a PDF text layer with different punctuation', () => {
+    const pdfText = 'In the event of any inconsistency among the terms — “precedence” applies.'
+    const quote = 'the terms - "precedence" applies.'
+    const doc = normalizeWithMap(pdfText)
+    const needle = normalizeWithMap(quote).norm
+    const at = doc.norm.indexOf(needle)
+    expect(at).toBeGreaterThan(-1)
+    // Projected start lands on the real "the terms" in the original string
+    expect(pdfText.slice(doc.map[at], doc.map[at] + 9)).toBe('the terms')
+  })
+})

--- a/frontend/src/utils/textMatch.ts
+++ b/frontend/src/utils/textMatch.ts
@@ -1,0 +1,49 @@
+// Text normalization for matching LLM-quoted passages against document text
+// (PDF text layers, rendered DOCX). The two routinely disagree on smart
+// quotes, dash variants, NBSP, soft hyphens, and ligatures, so both sides are
+// folded before matching, keeping a map back to source offsets.
+
+const FOLD_MAP: Record<string, string> = {
+  // curly quotes -> straight
+  '\u2018': "'", '\u2019': "'", '\u201A': "'", '\u201B': "'",
+  '\u201C': '"', '\u201D': '"', '\u201E': '"',
+  // hyphen/dash variants -> '-'
+  '\u2010': '-', '\u2011': '-', '\u2012': '-', '\u2013': '-',
+  '\u2014': '-', '\u2015': '-', '\u2212': '-',
+  // NBSP / figure / thin / narrow no-break space -> ' '
+  '\u00A0': ' ', '\u2007': ' ', '\u2009': ' ', '\u202F': ' ',
+  // ligatures
+  '\uFB01': 'fi', '\uFB02': 'fl',
+}
+// soft hyphen, BOM, zero-width space / non-joiner / joiner
+const DROP_CHARS = new Set(['\u00AD', '\uFEFF', '\u200B', '\u200C', '\u200D'])
+
+// Lowercase + fold + collapse whitespace, keeping a map from each normalized
+// char back to its source index so matches project onto real text offsets.
+export function normalizeWithMap(text: string): { norm: string; map: number[] } {
+  let norm = ''
+  const map: number[] = []
+  let lastWasSpace = true // trims leading whitespace
+  for (let i = 0; i < text.length; i++) {
+    const raw = text[i]
+    if (DROP_CHARS.has(raw)) continue
+    const folded = FOLD_MAP[raw] ?? raw
+    for (const c of folded) {
+      if (/\s/.test(c)) {
+        if (lastWasSpace) continue
+        norm += ' '
+        map.push(i)
+        lastWasSpace = true
+      } else {
+        norm += c.toLowerCase()
+        map.push(i)
+        lastWasSpace = false
+      }
+    }
+  }
+  if (norm.endsWith(' ')) {
+    norm = norm.slice(0, -1)
+    map.pop()
+  }
+  return { norm, map }
+}


### PR DESCRIPTION
## Summary

Support ticket (Kiran, oauthdev): clicking an extracted value only ran a blind Ctrl+F for the answer's exact wording — failing on reworded values, common strings ("1" → 542 highlights), and yes/no answers, always silently.

Extraction now records **where each answer came from**: the LLM returns a verbatim supporting passage per field, the backend verifies it against the document text and resolves it to a page, and clicking a value jumps to that exact passage. Untraceable answers get an explicit **"no source found"** state — which doubles as a hallucination warning.

## Ticket cases → behavior

| Case | Before | After |
|---|---|---|
| Reworded value (`*Effective December 31, 2025*`) | nothing, silently | highlights the verbatim source passage on page 1 |
| Common value ("1") | 542 highlights | the one source passage, on its page |
| Yes/No ("Is cost sharing required" → "Yes") | nothing | highlights the supporting cost-sharing paragraph |
| Untraceable answer | nothing, silently | "no source" chip + warning toast; viewer shows not-found bar |
| Source in a different / unopened document | highlight lost | opens the owning document, then highlights |

## Design notes

- **Quote only from the LLM** — pages are resolved server-side from `SmartDocument.text_markers` (the same machinery KB citations use), never asked of the model, so pages can't be fabricated. Unfindable quote ⇒ `verified: false`.
- Sources ride entities as a reserved `_field_sources` sidecar; consensus voting, two-pass draft hints, chunk merges, and `normalize_results` all skip it (quotes legitimately vary between replicates — stripping them keeps consensus converging).
- **Capture is enabled only on `/run-sync`** (the extraction panel path). Optimizer sweeps, workflow engine, validation, and the mgmt API are unchanged, so tuned baselines and token costs don't shift. The pinned prompt variants are untouched — the source clause is appended separately.
- Matching normalizes unicode (smart quotes, dash variants, NBSP, ligatures, soft hyphens) with offset maps on both backend (`extraction_sources.py`) and frontend (`utils/textMatch.ts`).
- Combined-context runs re-offset page markers into the merged text and keep per-document spans so each source attributes to the owning file.
- `run-sync` response gains `sources` (index-aligned with `results`); activity snapshots store them so rail restore and history recovery keep sources.

## Known limitations

- Highlight rectangle width still uses the existing proportional char-width estimate — match *finding* is much more reliable, but rect geometry is unchanged.
- OCR'd PDFs have interpolated page markers, so pages there are approximate (existing behavior of the marker system).

## Testing

- 19 new backend tests (normalization, quote→offset→page, combined-doc spans, sidecar plumbing, mocked end-to-end capture run); full extraction suites pass (177 + 35), ruff clean.
- 6 new frontend tests for the normalizer; `tsc -b` clean; all 287 vitest tests pass; no new lint warnings.
- Pending: live verify on oauthdev against the 45-page USDA T&C PDF from the ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)