### PR TITLE
fix: enforce unique model names and tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- **Duplicate model tags could silently route a request to a different model than the user selected.** `get_llm_model_by_name` resolves a selector by scanning model names first and tags second, returning the first match either way, and user model preferences are stored and returned as *tags* — so two models sharing a tag made the stored preference ambiguous and let list order decide which model actually answered, with no error and nothing in the UI indicating a substitution. The same first-match precedence meant a model whose **name** equalled another model's **tag** would capture that tag's traffic. Neither the admin form nor `POST`/`PUT /api/admin/config/models` rejected either arrangement. Model names and tags are now validated as one case-insensitive, whitespace-trimmed identifier namespace: the backend rejects a collision with **HTTP 409** naming the conflicting value and the model already holding it (via a new `ensure_model_identity_available` in the existing `name_conflicts` service, matching how workflow/KB/extraction name conflicts are already handled), and the model form warns before submitting. Editing a model no longer collides with itself. Validation runs only on create and update, so existing installs that already contain a collision keep working and can be repaired in place — nothing is renamed automatically.
+
 ## [v4.9.0] - 2026-07-23
 
 ### Fixed

--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -17,6 +17,10 @@ from app.models.audit_log import AdminAuditLog
 from app.models.system_config import SystemConfig
 from app.services import audit_service
 from app.services.llm_service import clear_agent_caches, get_agent_model
+from app.services.name_conflicts import (
+    DuplicateNameError,
+    ensure_model_identity_available,
+)
 from app.services.version_service import get_update_status
 from app.utils.encryption import decrypt_value, encrypt_value
 from app.models.team import Team, TeamMembership
@@ -1524,6 +1528,13 @@ async def add_model(
     await _require_superadmin(user)
 
     cfg = await SystemConfig.get_config()
+    try:
+        ensure_model_identity_available(
+            name=body.name, tag=body.tag, models=cfg.available_models,
+        )
+    except DuplicateNameError as e:
+        raise HTTPException(status_code=409, detail=str(e))
+
     was_empty = len(cfg.available_models) == 0
     cfg.available_models.append(
         {
@@ -1613,6 +1624,14 @@ async def update_model(
     cfg = await SystemConfig.get_config()
     if index < 0 or index >= len(cfg.available_models):
         raise HTTPException(status_code=404, detail="Model index out of range")
+
+    try:
+        ensure_model_identity_available(
+            name=body.name, tag=body.tag, models=cfg.available_models,
+            exclude_index=index,
+        )
+    except DuplicateNameError as e:
+        raise HTTPException(status_code=409, detail=str(e))
 
     # If the client sends '***', preserve the existing (encrypted) key
     new_api_key = body.api_key or ""

--- a/backend/app/services/name_conflicts.py
+++ b/backend/app/services/name_conflicts.py
@@ -35,6 +35,55 @@ def _exact_name(name: str) -> dict:
     return {"$regex": f"^{re.escape(name)}$", "$options": "i"}
 
 
+def _model_identifier(value: object) -> str:
+    """Normalize a model name or tag for comparison."""
+    return str(value or "").strip().casefold()
+
+
+def ensure_model_identity_available(
+    *,
+    name: str,
+    tag: str,
+    models: list,
+    exclude_index: int | None = None,
+) -> None:
+    """Reject a model whose name or tag is already in use by another model.
+
+    ``get_llm_model_by_name`` resolves a selector by scanning names first and
+    tags second, returning the first match either way, so names and tags form a
+    single identifier namespace: two models sharing a tag — or one model whose
+    name is another's tag — make a selector ambiguous, and the loser is decided
+    by list order. User model preferences are stored as that selector, so the
+    ambiguity silently routes requests to a model the user did not choose.
+
+    Unlike the ``ensure_*_available`` helpers above, ``available_models`` is an
+    embedded list on ``SystemConfig`` rather than a collection, so this compares
+    in memory instead of querying. Matching is case-insensitive on the trimmed
+    value, consistent with :func:`_exact_name`. Pass ``exclude_index`` when
+    updating so a model does not collide with itself.
+    """
+    candidates = (("name", str(name or "").strip()), ("tag", str(tag or "").strip()))
+
+    for index, existing in enumerate(models):
+        if index == exclude_index or not isinstance(existing, dict):
+            continue
+        owner = str(existing.get("name") or "").strip() or f"at index {index}"
+        taken = (
+            ("name", _model_identifier(existing.get("name"))),
+            ("tag", _model_identifier(existing.get("tag"))),
+        )
+        for field, value in candidates:
+            if not value:
+                continue
+            for taken_field, taken_value in taken:
+                if taken_value and _model_identifier(value) == taken_value:
+                    raise DuplicateNameError(
+                        f"Model {field} {value!r} is already used as the "
+                        f"{taken_field} of model {owner!r}. Model names and tags "
+                        f"must be unique."
+                    )
+
+
 def _library_scope(user_id: str, team_id: str | None) -> dict:
     # Mirrors the default (no-scope) query in workflow_service.list_workflows
     # and search_set_service.list_search_sets: own items + current team items.

--- a/backend/tests/test_admin_routes.py
+++ b/backend/tests/test_admin_routes.py
@@ -638,3 +638,102 @@ class TestOcrConnectivityTest:
             )
 
         assert resp.status_code == 400
+
+
+class TestModelIdentityUniqueness:
+    """POST/PUT /api/admin/config/models — model names and tags stay unambiguous.
+
+    Resolution scans names then tags and returns the first match, so a shared
+    tag makes a user's stored selector resolve to whichever model happens to be
+    first in the list.
+    """
+
+    def _cfg(self, *pairs):
+        return SimpleNamespace(
+            available_models=[{"name": n, "tag": t} for n, t in pairs],
+            default_model="",
+            updated_at=None,
+            updated_by=None,
+            save=AsyncMock(),
+        )
+
+    async def _call(self, client, cfg, method, url, body):
+        admin = _make_user("admin", is_admin=True)
+        cookies, headers = _auth("admin")
+        with (
+            patch("app.dependencies.decode_token", return_value={"sub": "admin", "type": "access"}),
+            patch("app.dependencies.User") as MockUser,
+            patch("app.routers.admin.SystemConfig") as MockCfg,
+            patch("app.routers.admin.encrypt_value", side_effect=lambda v: v),
+            patch("app.routers.admin.clear_agent_caches"),
+            patch("app.routers.admin._audit", new_callable=AsyncMock),
+        ):
+            MockUser.find_one = AsyncMock(return_value=admin)
+            MockCfg.get_config = AsyncMock(return_value=cfg)
+            return await getattr(client, method)(
+                url, json=body, cookies=cookies, headers=headers
+            )
+
+    @pytest.mark.asyncio
+    async def test_adding_a_model_with_a_unique_identity_succeeds(self, client):
+        cfg = self._cfg(("qwen-large", "local"))
+        resp = await self._call(
+            client, cfg, "post", "/api/admin/config/models",
+            {"name": "gpt-oss", "tag": "fast"},
+        )
+        assert resp.status_code == 200
+        assert len(cfg.available_models) == 2
+
+    @pytest.mark.asyncio
+    async def test_adding_a_model_with_a_duplicate_tag_is_rejected(self, client):
+        cfg = self._cfg(("qwen-large", "local"))
+        resp = await self._call(
+            client, cfg, "post", "/api/admin/config/models",
+            {"name": "gpt-oss", "tag": "local"},
+        )
+        assert resp.status_code == 409
+        assert "local" in resp.json()["detail"]
+        # The colliding model must not have been persisted.
+        assert len(cfg.available_models) == 1
+        cfg.save.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_adding_a_model_whose_name_is_another_models_tag_is_rejected(self, client):
+        cfg = self._cfg(("qwen-large", "local"))
+        resp = await self._call(
+            client, cfg, "post", "/api/admin/config/models",
+            {"name": "local", "tag": "reasoning"},
+        )
+        assert resp.status_code == 409
+        assert len(cfg.available_models) == 1
+
+    @pytest.mark.asyncio
+    async def test_updating_a_model_without_changing_its_identity_succeeds(self, client):
+        cfg = self._cfg(("qwen-large", "local"), ("gpt-oss", "fast"))
+        resp = await self._call(
+            client, cfg, "put", "/api/admin/config/models/0",
+            {"name": "qwen-large", "tag": "local", "context_window": 32768},
+        )
+        assert resp.status_code == 200
+        assert cfg.available_models[0]["context_window"] == 32768
+
+    @pytest.mark.asyncio
+    async def test_updating_a_model_onto_another_models_tag_is_rejected(self, client):
+        cfg = self._cfg(("qwen-large", "local"), ("gpt-oss", "fast"))
+        resp = await self._call(
+            client, cfg, "put", "/api/admin/config/models/0",
+            {"name": "qwen-large", "tag": "fast"},
+        )
+        assert resp.status_code == 409
+        # The original row must survive untouched.
+        assert cfg.available_models[0]["tag"] == "local"
+        cfg.save.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_index_bounds_are_still_checked_before_identity(self, client):
+        cfg = self._cfg(("qwen-large", "local"))
+        resp = await self._call(
+            client, cfg, "put", "/api/admin/config/models/7",
+            {"name": "gpt-oss", "tag": "fast"},
+        )
+        assert resp.status_code == 404

--- a/backend/tests/test_name_conflicts.py
+++ b/backend/tests/test_name_conflicts.py
@@ -148,3 +148,107 @@ class TestNextAvailableName:
     async def test_gives_up_and_returns_base_rather_than_failing(self):
         taken = AsyncMock(return_value=True)
         assert await nc.next_available_name("Everything Taken", taken) == "Everything Taken"
+
+
+# ---------------------------------------------------------------------------
+# Model identity: names and tags share one namespace
+# ---------------------------------------------------------------------------
+
+
+def _models(*pairs: tuple[str, str]) -> list[dict]:
+    return [{"name": n, "tag": t} for n, t in pairs]
+
+
+class TestEnsureModelIdentityAvailable:
+    def test_unique_name_and_tag_is_allowed(self):
+        nc.ensure_model_identity_available(
+            name="gpt-oss", tag="fast", models=_models(("qwen-large", "local")),
+        )
+
+    def test_duplicate_name_rejected(self):
+        with pytest.raises(nc.DuplicateNameError, match="qwen-large"):
+            nc.ensure_model_identity_available(
+                name="qwen-large", tag="fast", models=_models(("qwen-large", "local")),
+            )
+
+    def test_duplicate_name_differing_only_by_case_rejected(self):
+        with pytest.raises(nc.DuplicateNameError):
+            nc.ensure_model_identity_available(
+                name="QWEN-Large", tag="fast", models=_models(("qwen-large", "local")),
+            )
+
+    def test_duplicate_tag_rejected(self):
+        with pytest.raises(nc.DuplicateNameError, match="local"):
+            nc.ensure_model_identity_available(
+                name="gpt-oss", tag="local", models=_models(("qwen-large", "local")),
+            )
+
+    def test_duplicate_tag_differing_only_by_case_rejected(self):
+        with pytest.raises(nc.DuplicateNameError):
+            nc.ensure_model_identity_available(
+                name="gpt-oss", tag="LOCAL", models=_models(("qwen-large", "local")),
+            )
+
+    def test_name_colliding_with_another_models_tag_rejected(self):
+        # Resolution tries names before tags, so a new model named "local"
+        # would capture every request meant for the existing model's tag.
+        with pytest.raises(nc.DuplicateNameError):
+            nc.ensure_model_identity_available(
+                name="local", tag="reasoning", models=_models(("qwen-large", "local")),
+            )
+
+    def test_tag_colliding_with_another_models_name_rejected(self):
+        with pytest.raises(nc.DuplicateNameError):
+            nc.ensure_model_identity_available(
+                name="gpt-oss", tag="qwen-large", models=_models(("qwen-large", "local")),
+            )
+
+    def test_whitespace_around_the_submitted_value_cannot_bypass_the_check(self):
+        with pytest.raises(nc.DuplicateNameError):
+            nc.ensure_model_identity_available(
+                name="  qwen-large  ", tag="fast", models=_models(("qwen-large", "local")),
+            )
+
+    def test_whitespace_around_an_already_stored_value_cannot_bypass_the_check(self):
+        # A tag saved as "local " is indistinguishable from "local" in the admin
+        # UI, so it must still count as taken.
+        with pytest.raises(nc.DuplicateNameError):
+            nc.ensure_model_identity_available(
+                name="gpt-oss", tag="local", models=_models(("qwen-large", "  local  ")),
+            )
+
+    def test_a_models_own_name_may_equal_its_own_tag(self):
+        # Same model either way, so nothing is ambiguous.
+        nc.ensure_model_identity_available(
+            name="local", tag="local", models=_models(("qwen-large", "fast")),
+        )
+
+    def test_update_excludes_the_model_being_edited(self):
+        nc.ensure_model_identity_available(
+            name="qwen-large", tag="local",
+            models=_models(("qwen-large", "local"), ("gpt-oss", "fast")),
+            exclude_index=0,
+        )
+
+    def test_update_still_collides_with_a_different_model(self):
+        with pytest.raises(nc.DuplicateNameError, match="gpt-oss"):
+            nc.ensure_model_identity_available(
+                name="gpt-oss", tag="local",
+                models=_models(("qwen-large", "local"), ("gpt-oss", "fast")),
+                exclude_index=0,
+            )
+
+    def test_error_names_the_conflicting_value_and_the_model_holding_it(self):
+        with pytest.raises(nc.DuplicateNameError) as exc:
+            nc.ensure_model_identity_available(
+                name="gpt-oss", tag="local", models=_models(("qwen-large", "local")),
+            )
+        message = str(exc.value)
+        assert "local" in message and "qwen-large" in message
+
+    def test_entries_that_are_not_dicts_are_ignored(self):
+        # available_models is a free-form list on SystemConfig; the resolver
+        # guards with isinstance, so validation must not crash on junk.
+        nc.ensure_model_identity_available(
+            name="gpt-oss", tag="fast", models=["junk", None, {"name": "qwen", "tag": "local"}],
+        )

--- a/frontend/src/components/admin/ConfigTab.tsx
+++ b/frontend/src/components/admin/ConfigTab.tsx
@@ -21,6 +21,7 @@ import type {
   SystemConfigData,
 } from '../../api/admin'
 import { fileToConstrainedDataUrl } from '../../utils/imageResize'
+import { getModelIdentityError } from '../../utils/modelIdentity'
 import { ModelCharacterBars } from '../ModelEffortPicker'
 import type { ModelInfo } from '../../types/workflow'
 
@@ -742,6 +743,16 @@ export function ConfigTab() {
     }
     if (!newModel.tag.trim()) {
       setError('A tag is required (set one under Advanced settings)')
+      return
+    }
+    // Names and tags are one namespace: a collision makes a user's saved model
+    // selector resolve to whichever model comes first. The backend rejects this
+    // with a 409; warn here so the admin sees it before submitting.
+    const identityError = getModelIdentityError(
+      newModel.name, newModel.tag, cfg?.available_models ?? [], editingModelIndex,
+    )
+    if (identityError) {
+      setError(identityError)
       return
     }
     setSavingModel(true)

--- a/frontend/src/utils/modelIdentity.test.ts
+++ b/frontend/src/utils/modelIdentity.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest'
+
+import { getModelIdentityError } from './modelIdentity'
+
+const models = (...pairs: [string, string][]) => pairs.map(([name, tag]) => ({ name, tag }))
+
+describe('getModelIdentityError', () => {
+  it('allows a name and tag that collide with nothing', () => {
+    expect(getModelIdentityError('gpt-oss', 'fast', models(['qwen-large', 'local']))).toBeNull()
+  })
+
+  it('rejects a duplicate name and says which model holds it', () => {
+    const error = getModelIdentityError('qwen-large', 'fast', models(['qwen-large', 'local']))
+    expect(error).toContain('qwen-large')
+  })
+
+  it('rejects a duplicate tag and says which model holds it', () => {
+    const error = getModelIdentityError('gpt-oss', 'local', models(['qwen-large', 'local']))
+    expect(error).toContain('local')
+    expect(error).toContain('qwen-large')
+  })
+
+  it('treats case-only differences as collisions', () => {
+    expect(getModelIdentityError('QWEN-Large', 'fast', models(['qwen-large', 'local']))).not.toBeNull()
+    expect(getModelIdentityError('gpt-oss', 'LOCAL', models(['qwen-large', 'local']))).not.toBeNull()
+  })
+
+  it('rejects a name that matches another model tag', () => {
+    // Resolution tries names before tags, so this would hijack the other
+    // model's tag.
+    expect(getModelIdentityError('local', 'reasoning', models(['qwen-large', 'local']))).not.toBeNull()
+  })
+
+  it('rejects a tag that matches another model name', () => {
+    expect(getModelIdentityError('gpt-oss', 'qwen-large', models(['qwen-large', 'local']))).not.toBeNull()
+  })
+
+  it('ignores whitespace around the submitted value', () => {
+    expect(getModelIdentityError('  qwen-large  ', 'fast', models(['qwen-large', 'local']))).not.toBeNull()
+  })
+
+  it('ignores whitespace around an already stored value', () => {
+    expect(getModelIdentityError('gpt-oss', 'local', models(['qwen-large', '  local  ']))).not.toBeNull()
+  })
+
+  it('lets a model use the same string for its own name and tag', () => {
+    expect(getModelIdentityError('local', 'local', models(['qwen-large', 'fast']))).toBeNull()
+  })
+
+  it('excludes the model being edited', () => {
+    const existing = models(['qwen-large', 'local'], ['gpt-oss', 'fast'])
+    expect(getModelIdentityError('qwen-large', 'local', existing, 0)).toBeNull()
+  })
+
+  it('still reports a collision with a different model while editing', () => {
+    const existing = models(['qwen-large', 'local'], ['gpt-oss', 'fast'])
+    expect(getModelIdentityError('gpt-oss', 'local', existing, 0)).toContain('gpt-oss')
+  })
+
+  it('ignores empty values rather than matching them against each other', () => {
+    expect(getModelIdentityError('gpt-oss', '', models(['qwen-large', '']))).toBeNull()
+  })
+})

--- a/frontend/src/utils/modelIdentity.ts
+++ b/frontend/src/utils/modelIdentity.ts
@@ -1,0 +1,57 @@
+// Model names and tags form a single identifier namespace. The backend resolver
+// (get_llm_model_by_name) scans names first and tags second, returning the first
+// match either way, so two models sharing a tag - or one model whose name is
+// another's tag - make a selector ambiguous and let list order decide the
+// winner. User model preferences are stored as that selector.
+//
+// Mirrors backend/app/services/name_conflicts.py:ensure_model_identity_available
+// - keep the two in sync. The backend rejects collisions with an HTTP 409; this
+// lets the admin form warn before submitting.
+
+type ModelIdentity = { name?: string; tag?: string }
+
+/** Normalize a model name or tag for comparison. Mirrors _model_identifier. */
+function identifier(value: string | undefined): string {
+  return (value ?? '').trim().toLowerCase()
+}
+
+/**
+ * Check a proposed model name and tag against the models already configured.
+ * Returns a human-readable error message if either collides, or null if the
+ * identity is free. Pass `excludeIndex` when editing so a model does not
+ * collide with itself.
+ */
+export function getModelIdentityError(
+  name: string,
+  tag: string,
+  models: readonly ModelIdentity[],
+  excludeIndex: number | null = null,
+): string | null {
+  const candidates: [string, string][] = [
+    ['name', (name ?? '').trim()],
+    ['tag', (tag ?? '').trim()],
+  ]
+
+  for (let index = 0; index < models.length; index++) {
+    if (index === excludeIndex) continue
+    const existing = models[index]
+    if (!existing) continue
+
+    const owner = (existing.name ?? '').trim() || `at index ${index}`
+    const taken: [string, string][] = [
+      ['name', identifier(existing.name)],
+      ['tag', identifier(existing.tag)],
+    ]
+
+    for (const [field, value] of candidates) {
+      if (!value) continue
+      for (const [takenField, takenValue] of taken) {
+        if (takenValue && identifier(value) === takenValue) {
+          return `Model ${field} "${value}" is already used as the ${takenField} of model "${owner}". Model names and tags must be unique.`
+        }
+      }
+    }
+  }
+
+  return null
+}


### PR DESCRIPTION
## Summary

Model names and tags are resolved from one namespace but were validated as none: `get_llm_model_by_name` scans names first and tags second and returns the first match either way, while user model preferences are stored and returned as *tags*. Two models sharing a tag therefore made a user's saved selector ambiguous, and list order silently decided which model answered — no error, and nothing in the UI indicating a different model had been substituted. The same precedence meant a model whose **name** equalled another model's **tag** would capture that tag's traffic.

This validates names and tags as a single case-insensitive, whitespace-trimmed identifier namespace, rejected authoritatively by the backend and mirrored in the admin form.

Reported in #582.

## Changes

- **`backend/app/services/name_conflicts.py`** — new `ensure_model_identity_available(name, tag, models, exclude_index)`. Raises the module's existing `DuplicateNameError` naming both the conflicting value and the model already holding it. Unlike the other `ensure_*` helpers it compares in memory, because `available_models` is an embedded list on `SystemConfig` rather than a collection.
- **`backend/app/routers/admin.py`** — `add_model` and `update_model` call it and translate `DuplicateNameError` to **HTTP 409**, the same way `knowledge.py`, `workflows.py` and `extractions.py` already do. `update_model` passes `exclude_index` so editing a model doesn't collide with itself, and the existing index-bounds 404 still runs first.
- **`frontend/src/utils/modelIdentity.ts`** — `getModelIdentityError()`, mirroring the backend rule so the form can warn before submitting. Follows the pattern `nameValidation.ts` already documents for 409-backed uniqueness.
- **`frontend/src/components/admin/ConfigTab.tsx`** — `handleSaveModel` surfaces that message instead of submitting.
- **`CHANGELOG.md`** — entry under `[Unreleased] → Fixed`.

Rejected arrangements (case-insensitive, whitespace-trimmed):

```
Model A: name=qwen,    tag=local
Model B: name=gpt-oss, tag=local       # duplicate tag
Model C: name=local,   tag=reasoning   # name collides with A's tag
Model D: name=QWEN,    tag=fast        # case-only name collision
```

A model may still use the same string for its own name and tag — that resolves to one model either way, so nothing is ambiguous.

## Compatibility

Validation runs **only on create and update**, never at startup or load. An existing install that already contains a collision keeps working and stays editable so an administrator can repair it. Nothing is renamed automatically, and no migration is required.

Storing a durable model identifier in `UserModelConfig` instead of a tag would be a stronger long-term design, but it needs a migration for existing preferences and is deliberately left out of this PR.

## Test Plan

- [x] Shared checks pass (`make ci`)
- [ ] Release check passes if packaging or deployment changed (`make release-check`) — n/a, no packaging or deployment change
- [x] Manually tested the affected feature(s)
- [x] Updated `CHANGELOG.md` for user-facing or operator-facing changes
- [ ] Updated deploy/release docs — n/a, install and release paths unchanged

Added coverage:

- **`backend/tests/test_name_conflicts.py`** — 14 cases over the helper: duplicate name, duplicate tag, both cross-field directions, case-only collisions, whitespace on the submitted *and* the stored value, `exclude_index` on update, a model's own name equalling its own tag, non-dict entries in `available_models`, and the error message naming the conflicting value and its holder.
- **`backend/tests/test_admin_routes.py`** — 6 route cases: 409 on duplicate tag and on name-equals-another-tag for `POST`; 409 when an update moves onto another model's tag; 200 when an update leaves identity unchanged; 200 for a genuinely unique model; and 404 index bounds still checked before identity. The rejection cases assert the config was **not** saved.
- **`frontend/src/utils/modelIdentity.test.ts`** — 12 cases mirroring the backend rules.

Each test was written before the code and observed failing first. The helper was additionally checked against four deliberately wrong implementations — dropping `casefold`, dropping `strip`, ignoring `exclude_index`, and comparing same-field only. The first pass left the missing-`strip` mutant alive, which exposed a genuine gap: nothing covered a *stored* value carrying stray whitespace. A test was added for that case and all four mutants are now caught.

## Related Issues

Closes #582
