### PR TITLE
fix(workflows): pause at every approval gate, not just the first

### DIFF
--- a/backend/app/services/workflow_engine.py
+++ b/backend/app/services/workflow_engine.py
@@ -1553,8 +1553,12 @@ class WorkflowEngine:
 
             latest_output = output
 
-            # Check for approval pause signal
+            # Check for approval pause signal. Stamp the index of the node that
+            # paused: every ApprovalNode is named "Approval", so a workflow with
+            # more than one gate can't be resolved by name alone, and the caller
+            # needs the exact index to resume past *this* gate.
             if latest_output and latest_output.get("_approval_pause"):
+                latest_output["_paused_step_index"] = idx
                 return latest_output, data
 
             if workflow_result_updater:

--- a/backend/app/tasks/workflow_tasks.py
+++ b/backend/app/tasks/workflow_tasks.py
@@ -129,12 +129,18 @@ def _bson_safe(value):
     return str(value)
 
 
-def _pause_for_approval(db, final_output, engine, workflow_id, workflow_result_id):
+def _pause_for_approval(db, final_output, engine, workflow_id, workflow_result_id,
+                        search_from=0):
     """Persist the approval request and flip the run to ``pending_approval``.
 
     Extracted from :func:`execute_workflow_task` so the whole sequence runs
     under a single guard in the caller: any failure here must surface as an
     error status instead of silently freezing the run.
+
+    Args:
+        search_from: Index the current execution pass started at. Used only as
+            the floor for the legacy name-scan fallback; the engine normally
+            stamps the exact paused index on the sentinel.
     """
     import uuid as uuid_mod
     from datetime import datetime, timedelta, timezone
@@ -146,13 +152,21 @@ def _pause_for_approval(db, final_output, engine, workflow_id, workflow_result_i
         resolve_assignees_sync,
     )
 
-    # Find the step index (count of executed steps)
-    nodes = engine.get_topological_order()
-    step_index = 0
-    for idx, node in enumerate(nodes):
-        if node.name == "Approval":
-            step_index = idx
-            break
+    # Which step paused. The engine stamps the exact index on the sentinel;
+    # fall back to a name scan bounded below by ``search_from`` for sentinels
+    # produced before that stamp existed. The floor matters: all Approval nodes
+    # share the name "Approval", so an unbounded scan on the *second* gate would
+    # return the first gate's index and resume would replay it forever.
+    stamped = final_output.get("_paused_step_index")
+    if isinstance(stamped, int):
+        step_index = stamped
+    else:
+        nodes = engine.get_topological_order()
+        step_index = search_from
+        for idx, node in enumerate(nodes):
+            if idx >= search_from and node.name == "Approval":
+                step_index = idx
+                break
 
     approval_uuid = str(uuid_mod.uuid4())
     workflow_doc = db.workflow.find_one({"_id": ObjectId(workflow_id)})
@@ -1077,6 +1091,28 @@ def resume_workflow_after_approval(self, approval_uuid):
             {"$set": {"status": "error", "error": str(e)}},
         )
         raise
+
+    # A workflow may have more than one approval gate. Resuming past the first
+    # one can land on another, so the resume path needs the same pause handling
+    # as the initial run — without it the second gate's sentinel was treated as
+    # a normal final output and the run was marked "completed" with no review
+    # ever created for the second reviewer.
+    if isinstance(final_output, dict) and final_output.get("_approval_pause"):
+        try:
+            return _pause_for_approval(
+                db, final_output, engine, workflow_id, workflow_result_id,
+                search_from=step_index + 1,
+            )
+        except Exception as e:
+            logger.exception(
+                "Approval gate handling failed on resume for workflow %s (result %s)",
+                workflow_id, workflow_result_id,
+            )
+            db.workflow_result.update_one(
+                {"_id": ObjectId(workflow_result_id)},
+                {"$set": {"status": "error", "error": f"Approval gate failed: {e}"}},
+            )
+            raise
 
     db.workflow_result.update_one(
         {"_id": ObjectId(workflow_result_id)},

--- a/backend/tests/test_workflow_engine_core.py
+++ b/backend/tests/test_workflow_engine_core.py
@@ -266,8 +266,40 @@ class TestWorkflowEngineExecute:
         final, data = engine.execute()
         assert isinstance(final, dict)
         assert final.get("_approval_pause") is True
+        assert final.get("_paused_step_index") == 1
         # AddDocumentNode should NOT have executed
         assert all(d["name"] != "AddDocument" for d in data)
+
+    def test_second_approval_pause_reports_its_own_index(self):
+        """Two gates: resuming past the first must pause at the second and
+        report the second node's index, not the first's. All ApprovalNodes are
+        named "Approval", so the index is the only thing distinguishing them."""
+        engine = WorkflowEngine()
+        doc = DocumentNode({"doc_uuids": ["a"]})
+        first = ApprovalNode({"review_instructions": "First review"})
+        middle = AddDocumentNode({"doc_texts": ["between the gates"]})
+        second = ApprovalNode({"review_instructions": "Second review"})
+        tail = AddDocumentNode({"doc_texts": ["should not run"]})
+
+        for node in (doc, first, middle, second, tail):
+            engine.add_node(node)
+        engine.connect(doc, first)
+        engine.connect(first, middle)
+        engine.connect(middle, second)
+        engine.connect(second, tail)
+
+        final, _ = engine.execute()
+        assert final.get("_paused_step_index") == 1
+
+        # Resume past the first gate — the engine must stop again at index 3.
+        resumed, data = engine.execute(
+            start_index=2, initial_output={"output": "approved artifact"},
+        )
+        assert resumed.get("_approval_pause") is True
+        assert resumed.get("_review_instructions") == "Second review"
+        assert resumed.get("_paused_step_index") == 3
+        # Only the step between the gates ran; the tail is still pending.
+        assert [d["name"] for d in data] == ["AddDocument"]
 
     def test_resume_from_start_index(self):
         """Engine can resume from a specific step index with initial_output."""

--- a/backend/tests/test_workflow_tasks.py
+++ b/backend/tests/test_workflow_tasks.py
@@ -496,6 +496,96 @@ class TestResumeWorkflowAfterApproval:
         db.workflow.update_one.assert_called_once()
 
     @patch("app.tasks.workflow_tasks._get_db")
+    @patch("app.services.workflow_engine.build_workflow_engine")
+    def test_resume_pauses_again_at_second_approval(self, mock_build, mock_get_db):
+        """A workflow with two gates must pause a second time. The resume path
+        used to ignore the sentinel and mark the run completed, so the second
+        reviewer was never asked to approve anything."""
+        from app.tasks.workflow_tasks import resume_workflow_after_approval
+
+        wf_id, result_id = _fake_oid(), _fake_oid()
+        db = _mock_db(
+            workflow_doc=_make_workflow_doc(wf_id=wf_id),
+            result_doc=_make_result_doc(result_id=result_id, workflow_id=wf_id),
+            approval_doc={
+                "uuid": "a1", "status": "approved",
+                "workflow_result_id": result_id, "workflow_id": wf_id,
+                "step_index": 1, "data_for_review": {"extracted": "data"},
+            },
+        )
+        mock_get_db.return_value = db
+
+        mock_engine = MagicMock()
+        mock_engine.execute.return_value = ({
+            "_approval_pause": True,
+            "_paused_step_index": 3,
+            "_review_instructions": "Second review",
+            "_assigned_to_user_ids": ["reviewer2"],
+            "_data_for_review": {"key": "value"},
+            "output": {"key": "value"},
+        }, [])
+        mock_build.return_value = mock_engine
+
+        result = resume_workflow_after_approval("a1")
+
+        assert result["status"] == "pending_approval"
+        db.approval_request.insert_one.assert_called_once()
+        approval_data = db.approval_request.insert_one.call_args[0][0]
+        assert approval_data["status"] == "pending"
+        assert approval_data["step_index"] == 3
+        assert approval_data["review_instructions"] == "Second review"
+        assert approval_data["assigned_to_user_ids"] == ["reviewer2"]
+
+        statuses = [c[0][1].get("$set", {}).get("status")
+                    for c in db.workflow_result.update_one.call_args_list]
+        assert "completed" not in statuses
+        assert "pending_approval" in statuses
+        # A run still awaiting review must not count as an execution.
+        db.workflow.update_one.assert_not_called()
+
+    @patch("app.tasks.workflow_tasks._get_db")
+    @patch("app.services.workflow_engine.build_workflow_engine")
+    def test_resume_pause_without_stamped_index_scans_forward(self, mock_build, mock_get_db):
+        """Fallback path for a sentinel with no stamped index: the name scan is
+        floored at the resume point so it can't re-select the first gate."""
+        from app.tasks.workflow_tasks import resume_workflow_after_approval
+
+        wf_id, result_id = _fake_oid(), _fake_oid()
+        db = _mock_db(
+            workflow_doc=_make_workflow_doc(wf_id=wf_id),
+            result_doc=_make_result_doc(result_id=result_id, workflow_id=wf_id),
+            approval_doc={
+                "uuid": "a1", "status": "approved",
+                "workflow_result_id": result_id, "workflow_id": wf_id,
+                "step_index": 1, "data_for_review": {"extracted": "data"},
+            },
+        )
+        mock_get_db.return_value = db
+
+        def _node(name):
+            n = MagicMock()
+            n.name = name
+            return n
+
+        mock_engine = MagicMock()
+        mock_engine.execute.return_value = ({
+            "_approval_pause": True,
+            "_assigned_to_user_ids": ["reviewer2"],
+            "_data_for_review": {"key": "value"},
+            "output": {"key": "value"},
+        }, [])
+        mock_engine.get_topological_order.return_value = [
+            _node("Document"), _node("Approval"), _node("Prompt"),
+            _node("Approval"), _node("AddDocument"),
+        ]
+        mock_build.return_value = mock_engine
+
+        result = resume_workflow_after_approval("a1")
+
+        assert result["status"] == "pending_approval"
+        assert db.approval_request.insert_one.call_args[0][0]["step_index"] == 3
+
+    @patch("app.tasks.workflow_tasks._get_db")
     def test_missing_approval_raises(self, mock_get_db):
         from app.tasks.workflow_tasks import resume_workflow_after_approval
 


### PR DESCRIPTION
## Ticket

> Workflows with two approval steps skip the second one. A workflow with two approval steps only ever creates the first review. Once that's approved, the workflow resumes, reaches the second approval step, and instead of pausing for review it's marked Completed.

## Root cause

Two compounding defects:

**1. The resume task never checked for a pause.** `execute_workflow_task` inspects the engine's `_approval_pause` sentinel and hands it to `_pause_for_approval`. `resume_workflow_after_approval` had no such check — it took whatever `engine.execute()` returned and unconditionally wrote `status: "completed"`. The second gate's sentinel was stored as if it were the workflow's final output, and no `ApprovalRequest` was ever created. That is the reported symptom exactly.

**2. The step index was resolved by name.** `_pause_for_approval` scanned the topological order for the first node named `"Approval"`. Every `ApprovalNode` is constructed as `super().__init__("Approval")`, so a second gate is indistinguishable by name. Even with fix 1 alone, the second pause would record the *first* gate's index, and approving it would resume from that point again — replaying the middle steps and re-hitting the same gate forever.

## Fix

- `WorkflowEngine.execute` stamps `_paused_step_index` on the sentinel with the index of the node that actually paused — the only unambiguous identifier when every gate shares a name.
- `_pause_for_approval` prefers that stamp. The name scan survives as a fallback for any sentinel already in flight when this deploys, now floored at a new `search_from` argument so it cannot select an earlier gate.
- `resume_workflow_after_approval` gets the same guarded pause handling as the initial run, so a resumed run that lands on another gate goes back to `pending_approval` instead of `completed`.

A run still awaiting review no longer increments `num_executions`, since it hasn't finished.

## Tests

- `test_workflow_engine_core.py` — a five-node two-gate graph asserting the resumed pass pauses at index 3 and carries the *second* gate's review instructions.
- `test_workflow_tasks.py` — resume pauses again and creates the request with `step_index: 3` and the second gate's assignee, never writes `completed`, and doesn't increment `num_executions`; plus the unstamped-sentinel fallback path.

All four new/changed assertions were confirmed to fail with the source fix reverted and pass with it applied. 202 workflow tests pass; ruff output on the touched files is unchanged from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)