### PR TITLE
feat(notifications): notify users when things fail

### DIFF
--- a/backend/app/models/notification.py
+++ b/backend/app/models/notification.py
@@ -1,4 +1,4 @@
-"""User notifications for verification status changes and quality alerts."""
+"""User notifications for verification status changes, quality alerts, and failures."""
 
 import datetime
 import uuid as uuid_mod
@@ -11,16 +11,28 @@ from pydantic import Field
 class Notification(Document):
     uuid: str = Field(default_factory=lambda: uuid_mod.uuid4().hex)
     user_id: str  # recipient
-    kind: str  # "verification_approved", "verification_rejected", "verification_returned", "verification_stale"
+    kind: str  # "verification_approved", "workflow_failed", "document_failed", ...
     title: str
     body: Optional[str] = None
     link: Optional[str] = None  # frontend route to navigate to
+
+    # "info" for the ordinary event stream, "error" for failures. The bell
+    # styles these differently, and it lets a failures-only view filter without
+    # having to enumerate every failure kind.
+    severity: str = "info"
 
     # Related entity
     item_kind: Optional[str] = None  # "workflow", "search_set", "knowledge_base"
     item_id: Optional[str] = None
     item_name: Optional[str] = None
     request_uuid: Optional[str] = None  # verification request UUID
+
+    # Repeated occurrences of the same event fold into one unread row keyed by
+    # coalesce_key rather than filling the bell. A weekly automation that has
+    # failed nine times is one entry with occurrences=9, not nine entries.
+    # (Named `occurrences`, not `count`, which would shadow Document.count.)
+    coalesce_key: Optional[str] = None
+    occurrences: int = 1
 
     read: bool = False
     created_at: datetime.datetime = Field(
@@ -33,4 +45,5 @@ class Notification(Document):
             "user_id",
             "uuid",
             [("user_id", 1), ("read", 1), ("created_at", -1)],
+            [("user_id", 1), ("coalesce_key", 1), ("read", 1)],
         ]

--- a/backend/app/services/failure_notifications.py
+++ b/backend/app/services/failure_notifications.py
@@ -1,0 +1,217 @@
+"""Emitters for "your thing broke" notifications.
+
+The notification system historically carried only successful events (approvals,
+verification decisions, catalog updates, team shares), so a failed workflow, a
+document that never finished processing, or a recurring automation that has been
+erroring for weeks produced no signal at all — the only way to find out was to
+go looking.
+
+These helpers are the failure half. They run in Celery workers, which hold a raw
+pymongo handle rather than a Beanie session, so everything here is sync and
+routes through `notification_service.create_notification_sync`.
+
+Two rules the call sites depend on:
+
+* **Never raise.** A notification is a side channel; a task that did real work
+  must not fail (or retry) because the bell entry could not be written.
+* **Only fire on the final attempt.** Most of these tasks carry
+  `autoretry_for=TRANSIENT_EXCEPTIONS`, so a mid-retry emit would tell the user
+  a run failed while it is in fact about to succeed. Use `is_final_attempt`.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from app.services.notification_service import create_notification_sync
+from app.tasks import TRANSIENT_EXCEPTIONS
+
+logger = logging.getLogger(__name__)
+
+# Failure bodies quote the underlying error. Keep it short enough to read in the
+# bell dropdown — the full text is always on the run/document record.
+_ERROR_SNIPPET = 200
+
+
+def is_final_attempt(task: Any, exc: BaseException) -> bool:
+    """True when Celery will not retry `exc` for `task` again.
+
+    A non-transient exception is never retried, so the first raise is also the
+    last. A transient one is final only once the retry budget is spent.
+    """
+    if not isinstance(exc, TRANSIENT_EXCEPTIONS):
+        return True
+    try:
+        retries = task.request.retries or 0
+        max_retries = task.max_retries
+    except AttributeError:
+        return True
+    if max_retries is None:
+        return False
+    return retries >= max_retries
+
+
+def _snippet(error: Any) -> str:
+    text = str(error or "").strip()
+    if not text:
+        return "No error detail was recorded."
+    return text[:_ERROR_SNIPPET]
+
+
+def notify_workflow_failed(
+    db,
+    *,
+    workflow_doc: dict | None,
+    error: Any,
+    user_id: str | None = None,
+    automation_name: str | None = None,
+) -> None:
+    """Notify the owner that a workflow run failed.
+
+    `automation_name` distinguishes "the workflow you just ran failed" from "the
+    automation that runs this workflow on a schedule failed", which is the case
+    the user has no other way to notice.
+    """
+    try:
+        workflow_doc = workflow_doc or {}
+        recipient = user_id or workflow_doc.get("user_id")
+        if not recipient:
+            return
+
+        workflow_id = str(workflow_doc.get("_id") or "")
+        name = workflow_doc.get("name") or "Workflow"
+
+        if automation_name:
+            title = f"Automation failed: {automation_name}"
+            group_title = f"Automation failed {{count}}×: {automation_name}"
+            body = f'Workflow "{name}" did not complete. {_snippet(error)}'
+        else:
+            title = f"Workflow failed: {name}"
+            group_title = f"Workflow failed {{count}}×: {name}"
+            body = _snippet(error)
+
+        create_notification_sync(
+            db,
+            user_id=recipient,
+            kind="workflow_failed",
+            title=title,
+            body=body,
+            link=f"/?workflow={workflow_id}" if workflow_id else "/",
+            item_kind="workflow",
+            item_id=workflow_id or None,
+            item_name=name,
+            coalesce_key=f"workflow_failed:{workflow_id or name}",
+            group_title=group_title,
+        )
+    except Exception:
+        logger.exception("Failed to emit workflow failure notification")
+
+
+def notify_extraction_failed(
+    db,
+    *,
+    user_id: str | None,
+    search_set_uuid: str | None,
+    error: Any,
+    search_set_name: str | None = None,
+) -> None:
+    """Notify the owner that an extraction run failed."""
+    try:
+        if not user_id:
+            return
+
+        name = search_set_name
+        if not name and search_set_uuid:
+            ss = db.search_set.find_one({"uuid": search_set_uuid}, {"title": 1})
+            name = (ss or {}).get("title")
+        name = name or "Extraction"
+
+        create_notification_sync(
+            db,
+            user_id=user_id,
+            kind="extraction_failed",
+            title=f"Extraction failed: {name}",
+            body=_snippet(error),
+            link=f"/?extraction={search_set_uuid}" if search_set_uuid else "/",
+            item_kind="search_set",
+            item_id=search_set_uuid,
+            item_name=name,
+            coalesce_key=f"extraction_failed:{search_set_uuid or name}",
+            group_title=f"Extraction failed {{count}}×: {name}",
+        )
+    except Exception:
+        logger.exception("Failed to emit extraction failure notification")
+
+
+def notify_document_failed(db, *, doc: dict | None, error: Any) -> None:
+    """Notify the owner that a document could not be processed.
+
+    Coalesced per user rather than per document: a 50-file upload where a dozen
+    files are corrupt should read as "12 documents failed to process", not bury
+    the bell.
+    """
+    try:
+        doc = doc or {}
+        recipient = doc.get("user_id")
+        if not recipient:
+            return
+
+        title = doc.get("title") or "Document"
+        create_notification_sync(
+            db,
+            user_id=recipient,
+            kind="document_failed",
+            title=f"Document failed to process: {title}",
+            body=_snippet(error),
+            link="/?mode=files",
+            item_kind="document",
+            item_id=doc.get("uuid"),
+            item_name=title,
+            coalesce_key=f"document_failed:{recipient}",
+            group_title="{count} documents failed to process",
+        )
+    except Exception:
+        logger.exception("Failed to emit document failure notification")
+
+
+def notify_automation_failed(
+    db,
+    *,
+    automation: dict | None,
+    error: Any,
+    detail: str | None = None,
+) -> None:
+    """Notify the owner that an automation could not be dispatched or run.
+
+    This is the scheduler-side failure — the automation never got as far as a
+    workflow run, so `notify_workflow_failed` would never fire for it.
+    """
+    try:
+        automation = automation or {}
+        recipient = automation.get("user_id")
+        if not recipient:
+            return
+
+        automation_id = str(automation.get("_id") or "")
+        name = automation.get("name") or "Automation"
+        body = f"{detail} {_snippet(error)}" if detail else _snippet(error)
+
+        create_notification_sync(
+            db,
+            user_id=recipient,
+            kind="automation_failed",
+            title=f"Automation failed: {name}",
+            body=body,
+            link=(
+                f"/?mode=automations&automation={automation_id}"
+                if automation_id else "/?mode=automations"
+            ),
+            item_kind="automation",
+            item_id=automation_id or None,
+            item_name=name,
+            coalesce_key=f"automation_failed:{automation_id or name}",
+            group_title=f"Automation failed {{count}}×: {name}",
+        )
+    except Exception:
+        logger.exception("Failed to emit automation failure notification")

--- a/backend/app/services/notification_service.py
+++ b/backend/app/services/notification_service.py
@@ -1,8 +1,12 @@
-"""Notification service for verification and support events."""
+"""Notification service for verification, support, and failure events."""
 
 import datetime
+import logging
+import uuid as uuid_mod
 
 from app.models.notification import Notification
+
+logger = logging.getLogger(__name__)
 
 # Notification kinds that should coalesce: if an unread notification already
 # exists for the same (user, item_kind, item_id), update it instead of
@@ -13,6 +17,35 @@ _COALESCE_KINDS = frozenset({
     "support_new_message",
     "support_new_ticket",
 })
+
+# Kinds that report something went wrong. Callers may pass severity explicitly;
+# this set means the failure emitters can't forget to.
+FAILURE_KINDS = frozenset({
+    "workflow_failed",
+    "extraction_failed",
+    "document_failed",
+    "automation_failed",
+})
+
+
+def _resolve_severity(kind: str, severity: str | None) -> str:
+    if severity:
+        return severity
+    return "error" if kind in FAILURE_KINDS else "info"
+
+
+def _apply_group_title(group_title: str | None, fallback: str, count: int) -> str:
+    """Render the repeat-count title for a coalesced notification.
+
+    `group_title` is a format string taking {count}; a malformed one falls back
+    to the single-event title rather than blowing up the calling task.
+    """
+    if not group_title or count < 2:
+        return fallback
+    try:
+        return group_title.format(count=count)
+    except (KeyError, IndexError, ValueError):
+        return fallback
 
 
 async def create_notification(
@@ -25,8 +58,36 @@ async def create_notification(
     item_id: str | None = None,
     item_name: str | None = None,
     request_uuid: str | None = None,
+    severity: str | None = None,
+    coalesce_key: str | None = None,
+    group_title: str | None = None,
 ) -> dict:
-    # Coalesce: update existing unread notification for the same item
+    severity = _resolve_severity(kind, severity)
+    now = datetime.datetime.now(datetime.timezone.utc)
+
+    # Explicit group coalescing: repeated occurrences of the same event fold
+    # into one unread row and bump its count.
+    if coalesce_key:
+        existing = await Notification.find_one(
+            Notification.user_id == user_id,
+            Notification.coalesce_key == coalesce_key,
+            Notification.read == False,  # noqa: E712
+        )
+        if existing:
+            existing.occurrences = (existing.occurrences or 1) + 1
+            existing.title = _apply_group_title(group_title, title, existing.occurrences)
+            existing.body = body
+            existing.kind = kind
+            existing.link = link
+            existing.severity = severity
+            existing.item_kind = item_kind
+            existing.item_id = item_id
+            existing.item_name = item_name
+            existing.created_at = now
+            await existing.save()
+            return _to_dict(existing)
+
+    # Legacy per-item coalescing for the support kinds.
     if kind in _COALESCE_KINDS and item_kind and item_id:
         existing = await Notification.find_one(
             Notification.user_id == user_id,
@@ -39,7 +100,7 @@ async def create_notification(
             existing.body = body
             existing.kind = kind
             existing.link = link
-            existing.created_at = datetime.datetime.now(datetime.timezone.utc)
+            existing.created_at = now
             await existing.save()
             return _to_dict(existing)
 
@@ -49,13 +110,88 @@ async def create_notification(
         title=title,
         body=body,
         link=link,
+        severity=severity,
         item_kind=item_kind,
         item_id=item_id,
         item_name=item_name,
         request_uuid=request_uuid,
+        coalesce_key=coalesce_key,
     )
     await n.insert()
     return _to_dict(n)
+
+
+def create_notification_sync(
+    db,
+    user_id: str,
+    kind: str,
+    title: str,
+    body: str | None = None,
+    link: str | None = None,
+    item_kind: str | None = None,
+    item_id: str | None = None,
+    item_name: str | None = None,
+    severity: str | None = None,
+    coalesce_key: str | None = None,
+    group_title: str | None = None,
+) -> None:
+    """Create a notification from a synchronous (Celery worker) context.
+
+    Celery tasks hold a raw pymongo handle, not a Beanie/Motor session, so they
+    cannot await `create_notification`. This mirrors its coalescing semantics
+    against the same collection. Never raises: a task that did real work must
+    not fail because the bell entry could not be written.
+    """
+    try:
+        now = datetime.datetime.now(datetime.timezone.utc)
+        severity = _resolve_severity(kind, severity)
+
+        if coalesce_key:
+            existing = db.notification.find_one({
+                "user_id": user_id,
+                "coalesce_key": coalesce_key,
+                "read": False,
+            })
+            if existing:
+                occurrences = (existing.get("occurrences") or 1) + 1
+                db.notification.update_one(
+                    {"_id": existing["_id"]},
+                    {"$set": {
+                        "occurrences": occurrences,
+                        "title": _apply_group_title(group_title, title, occurrences),
+                        "body": body,
+                        "kind": kind,
+                        "link": link,
+                        "severity": severity,
+                        "item_kind": item_kind,
+                        "item_id": item_id,
+                        "item_name": item_name,
+                        "created_at": now,
+                    }},
+                )
+                return
+
+        db.notification.insert_one({
+            "uuid": uuid_mod.uuid4().hex,
+            "user_id": user_id,
+            "kind": kind,
+            "title": title,
+            "body": body,
+            "link": link,
+            "severity": severity,
+            "item_kind": item_kind,
+            "item_id": item_id,
+            "item_name": item_name,
+            "request_uuid": None,
+            "coalesce_key": coalesce_key,
+            "occurrences": 1,
+            "read": False,
+            "created_at": now,
+        })
+    except Exception:
+        logger.exception(
+            "Failed to write %s notification for user %s", kind, user_id,
+        )
 
 
 async def list_notifications(user_id: str, unread_only: bool = False, limit: int = 50) -> list[dict]:
@@ -117,6 +253,8 @@ def _to_dict(n: Notification) -> dict:
         "title": n.title,
         "body": n.body,
         "link": n.link,
+        "severity": getattr(n, "severity", None) or "info",
+        "occurrences": getattr(n, "occurrences", None) or 1,
         "item_kind": n.item_kind,
         "item_id": n.item_id,
         "item_name": n.item_name,

--- a/backend/app/services/output_handlers.py
+++ b/backend/app/services/output_handlers.py
@@ -8,6 +8,7 @@ import csv
 import json
 import logging
 from datetime import datetime, timezone
+from html import escape
 from pathlib import Path
 from uuid import uuid4
 
@@ -264,6 +265,16 @@ def _save_extraction_as_pdf(file_path: Path, data: dict, title: str = "Extractio
         f.write(pdf_bytes)
 
 
+# A run that failed is recorded as "error" on WorkflowResult but "failed" on the
+# trigger event and activity rail. Both spellings reach the output handlers, and
+# treating only one as failure is why "notify me on failure" never fired.
+_FAILED_STATUSES = frozenset({"error", "failed"})
+
+
+def is_failed_status(status: str | None) -> bool:
+    return (status or "") in _FAILED_STATUSES
+
+
 def should_send_notification(result_doc: dict, notification: dict) -> bool:
     """Check if notification should be sent based on conditions."""
     condition = notification.get("conditions", "always")
@@ -272,7 +283,7 @@ def should_send_notification(result_doc: dict, notification: dict) -> bool:
     elif condition == "success":
         return result_doc.get("status") == "completed"
     elif condition == "failure":
-        return result_doc.get("status") == "failed"
+        return is_failed_status(result_doc.get("status"))
     return True
 
 
@@ -308,19 +319,30 @@ def send_workflow_notification(
     wf_name = workflow.get("name", "Workflow")
     status = result_doc.get("status", "unknown")
 
+    safe_name = escape(str(wf_name))
+    error_html = ""
+
     if status == "completed":
         subject = f"✓ {wf_name} completed"
-    elif status == "failed":
+        summary = f'Your workflow "{safe_name}" has completed.'
+    elif is_failed_status(status):
         subject = f"⚠️ {wf_name} failed"
+        summary = f'Your workflow "{safe_name}" failed.'
+        # Without the reason the mail says only "something broke", which sends
+        # the reader back into the app to find out what.
+        error = str(result_doc.get("error") or "No error detail was recorded.")
+        error_html = f"<p><strong>Error:</strong> {escape(error[:500])}</p>"
     else:
         subject = f"{wf_name} - {status}"
+        summary = f'Your workflow "{safe_name}" is {escape(str(status))}.'
 
     html_body = f"""
     <html>
     <body>
-        <h2>{subject}</h2>
-        <p>Your workflow "{wf_name}" has {status}.</p>
-        <p><strong>Trigger Type:</strong> {result_doc.get('trigger_type', 'manual')}</p>
+        <h2>{escape(subject)}</h2>
+        <p>{summary}</p>
+        {error_html}
+        <p><strong>Trigger Type:</strong> {escape(str(result_doc.get('trigger_type', 'manual')))}</p>
     </body>
     </html>
     """
@@ -378,8 +400,13 @@ def _send_teams_notification(
 
     from app.services.teams_cards import build_exception_card, build_work_item_card
 
-    if result_doc.get("status") == "failed":
-        error = str((result_doc.get("final_output") or {}).get("error", "Unknown error"))
+    if is_failed_status(result_doc.get("status")):
+        # A failed run has no final_output — the reason lives on `error`.
+        error = str(
+            result_doc.get("error")
+            or (result_doc.get("final_output") or {}).get("error")
+            or "Unknown error"
+        )
         if work_item_doc:
             card = build_exception_card(work_item_doc, error)
         else:

--- a/backend/app/tasks/document_tasks.py
+++ b/backend/app/tasks/document_tasks.py
@@ -262,6 +262,21 @@ def _remove_images_from_markdown(markdown_text: str) -> str:
     return text.strip()
 
 
+def _notify_document_processing_failed(db, document_uuid: str, message: str) -> None:
+    """Tell the uploader their document never became readable.
+
+    Both callers swallow the exception and return "" rather than re-raising, so
+    the document simply sits in the file list with an error state nobody is told
+    about — the bell is the only signal the uploader gets.
+    """
+    from app.services.failure_notifications import notify_document_failed
+
+    doc = db.smart_document.find_one(
+        {"uuid": document_uuid}, {"uuid": 1, "title": 1, "user_id": 1},
+    )
+    notify_document_failed(db, doc=doc, error=message)
+
+
 @celery_app.task(
     bind=True,
     name="tasks.document.extraction",
@@ -392,6 +407,10 @@ def perform_extraction_and_update(self, document_uuid: str, extension: str) -> s
             "Source file missing for document %s — skipping extraction: %s",
             document_uuid, e,
         )
+        message = (
+            "The uploaded file is no longer available "
+            "(it may have been deleted during processing)."
+        )
         db.smart_document.update_one(
             {"uuid": document_uuid},
             {
@@ -399,17 +418,16 @@ def perform_extraction_and_update(self, document_uuid: str, extension: str) -> s
                     "raw_text": "",
                     "processing": False,
                     "task_status": "error",
-                    "error_message": (
-                        "The uploaded file is no longer available "
-                        "(it may have been deleted during processing)."
-                    ),
+                    "error_message": message,
                 }
             },
         )
+        _notify_document_processing_failed(db, document_uuid, message)
         return ""
 
     except Exception as e:
         logger.exception("Error extracting text from document %s", document_uuid)
+        message = f"Text extraction failed: {str(e)[:300]}"
         db.smart_document.update_one(
             {"uuid": document_uuid},
             {
@@ -417,10 +435,11 @@ def perform_extraction_and_update(self, document_uuid: str, extension: str) -> s
                     "raw_text": "",
                     "processing": False,
                     "task_status": "error",
-                    "error_message": f"Text extraction failed: {str(e)[:300]}",
+                    "error_message": message,
                 }
             },
         )
+        _notify_document_processing_failed(db, document_uuid, message)
         return ""
 
 
@@ -590,6 +609,14 @@ def _check_folder_watch_automations(db, document_uuid: str) -> None:
                 _run_automation_extraction(db, auto, action_id, doc)
             except Exception as e:
                 logger.error("Extraction automation '%s' failed: %s", auto.get("name"), e)
+                from app.services.failure_notifications import notify_automation_failed
+
+                notify_automation_failed(
+                    db,
+                    automation=auto,
+                    error=e,
+                    detail=f'Extraction on "{doc.get("title") or "a document"}" failed.',
+                )
 
         else:
             logger.info("Skipping automation %s: unsupported action_type '%s'", auto.get("name"), action_type)

--- a/backend/app/tasks/extraction_tasks.py
+++ b/backend/app/tasks/extraction_tasks.py
@@ -255,6 +255,21 @@ def perform_extraction_task(
                     }
                 },
             )
+
+        # Only once Celery is done retrying — a mid-retry bell entry would
+        # report a failure for a run that is about to succeed.
+        from app.services.failure_notifications import (
+            is_final_attempt,
+            notify_extraction_failed,
+        )
+
+        if is_final_attempt(self, e):
+            notify_extraction_failed(
+                db,
+                user_id=(activity or {}).get("user_id"),
+                search_set_uuid=searchset_uuid,
+                error=e,
+            )
         raise
 
 

--- a/backend/app/tasks/passive_tasks.py
+++ b/backend/app/tasks/passive_tasks.py
@@ -18,6 +18,16 @@ from app.tasks import TRANSIENT_EXCEPTIONS, get_sync_db
 logger = logging.getLogger(__name__)
 
 
+def _find_automation(db, automation_id: str | None) -> dict | None:
+    """Look up an automation by its stringified ObjectId, tolerating junk ids."""
+    if not automation_id:
+        return None
+    try:
+        return db.automation.find_one({"_id": ObjectId(automation_id)})
+    except Exception:
+        return None
+
+
 # ---------------------------------------------------------------------------
 # Beat task: process pending triggers (every 60s)
 # ---------------------------------------------------------------------------
@@ -190,6 +200,19 @@ def process_pending_triggers(self) -> dict:
                 {"_id": event["_id"]},
                 {"$set": {"status": "failed", "error": f"Processing error: {e}"}},
             )
+            # The event never reached execution, so no run exists to carry the
+            # failure — notify the automation owner directly.
+            from app.services.failure_notifications import notify_automation_failed
+
+            ctx = event.get("trigger_context") or {}
+            automation_doc = _find_automation(db, ctx.get("automation_id"))
+            if automation_doc:
+                notify_automation_failed(
+                    db,
+                    automation=automation_doc,
+                    error=e,
+                    detail="The trigger could not be processed.",
+                )
 
     return {"processed": processed, "timestamp": now.isoformat()}
 
@@ -338,6 +361,17 @@ def process_scheduled_automations(self) -> dict:
                 "Error processing scheduled automation %s: %s",
                 auto.get("name"), e,
             )
+            # A schedule that can't even be evaluated (bad cron expression,
+            # deleted action, unreadable trigger config) never produces a run,
+            # so this is the only place the owner can be told.
+            from app.services.failure_notifications import notify_automation_failed
+
+            notify_automation_failed(
+                db,
+                automation=auto,
+                error=e,
+                detail="The schedule could not be evaluated.",
+            )
 
     return {"processed": processed, "timestamp": now.isoformat()}
 
@@ -370,6 +404,9 @@ def execute_workflow_passive(self, trigger_event_id: str) -> dict:
 
     now = datetime.now(timezone.utc)
     sys_config = db.system_config.find_one() or {}
+    # Bound before the try so the failure handler can reference it even when the
+    # run dies before the result document is created.
+    result_id = None
 
     try:
         # Mark running
@@ -528,16 +565,22 @@ def execute_workflow_passive(self, trigger_event_id: str) -> dict:
         duration_ms = int((completed_at - started_at).total_seconds() * 1000) if started_at else 0
 
         doc_ids = event.get("documents", [])
+        failure_update = {
+            "status": "failed",
+            "completed_at": completed_at,
+            "duration_ms": duration_ms,
+            "error": str(e),
+            "documents_succeeded": 0,
+            "documents_failed": len(doc_ids),
+        }
+        # Link the run to its trigger event on failure too. Only the success
+        # path used to do this, so process_outputs could not walk back to the
+        # automation that produced a failed run and would resolve the wrong
+        # output_config (or none) when several automations share a workflow.
+        if result_id is not None:
+            failure_update["workflow_result"] = result_id
         db.workflow_trigger_event.update_one(
-            {"_id": event["_id"]},
-            {"$set": {
-                "status": "failed",
-                "completed_at": completed_at,
-                "duration_ms": duration_ms,
-                "error": str(e),
-                "documents_succeeded": 0,
-                "documents_failed": len(doc_ids),
-            }},
+            {"_id": event["_id"]}, {"$set": failure_update},
         )
 
         # Update workflow failure stats
@@ -569,8 +612,42 @@ def execute_workflow_passive(self, trigger_event_id: str) -> dict:
             )
             return {"status": "retry_scheduled", "attempt": attempt + 1}
 
-        # Retries exhausted — deliver failure callback if configured
+        # Retries exhausted. Record the failure on the run itself — until now a
+        # passive run that died left its WorkflowResult stuck in "running"
+        # forever, so even someone who went looking saw no failure.
         ctx = event.get("trigger_context") or {}
+        if result_id is not None:
+            db.workflow_result.update_one(
+                {"_id": result_id},
+                {"$set": {"status": "error", "error": str(e)}},
+            )
+
+        # Tell the owner. An automation firing on a schedule has no one watching
+        # it — without this it can fail every night for weeks in silence. The
+        # automation's owner is the right recipient when one exists: they are
+        # the person who set the schedule, and need not own the workflow.
+        from app.services.failure_notifications import notify_workflow_failed
+
+        automation_doc = _find_automation(db, ctx.get("automation_id"))
+        notify_workflow_failed(
+            db,
+            workflow_doc=workflow,
+            error=e,
+            user_id=(automation_doc or {}).get("user_id"),
+            automation_name=(
+                ctx.get("automation_name")
+                or (automation_doc or {}).get("name")
+                or None
+            ),
+        )
+
+        # Run the automation's own opt-in notification outputs (email/Teams).
+        # These were previously unreachable on failure: process_outputs was only
+        # dispatched from the success path.
+        if result_id is not None:
+            process_outputs.delay(str(result_id))
+
+        # Deliver failure callback if configured
         cb_url = ctx.get("callback_url")
         if cb_url:
             fail_now = datetime.now(timezone.utc)
@@ -608,7 +685,13 @@ def execute_workflow_passive(self, trigger_event_id: str) -> dict:
     default_retry_delay=10,
 )
 def process_outputs(self, workflow_result_id: str) -> dict:
-    """Process output configuration after workflow completes."""
+    """Process output configuration after a workflow run finishes.
+
+    Dispatched for failed runs too, so a user who configured "notify me on
+    failure" actually hears about it. Anything that delivers a *result* —
+    storage, OneDrive, chained workflows — is gated on the run having succeeded;
+    there is no output worth writing or handing downstream otherwise.
+    """
     from app.services.output_handlers import (
         call_webhook,
         save_results_to_folder,
@@ -657,9 +740,13 @@ def process_outputs(self, workflow_result_id: str) -> dict:
 
     outputs = {"storage": None, "onedrive": None, "notifications": [], "webhooks": [], "chains": []}
 
+    # Failed runs get notifications and webhooks (both carry the status) but no
+    # deliverables — see the docstring.
+    run_succeeded = result_doc.get("status") == "completed"
+
     # 1. Local storage
     storage_cfg = output_config.get("storage", {})
-    if storage_cfg.get("enabled"):
+    if run_succeeded and storage_cfg.get("enabled"):
         try:
             path = save_results_to_folder(result_doc, storage_cfg)
             outputs["storage"] = {"status": "completed", "path": path}
@@ -684,7 +771,7 @@ def process_outputs(self, workflow_result_id: str) -> dict:
 
     # 2. OneDrive case folder
     onedrive_cfg = output_config.get("onedrive", {})
-    if onedrive_cfg.get("enabled"):
+    if run_succeeded and onedrive_cfg.get("enabled"):
         try:
             folder_path = save_results_to_onedrive_channel(result_doc, onedrive_cfg, work_item)
             outputs["onedrive"] = {"status": "completed", "path": folder_path}
@@ -748,8 +835,9 @@ def process_outputs(self, workflow_result_id: str) -> dict:
             wr = {"url": webhook_cfg.get("url"), "status": "failed", "error": str(e)}
             outputs["webhooks"].append(wr)
 
-    # 5. Chain triggers — dispatch to downstream workflows
-    for chain_cfg in output_config.get("chains", []):
+    # 5. Chain triggers — dispatch to downstream workflows. Never chain off a
+    # failed run: the downstream workflow would consume a result that isn't there.
+    for chain_cfg in (output_config.get("chains", []) if run_succeeded else []):
         target_workflow_id = chain_cfg.get("workflow_id")
         if not target_workflow_id:
             continue
@@ -861,6 +949,7 @@ def process_extraction_outputs(
     If *results* is None, runs the extraction first (used by schedule triggers).
     If *results* is provided, just processes outputs (used by API triggers).
     """
+    from app.services.failure_notifications import notify_automation_failed
     from app.services.output_handlers import (
         call_webhook,
         save_extraction_results_to_folder,
@@ -910,6 +999,12 @@ def process_extraction_outputs(
                     {"$set": {"status": "failed", "error": "No extraction keys found",
                               "completed_at": datetime.now(timezone.utc)}},
                 )
+            notify_automation_failed(
+                db,
+                automation=auto,
+                error="The extraction set has no fields to extract.",
+                detail="The extraction could not run.",
+            )
             return {"error": "No extraction keys found"}
 
         field_metadata = [
@@ -963,18 +1058,37 @@ def process_extraction_outputs(
                 logger.error("Extraction failed for doc %s: %s", doc_uuid, e)
                 results.append({"document_id": doc_uuid, "error": str(e)})
 
+    # The run used to be reported as "completed" unconditionally, so an
+    # extraction automation that errored on every document still looked
+    # successful and never tripped a failure-conditioned notification. Treat
+    # "every document errored" (or produced nothing at all) as a failed run.
+    result_list = results if isinstance(results, list) else []
+    errored = [r for r in result_list if isinstance(r, dict) and r.get("error")]
+    run_failed = bool(errored) and len(errored) == len(result_list)
+    run_status = "failed" if run_failed else "completed"
+    run_error = errored[0].get("error") if run_failed else None
+
+    if run_failed:
+        notify_automation_failed(
+            db,
+            automation=auto,
+            error=run_error,
+            detail="Extraction failed on every input document.",
+        )
+
     output_config = auto.get("output_config") or {}
     if not output_config:
         if extraction_event_id:
             db.extraction_trigger_event.update_one(
                 {"_id": ObjectId(extraction_event_id)},
                 {"$set": {
-                    "status": "completed",
+                    "status": run_status,
+                    "error": run_error,
                     "result": results,
                     "completed_at": datetime.now(timezone.utc),
                 }},
             )
-        return {"status": "completed", "results": results}
+        return {"status": run_status, "results": results}
 
     automation_dict = {
         "name": auto.get("name"),
@@ -984,16 +1098,17 @@ def process_extraction_outputs(
     }
 
     result_doc = {
-        "status": "completed",
+        "status": run_status,
+        "error": run_error,
         "trigger_type": auto.get("trigger_type", "api"),
         "final_output": {"output": results},
     }
 
     outputs = {"storage": None, "notifications": [], "webhooks": []}
 
-    # Storage
+    # Storage — nothing worth writing when every document errored.
     storage_cfg = output_config.get("storage", {})
-    if storage_cfg.get("enabled"):
+    if not run_failed and storage_cfg.get("enabled"):
         try:
             path = save_extraction_results_to_folder(results, automation_dict, storage_cfg)
             outputs["storage"] = {"status": "completed", "path": path}
@@ -1029,14 +1144,15 @@ def process_extraction_outputs(
                 "error": str(e),
             })
 
-    # Persist results and mark extraction event as completed
+    # Persist results and close out the extraction event
     if extraction_event_id:
         now = datetime.now(timezone.utc)
         duration_ms = int((now - ext_started_at).total_seconds() * 1000) if ext_started_at else None
         db.extraction_trigger_event.update_one(
             {"_id": ObjectId(extraction_event_id)},
             {"$set": {
-                "status": "completed",
+                "status": run_status,
+                "error": run_error,
                 "result": results,
                 "completed_at": now,
                 "duration_ms": duration_ms,
@@ -1058,19 +1174,22 @@ def process_extraction_outputs(
                 trigger_event_id=extraction_event_id,
                 callback_url=cb_url,
                 payload={
-                    "event": "automation.completed",
+                    "event": (
+                        "automation.failed" if run_failed else "automation.completed"
+                    ),
                     "trigger_event_id": extraction_event_id,
                     "automation_id": automation_id,
                     "action_type": "extraction",
-                    "status": "completed",
+                    "status": run_status,
                     "output": results,
+                    "error": run_error,
                     "completed_at": now.isoformat(),
                     "timestamp": now.isoformat(),
                 },
                 user_id=user_id,
             )
 
-    return {"status": "completed", "outputs": outputs}
+    return {"status": run_status, "outputs": outputs}
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/tasks/workflow_tasks.py
+++ b/backend/app/tasks/workflow_tasks.py
@@ -63,25 +63,21 @@ def _notify_approval_reviewers_sync(
     step_name: str, instructions: str, approval_uuid: str,
 ) -> None:
     """Create in-app notifications and send emails to assigned reviewers (sync context)."""
-    import secrets
-    from datetime import datetime, timezone
     from app.config import Settings
+    from app.services.notification_service import create_notification_sync
 
     settings = Settings()
-    now = datetime.now(timezone.utc)
 
     for user_id in assigned_user_ids:
         # In-app notification
-        db.notification.insert_one({
-            "uuid": secrets.token_urlsafe(12),
-            "user_id": user_id,
-            "kind": "approval_request",
-            "title": f"Approval needed: {workflow_name}",
-            "body": f"Step \"{step_name}\" is waiting for your review.",
-            "link": f"/reviews/{approval_uuid}",
-            "read": False,
-            "created_at": now,
-        })
+        create_notification_sync(
+            db,
+            user_id=user_id,
+            kind="approval_request",
+            title=f"Approval needed: {workflow_name}",
+            body=f'Step "{step_name}" is waiting for your review.',
+            link=f"/reviews/{approval_uuid}",
+        )
 
         # Email
         user_doc = db.user.find_one({"user_id": user_id})
@@ -282,9 +278,15 @@ def _classify_input_documents(db, workflow_doc: dict, doc_uuids: list[str]):
     return ready, processing, failed
 
 
-def _mark_workflow_failed(db, workflow_result_id, activity_id, error_msg, error_payload=None):
+def _mark_workflow_failed(
+    db, workflow_result_id, activity_id, error_msg, error_payload=None, notify=True,
+):
     """Flip a WorkflowResult (and its activity rail entry) to a failed state
-    with a user-facing message, matching the pre-flight oversize handler."""
+    with a user-facing message, matching the pre-flight oversize handler.
+
+    `notify=False` suppresses the bell entry for a failure Celery is still going
+    to retry — the run is not actually over yet.
+    """
     from bson import ObjectId
 
     update = {"status": "error", "error": error_msg}
@@ -293,6 +295,7 @@ def _mark_workflow_failed(db, workflow_result_id, activity_id, error_msg, error_
     db.workflow_result.update_one(
         {"_id": ObjectId(workflow_result_id)}, {"$set": update}
     )
+    activity = None
     if activity_id:
         from datetime import datetime, timezone
 
@@ -305,8 +308,36 @@ def _mark_workflow_failed(db, workflow_result_id, activity_id, error_msg, error_
                     "finished_at": datetime.now(timezone.utc),
                 }},
             )
+            activity = db.activity_event.find_one(
+                {"_id": ObjectId(activity_id)}, {"user_id": 1},
+            )
         except Exception:
             pass
+
+    if not notify:
+        return
+
+    # A run that fails after the user has navigated away leaves no trace they
+    # would see, so the bell is the only signal. Resolve the owner from the
+    # activity rail entry (which carries the user who launched it) and fall
+    # back to the workflow's owner for runs with no activity record.
+    try:
+        from app.services.failure_notifications import notify_workflow_failed
+
+        result_doc = db.workflow_result.find_one(
+            {"_id": ObjectId(workflow_result_id)}, {"workflow": 1},
+        ) or {}
+        workflow_doc = db.workflow.find_one({"_id": result_doc.get("workflow")}) or {}
+        notify_workflow_failed(
+            db,
+            workflow_doc=workflow_doc,
+            error=error_msg,
+            user_id=(activity or {}).get("user_id"),
+        )
+    except Exception:
+        logger.exception(
+            "Failed to notify owner of workflow failure (result %s)", workflow_result_id,
+        )
 
 
 @celery_app.task(
@@ -600,27 +631,10 @@ def execute_workflow_task(self, workflow_result_id, workflow_id, trigger_step_da
                 "suggested_action": "convert_to_kb",
                 "oversize_documents": [o.to_dict() for o in oversize],
             }
-            db.workflow_result.update_one(
-                {"_id": ObjectId(workflow_result_id)},
-                {"$set": {
-                    "status": "error",
-                    "error": error_msg,
-                    "error_payload": error_payload,
-                }},
+            _mark_workflow_failed(
+                db, workflow_result_id, activity_id, error_msg,
+                error_payload=error_payload,
             )
-            if activity_id:
-                from datetime import datetime, timezone
-                try:
-                    db.activity_event.update_one(
-                        {"_id": ObjectId(activity_id)},
-                        {"$set": {
-                            "status": "failed",
-                            "error": error_msg[:2000],
-                            "finished_at": datetime.now(timezone.utc),
-                        }},
-                    )
-                except Exception:
-                    pass
             logger.warning(
                 "Workflow %s aborted pre-flight: oversize docs %s for model=%s",
                 workflow_id, [o.uuid for o in oversize], model,
@@ -689,19 +703,12 @@ def execute_workflow_task(self, workflow_result_id, workflow_id, trigger_step_da
         return {"status": "canceled", "result_id": workflow_result_id}
     except Exception as e:
         logger.error("Workflow execution failed for %s: %s", workflow_id, e)
-        db.workflow_result.update_one(
-            {"_id": ObjectId(workflow_result_id)},
-            {"$set": {"status": "error", "error": str(e)}},
+        from app.services.failure_notifications import is_final_attempt
+
+        _mark_workflow_failed(
+            db, workflow_result_id, activity_id, str(e),
+            notify=is_final_attempt(self, e),
         )
-        if activity_id:
-            try:
-                from datetime import datetime, timezone
-                db.activity_event.update_one(
-                    {"_id": ObjectId(activity_id)},
-                    {"$set": {"status": "failed", "error": str(e)[:2000], "finished_at": datetime.now(timezone.utc)}},
-                )
-            except Exception:
-                pass
         raise
 
     # Check if workflow paused for approval. The handling below must run under a
@@ -719,19 +726,12 @@ def execute_workflow_task(self, workflow_result_id, workflow_id, trigger_step_da
                 "Approval gate handling failed for workflow %s (result %s)",
                 workflow_id, workflow_result_id,
             )
-            db.workflow_result.update_one(
-                {"_id": ObjectId(workflow_result_id)},
-                {"$set": {"status": "error", "error": f"Approval gate failed: {e}"}},
+            from app.services.failure_notifications import is_final_attempt
+
+            _mark_workflow_failed(
+                db, workflow_result_id, activity_id, f"Approval gate failed: {e}",
+                notify=is_final_attempt(self, e),
             )
-            if activity_id:
-                try:
-                    from datetime import datetime, timezone
-                    db.activity_event.update_one(
-                        {"_id": ObjectId(activity_id)},
-                        {"$set": {"status": "failed", "error": str(e)[:2000], "finished_at": datetime.now(timezone.utc)}},
-                    )
-                except Exception:
-                    pass
             raise
 
     # Aggregate citations from every step that produced retrieved_sources so
@@ -1054,11 +1054,13 @@ def resume_workflow_after_approval(self, approval_uuid):
         allow_code_execution=is_admin,
     )
 
+    # Resolved before the try so the failure handler below can always reach it.
+    _act = db.activity_event.find_one(
+        {"workflow_result": ObjectId(workflow_result_id)}, {"_id": 1}
+    )
+
     try:
         from app.services.metering import metered
-        _act = db.activity_event.find_one(
-            {"workflow_result": ObjectId(workflow_result_id)}, {"_id": 1}
-        )
         with metered(
             "workflow",
             user_id=user_id,
@@ -1072,9 +1074,12 @@ def resume_workflow_after_approval(self, approval_uuid):
             )
     except Exception as e:
         logger.error("Workflow resume failed for %s: %s", workflow_id, e)
-        db.workflow_result.update_one(
-            {"_id": ObjectId(workflow_result_id)},
-            {"$set": {"status": "error", "error": str(e)}},
+        from app.services.failure_notifications import is_final_attempt
+
+        _mark_workflow_failed(
+            db, workflow_result_id,
+            str(_act["_id"]) if _act else None, str(e),
+            notify=is_final_attempt(self, e),
         )
         raise
 

--- a/backend/tests/test_failure_notification_triggers.py
+++ b/backend/tests/test_failure_notification_triggers.py
@@ -1,0 +1,317 @@
+"""Tests for the failure-notification emission sites.
+
+`test_failure_notifications.py` covers the emitters themselves. This file covers
+the wiring: that each kind of failure actually reaches an emitter, that a
+mid-retry failure does not, and that a failed run no longer produces deliverables
+it has no output for.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from bson import ObjectId
+
+
+# ---------------------------------------------------------------------------
+# Workflow runs
+# ---------------------------------------------------------------------------
+
+
+class TestMarkWorkflowFailed:
+    def _db(self, *, user_id="alice"):
+        db = MagicMock()
+        db.workflow_result.find_one.return_value = {"workflow": ObjectId()}
+        db.workflow.find_one.return_value = {
+            "_id": ObjectId(), "name": "Budget Review", "user_id": "wf-owner",
+        }
+        db.activity_event.find_one.return_value = {"user_id": user_id}
+        return db
+
+    def test_notifies_the_user_who_launched_the_run(self):
+        from app.tasks.workflow_tasks import _mark_workflow_failed
+
+        db = self._db(user_id="alice")
+        with patch(
+            "app.services.failure_notifications.notify_workflow_failed"
+        ) as notify:
+            _mark_workflow_failed(db, str(ObjectId()), str(ObjectId()), "step 2 blew up")
+
+        assert notify.call_args.kwargs["user_id"] == "alice"
+        assert notify.call_args.kwargs["error"] == "step 2 blew up"
+
+    def test_notify_false_suppresses_the_bell_entry(self):
+        # Celery is going to retry — the run is not actually over.
+        from app.tasks.workflow_tasks import _mark_workflow_failed
+
+        db = self._db()
+        with patch(
+            "app.services.failure_notifications.notify_workflow_failed"
+        ) as notify:
+            _mark_workflow_failed(
+                db, str(ObjectId()), str(ObjectId()), "blip", notify=False,
+            )
+
+        notify.assert_not_called()
+
+    def test_run_and_activity_are_still_marked_failed(self):
+        from app.tasks.workflow_tasks import _mark_workflow_failed
+
+        db = self._db()
+        with patch("app.services.failure_notifications.notify_workflow_failed"):
+            _mark_workflow_failed(db, str(ObjectId()), str(ObjectId()), "boom")
+
+        result_update = db.workflow_result.update_one.call_args.args[1]["$set"]
+        assert result_update["status"] == "error"
+        activity_update = db.activity_event.update_one.call_args.args[1]["$set"]
+        assert activity_update["status"] == "failed"
+
+    def test_notification_failure_does_not_break_the_task(self):
+        from app.tasks.workflow_tasks import _mark_workflow_failed
+
+        db = self._db()
+        with patch(
+            "app.services.failure_notifications.notify_workflow_failed",
+            side_effect=RuntimeError("mongo down"),
+        ):
+            _mark_workflow_failed(db, str(ObjectId()), str(ObjectId()), "boom")
+
+
+# ---------------------------------------------------------------------------
+# Documents
+# ---------------------------------------------------------------------------
+
+
+class TestDocumentProcessingFailure:
+    def test_uploader_is_notified_when_text_extraction_fails(self):
+        from app.tasks.document_tasks import _notify_document_processing_failed
+
+        db = MagicMock()
+        db.smart_document.find_one.return_value = {
+            "uuid": "d-1", "title": "grant.pdf", "user_id": "alice",
+        }
+
+        with patch(
+            "app.services.failure_notifications.notify_document_failed"
+        ) as notify:
+            _notify_document_processing_failed(db, "d-1", "Text extraction failed: boom")
+
+        assert notify.call_args.kwargs["doc"]["user_id"] == "alice"
+        assert "boom" in notify.call_args.kwargs["error"]
+
+    def test_deleted_document_is_a_no_op(self):
+        from app.tasks.document_tasks import _notify_document_processing_failed
+
+        db = MagicMock()
+        db.smart_document.find_one.return_value = None
+
+        with patch(
+            "app.services.failure_notifications.notify_document_failed"
+        ) as notify:
+            _notify_document_processing_failed(db, "gone", "boom")
+
+        # The emitter itself no-ops on a missing doc; assert we still called it
+        # rather than crashing on the None.
+        assert notify.call_args.kwargs["doc"] is None
+
+
+# ---------------------------------------------------------------------------
+# Extractions
+# ---------------------------------------------------------------------------
+
+
+class TestExtractionTaskFailure:
+    def _run_and_capture(self, *, side_effect, retries=0):
+        """Drive perform_extraction_task to its failure path."""
+        from app.tasks.extraction_tasks import perform_extraction_task
+
+        db = MagicMock()
+        db.system_config.find_one.return_value = {}
+        db.activity_event.find_one.return_value = {
+            "user_id": "alice", "team_id": None, "type": "search_set_run",
+        }
+
+        engine = MagicMock()
+        engine.extract.side_effect = side_effect
+
+        with (
+            patch("app.tasks.extraction_tasks._get_db", return_value=db),
+            patch(
+                "app.services.extraction_engine.ExtractionEngine",
+                return_value=engine,
+            ),
+            patch("app.tasks.extraction_tasks._get_user_model_name", return_value="m"),
+            patch("app.services.metering.metered"),
+            patch(
+                "app.services.failure_notifications.notify_extraction_failed"
+            ) as notify,
+        ):
+            task = perform_extraction_task
+            task.push_request(retries=retries)
+            try:
+                task.run(
+                    activity_id=str(ObjectId()),
+                    searchset_uuid="ss-1",
+                    document_uuids=["d-1"],
+                    keys=["field"],
+                    root_path="/tmp",
+                )
+            except Exception:
+                pass
+            finally:
+                task.pop_request()
+        return notify
+
+    def test_owner_is_notified_on_a_terminal_failure(self):
+        notify = self._run_and_capture(side_effect=ValueError("bad prompt"))
+
+        notify.assert_called_once()
+        assert notify.call_args.kwargs["user_id"] == "alice"
+        assert notify.call_args.kwargs["search_set_uuid"] == "ss-1"
+
+    def test_no_notification_while_retries_remain(self):
+        notify = self._run_and_capture(
+            side_effect=ConnectionError("blip"), retries=0,
+        )
+
+        notify.assert_not_called()
+
+    def test_notification_once_retries_are_exhausted(self):
+        notify = self._run_and_capture(
+            side_effect=ConnectionError("blip"), retries=3,
+        )
+
+        notify.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Automations / scheduled runs
+# ---------------------------------------------------------------------------
+
+
+class TestScheduledAutomationFailure:
+    @patch("app.tasks.passive_tasks.get_sync_db")
+    def test_unevaluatable_schedule_notifies_the_owner(self, mock_get_db):
+        from app.tasks.passive_tasks import process_scheduled_automations
+
+        db = MagicMock()
+        mock_get_db.return_value = db
+        auto = {
+            "_id": ObjectId(),
+            "name": "Nightly intake",
+            "user_id": "alice",
+            "enabled": True,
+            "trigger_type": "schedule",
+            "action_id": str(ObjectId()),
+            "action_type": "workflow",
+            "trigger_config": {"cron_expression": "not a cron"},
+        }
+        db.automation.find.return_value = [auto]
+        db.workflow_trigger_event.find_one.return_value = None
+
+        with patch(
+            "app.services.failure_notifications.notify_automation_failed"
+        ) as notify:
+            process_scheduled_automations()
+
+        notify.assert_called_once()
+        assert notify.call_args.kwargs["automation"]["user_id"] == "alice"
+
+    @patch("app.tasks.passive_tasks.get_sync_db")
+    def test_trigger_processing_error_notifies_the_automation_owner(self, mock_get_db):
+        from app.tasks.passive_tasks import process_pending_triggers
+
+        db = MagicMock()
+        mock_get_db.return_value = db
+
+        auto_oid = ObjectId()
+        event = {
+            "_id": ObjectId(),
+            "uuid": "evt-1",
+            "workflow": ObjectId(),
+            "trigger_context": {"automation_id": str(auto_oid)},
+        }
+        db.workflow_trigger_event.find.return_value.limit.return_value = [event]
+        # Blow up inside the per-event body.
+        db.workflow.find_one.side_effect = RuntimeError("mongo hiccup")
+        db.automation.find_one.return_value = {
+            "_id": auto_oid, "name": "Nightly intake", "user_id": "alice",
+        }
+
+        with patch(
+            "app.services.failure_notifications.notify_automation_failed"
+        ) as notify:
+            process_pending_triggers()
+
+        notify.assert_called_once()
+        assert notify.call_args.kwargs["automation"]["user_id"] == "alice"
+
+
+# ---------------------------------------------------------------------------
+# process_outputs on a failed run
+# ---------------------------------------------------------------------------
+
+
+class TestProcessOutputsOnFailedRun:
+    def _setup(self, db, *, status):
+        wf_oid = ObjectId()
+        db.workflow_result.find_one.return_value = {
+            "_id": ObjectId(), "workflow": wf_oid, "status": status,
+            "error": "step 2 blew up",
+        }
+        db.workflow.find_one.return_value = {
+            "_id": wf_oid,
+            "name": "WF",
+            "user_id": "alice",
+            "output_config": {
+                "storage": {"enabled": True},
+                "chains": [{"workflow_id": str(ObjectId())}],
+                "notifications": [
+                    {"channel": "email", "recipients": ["a@b.com"], "conditions": "failure"},
+                ],
+            },
+        }
+        db.workflow_trigger_event.find_one.return_value = None
+        db.work_items.find_one.return_value = None
+        db.automation.find_one.return_value = None
+
+    @patch("app.tasks.passive_tasks.get_sync_db")
+    def test_failure_notification_fires_for_an_errored_run(self, mock_get_db):
+        from app.tasks.passive_tasks import process_outputs
+
+        db = MagicMock()
+        mock_get_db.return_value = db
+        self._setup(db, status="error")
+
+        with (
+            patch("app.services.output_handlers.send_workflow_notification") as send,
+            patch("app.services.output_handlers.save_results_to_folder") as save,
+            patch("app.services.passive_triggers.create_chain_trigger") as chain,
+        ):
+            process_outputs(str(ObjectId()))
+
+        send.assert_called_once()
+        # No output exists, so nothing is written or handed downstream.
+        save.assert_not_called()
+        chain.assert_not_called()
+
+    @patch("app.tasks.passive_tasks.get_sync_db")
+    def test_successful_run_still_produces_deliverables(self, mock_get_db):
+        from app.tasks.passive_tasks import process_outputs
+
+        db = MagicMock()
+        mock_get_db.return_value = db
+        self._setup(db, status="completed")
+
+        with (
+            patch("app.services.output_handlers.send_workflow_notification"),
+            patch("app.services.output_handlers.save_results_to_folder") as save,
+            patch(
+                "app.services.passive_triggers.create_chain_trigger",
+                return_value=None,
+            ) as chain,
+        ):
+            process_outputs(str(ObjectId()))
+
+        save.assert_called_once()
+        chain.assert_called_once()

--- a/backend/tests/test_failure_notifications.py
+++ b/backend/tests/test_failure_notifications.py
@@ -1,0 +1,244 @@
+"""Tests for app.services.failure_notifications.
+
+These emitters run inside Celery tasks that have already done real work, so the
+behaviors worth locking in are the ones that keep them from causing damage:
+they never raise, they never fire mid-retry, and they address the right user.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from bson import ObjectId
+
+from app.services.failure_notifications import (
+    is_final_attempt,
+    notify_automation_failed,
+    notify_document_failed,
+    notify_extraction_failed,
+    notify_workflow_failed,
+)
+
+
+def _task(retries: int = 0, max_retries: int | None = 3):
+    return SimpleNamespace(
+        request=SimpleNamespace(retries=retries), max_retries=max_retries,
+    )
+
+
+# ---------------------------------------------------------------------------
+# is_final_attempt
+# ---------------------------------------------------------------------------
+
+
+class TestIsFinalAttempt:
+    def test_non_transient_error_is_final_immediately(self):
+        # ValueError isn't in autoretry_for, so Celery will not retry it.
+        assert is_final_attempt(_task(retries=0), ValueError("bad input")) is True
+
+    def test_transient_error_with_budget_left_is_not_final(self):
+        assert is_final_attempt(_task(retries=1), ConnectionError("blip")) is False
+
+    def test_transient_error_with_budget_spent_is_final(self):
+        assert is_final_attempt(_task(retries=3), ConnectionError("blip")) is True
+
+    def test_unlimited_retries_is_never_final(self):
+        assert is_final_attempt(
+            _task(retries=99, max_retries=None), TimeoutError("slow"),
+        ) is False
+
+    def test_task_without_request_is_treated_as_final(self):
+        # Better a notification the user can act on than silence.
+        assert is_final_attempt(object(), ConnectionError("blip")) is True
+
+
+# ---------------------------------------------------------------------------
+# notify_workflow_failed
+# ---------------------------------------------------------------------------
+
+
+class TestNotifyWorkflowFailed:
+    def test_notifies_workflow_owner_with_deep_link(self):
+        wf_id = ObjectId()
+        with patch(
+            "app.services.failure_notifications.create_notification_sync"
+        ) as create:
+            notify_workflow_failed(
+                MagicMock(),
+                workflow_doc={"_id": wf_id, "name": "Budget Review", "user_id": "alice"},
+                error=RuntimeError("step 2 blew up"),
+            )
+
+        kwargs = create.call_args.kwargs
+        assert kwargs["user_id"] == "alice"
+        assert kwargs["kind"] == "workflow_failed"
+        assert kwargs["title"] == "Workflow failed: Budget Review"
+        assert kwargs["link"] == f"/?workflow={wf_id}"
+        assert "step 2 blew up" in kwargs["body"]
+        assert kwargs["coalesce_key"] == f"workflow_failed:{wf_id}"
+
+    def test_explicit_user_id_wins_over_workflow_owner(self):
+        # An automation's owner set the schedule and need not own the workflow.
+        with patch(
+            "app.services.failure_notifications.create_notification_sync"
+        ) as create:
+            notify_workflow_failed(
+                MagicMock(),
+                workflow_doc={"_id": ObjectId(), "name": "WF", "user_id": "alice"},
+                error="boom",
+                user_id="bob",
+            )
+
+        assert create.call_args.kwargs["user_id"] == "bob"
+
+    def test_automation_run_is_titled_as_an_automation(self):
+        with patch(
+            "app.services.failure_notifications.create_notification_sync"
+        ) as create:
+            notify_workflow_failed(
+                MagicMock(),
+                workflow_doc={"_id": ObjectId(), "name": "WF", "user_id": "alice"},
+                error="boom",
+                automation_name="Nightly intake",
+            )
+
+        kwargs = create.call_args.kwargs
+        assert kwargs["title"] == "Automation failed: Nightly intake"
+        assert "WF" in kwargs["body"]
+
+    def test_no_recipient_means_no_notification(self):
+        with patch(
+            "app.services.failure_notifications.create_notification_sync"
+        ) as create:
+            notify_workflow_failed(MagicMock(), workflow_doc={}, error="boom")
+
+        create.assert_not_called()
+
+    def test_never_raises_when_the_write_fails(self):
+        with patch(
+            "app.services.failure_notifications.create_notification_sync",
+            side_effect=RuntimeError("mongo down"),
+        ):
+            notify_workflow_failed(
+                MagicMock(),
+                workflow_doc={"_id": ObjectId(), "name": "WF", "user_id": "alice"},
+                error="boom",
+            )  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# notify_extraction_failed
+# ---------------------------------------------------------------------------
+
+
+class TestNotifyExtractionFailed:
+    def test_resolves_set_title_from_the_database(self):
+        db = MagicMock()
+        db.search_set.find_one.return_value = {"title": "NSF Budget Fields"}
+
+        with patch(
+            "app.services.failure_notifications.create_notification_sync"
+        ) as create:
+            notify_extraction_failed(
+                db, user_id="alice", search_set_uuid="ss-1", error="LLM timeout",
+            )
+
+        kwargs = create.call_args.kwargs
+        assert kwargs["title"] == "Extraction failed: NSF Budget Fields"
+        assert kwargs["link"] == "/?extraction=ss-1"
+        assert kwargs["kind"] == "extraction_failed"
+
+    def test_falls_back_when_the_set_is_gone(self):
+        db = MagicMock()
+        db.search_set.find_one.return_value = None
+
+        with patch(
+            "app.services.failure_notifications.create_notification_sync"
+        ) as create:
+            notify_extraction_failed(
+                db, user_id="alice", search_set_uuid="ss-1", error="boom",
+            )
+
+        assert create.call_args.kwargs["title"] == "Extraction failed: Extraction"
+
+    def test_no_user_means_no_notification(self):
+        with patch(
+            "app.services.failure_notifications.create_notification_sync"
+        ) as create:
+            notify_extraction_failed(
+                MagicMock(), user_id=None, search_set_uuid="ss-1", error="boom",
+            )
+
+        create.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# notify_document_failed
+# ---------------------------------------------------------------------------
+
+
+class TestNotifyDocumentFailed:
+    def test_coalesces_per_user_not_per_document(self):
+        # A 50-file upload with a dozen bad files should read as one row.
+        with patch(
+            "app.services.failure_notifications.create_notification_sync"
+        ) as create:
+            notify_document_failed(
+                MagicMock(),
+                doc={"uuid": "d-1", "title": "grant.pdf", "user_id": "alice"},
+                error="encrypted PDF",
+            )
+
+        kwargs = create.call_args.kwargs
+        assert kwargs["coalesce_key"] == "document_failed:alice"
+        assert kwargs["group_title"] == "{count} documents failed to process"
+        assert kwargs["item_id"] == "d-1"
+        assert kwargs["link"] == "/?mode=files"
+
+    def test_missing_document_is_a_no_op(self):
+        with patch(
+            "app.services.failure_notifications.create_notification_sync"
+        ) as create:
+            notify_document_failed(MagicMock(), doc=None, error="boom")
+
+        create.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# notify_automation_failed
+# ---------------------------------------------------------------------------
+
+
+class TestNotifyAutomationFailed:
+    def test_notifies_owner_with_detail_prefix(self):
+        auto_id = ObjectId()
+        with patch(
+            "app.services.failure_notifications.create_notification_sync"
+        ) as create:
+            notify_automation_failed(
+                MagicMock(),
+                automation={"_id": auto_id, "name": "Nightly intake", "user_id": "alice"},
+                error="bad cron expression",
+                detail="The schedule could not be evaluated.",
+            )
+
+        kwargs = create.call_args.kwargs
+        assert kwargs["user_id"] == "alice"
+        assert kwargs["kind"] == "automation_failed"
+        assert kwargs["title"] == "Automation failed: Nightly intake"
+        assert kwargs["body"].startswith("The schedule could not be evaluated.")
+        assert "bad cron expression" in kwargs["body"]
+        assert kwargs["link"] == f"/?mode=automations&automation={auto_id}"
+
+    def test_empty_error_still_produces_a_readable_body(self):
+        with patch(
+            "app.services.failure_notifications.create_notification_sync"
+        ) as create:
+            notify_automation_failed(
+                MagicMock(),
+                automation={"_id": ObjectId(), "name": "A", "user_id": "alice"},
+                error=None,
+            )
+
+        assert create.call_args.kwargs["body"] == "No error detail was recorded."

--- a/backend/tests/test_notification_service.py
+++ b/backend/tests/test_notification_service.py
@@ -15,8 +15,10 @@ import pytest
 
 from app.services.notification_service import (
     _COALESCE_KINDS,
+    FAILURE_KINDS,
     _to_dict,
     create_notification,
+    create_notification_sync,
     list_notifications,
     mark_all_read,
     mark_read,
@@ -46,10 +48,13 @@ def _notif(
         title=title,
         body=body,
         link=link,
+        severity="info",
         item_kind=item_kind,
         item_id=item_id,
         item_name=item_name,
         request_uuid=None,
+        coalesce_key=None,
+        occurrences=1,
         read=read,
         created_at=created_at or datetime.datetime(2026, 3, 5, 12, 0, 0),
     )
@@ -74,6 +79,17 @@ class TestToDict:
         assert d["item_name"] == "Ticket #1"
         assert d["read"] is False
         assert d["created_at"] == now.isoformat()
+        assert d["severity"] == "info"
+        assert d["occurrences"] == 1
+
+    def test_legacy_row_without_new_fields_gets_defaults(self):
+        # Rows written before severity/occurrences existed must still serialize.
+        n = _notif()
+        del n.severity
+        del n.occurrences
+        d = _to_dict(n)
+        assert d["severity"] == "info"
+        assert d["occurrences"] == 1
 
     def test_missing_created_at_is_none(self):
         n = _notif()
@@ -92,6 +108,16 @@ class TestCoalesceKinds:
     def test_non_support_kinds_are_not_coalesced(self):
         assert "verification_passed" not in _COALESCE_KINDS
         assert "workflow_complete" not in _COALESCE_KINDS
+
+    def test_every_failure_kind_is_registered(self):
+        # FAILURE_KINDS drives the default severity, which is what makes the
+        # bell render a failure in red. A kind missing here looks like news.
+        assert FAILURE_KINDS == {
+            "workflow_failed",
+            "extraction_failed",
+            "document_failed",
+            "automation_failed",
+        }
 
 
 class TestCreateNotification:
@@ -175,6 +201,178 @@ class TestCreateNotification:
 
         MockN.find_one.assert_not_called()
         new_n.insert.assert_awaited_once()
+
+
+class TestGroupCoalescing:
+    """`coalesce_key` folds repeats into one unread row and counts them."""
+
+    @pytest.mark.asyncio
+    async def test_repeat_bumps_occurrences_and_rewrites_title(self):
+        existing = _notif(kind="automation_failed", title="Automation failed: Nightly")
+        existing.occurrences = 4
+
+        with patch("app.services.notification_service.Notification") as MockN:
+            MockN.find_one = AsyncMock(return_value=existing)
+
+            result = await create_notification(
+                user_id="alice",
+                kind="automation_failed",
+                title="Automation failed: Nightly",
+                coalesce_key="automation_failed:a-1",
+                group_title="Automation failed {count}×: Nightly",
+            )
+
+        assert existing.occurrences == 5
+        assert existing.title == "Automation failed 5×: Nightly"
+        assert result["occurrences"] == 5
+
+    @pytest.mark.asyncio
+    async def test_first_occurrence_keeps_the_singular_title(self):
+        new_n = _notif(kind="document_failed", title="Document failed to process: a.pdf")
+        with patch("app.services.notification_service.Notification") as MockN:
+            MockN.find_one = AsyncMock(return_value=None)
+            MockN.return_value = new_n
+
+            await create_notification(
+                user_id="alice",
+                kind="document_failed",
+                title="Document failed to process: a.pdf",
+                coalesce_key="document_failed:alice",
+                group_title="{count} documents failed to process",
+            )
+
+        new_n.insert.assert_awaited_once()
+        assert MockN.call_args.kwargs["title"] == "Document failed to process: a.pdf"
+
+    @pytest.mark.asyncio
+    async def test_read_notification_does_not_absorb_new_failures(self):
+        # Only unread rows coalesce — a dismissed failure must not silently
+        # swallow the next one and leave the bell empty.
+        new_n = _notif(kind="workflow_failed")
+        with patch("app.services.notification_service.Notification") as MockN:
+            MockN.find_one = AsyncMock(return_value=None)
+            MockN.return_value = new_n
+
+            await create_notification(
+                user_id="alice",
+                kind="workflow_failed",
+                title="Workflow failed: WF",
+                coalesce_key="workflow_failed:wf-1",
+            )
+
+        MockN.find_one.assert_awaited_once()
+        new_n.insert.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_failure_kind_defaults_to_error_severity(self):
+        new_n = _notif(kind="workflow_failed")
+        with patch("app.services.notification_service.Notification") as MockN:
+            MockN.find_one = AsyncMock(return_value=None)
+            MockN.return_value = new_n
+
+            await create_notification(
+                user_id="alice", kind="workflow_failed", title="Workflow failed: WF",
+            )
+
+        assert MockN.call_args.kwargs["severity"] == "error"
+
+    @pytest.mark.asyncio
+    async def test_ordinary_kind_defaults_to_info_severity(self):
+        new_n = _notif(kind="team_share")
+        with patch("app.services.notification_service.Notification") as MockN:
+            MockN.find_one = AsyncMock(return_value=None)
+            MockN.return_value = new_n
+
+            await create_notification(
+                user_id="alice", kind="team_share", title="Shared with you",
+            )
+
+        assert MockN.call_args.kwargs["severity"] == "info"
+
+    @pytest.mark.asyncio
+    async def test_malformed_group_title_falls_back(self):
+        existing = _notif(kind="workflow_failed", title="old")
+        existing.occurrences = 2
+        with patch("app.services.notification_service.Notification") as MockN:
+            MockN.find_one = AsyncMock(return_value=existing)
+
+            await create_notification(
+                user_id="alice",
+                kind="workflow_failed",
+                title="Workflow failed: WF",
+                coalesce_key="workflow_failed:wf-1",
+                group_title="Failed {nope}×",
+            )
+
+        assert existing.title == "Workflow failed: WF"
+
+
+class TestCreateNotificationSync:
+    """The pymongo path Celery workers use — same semantics, no event loop."""
+
+    def test_inserts_a_new_row(self):
+        db = MagicMock()
+        db.notification.find_one.return_value = None
+
+        create_notification_sync(
+            db,
+            user_id="alice",
+            kind="workflow_failed",
+            title="Workflow failed: WF",
+            body="boom",
+            link="/?workflow=wf-1",
+            coalesce_key="workflow_failed:wf-1",
+        )
+
+        doc = db.notification.insert_one.call_args.args[0]
+        assert doc["user_id"] == "alice"
+        assert doc["kind"] == "workflow_failed"
+        assert doc["severity"] == "error"
+        assert doc["occurrences"] == 1
+        assert doc["read"] is False
+        assert doc["uuid"]
+
+    def test_repeat_updates_instead_of_inserting(self):
+        db = MagicMock()
+        db.notification.find_one.return_value = {"_id": "n-1", "occurrences": 2}
+
+        create_notification_sync(
+            db,
+            user_id="alice",
+            kind="automation_failed",
+            title="Automation failed: Nightly",
+            coalesce_key="automation_failed:a-1",
+            group_title="Automation failed {count}×: Nightly",
+        )
+
+        db.notification.insert_one.assert_not_called()
+        update = db.notification.update_one.call_args.args[1]["$set"]
+        assert update["occurrences"] == 3
+        assert update["title"] == "Automation failed 3×: Nightly"
+
+    def test_without_coalesce_key_every_call_inserts(self):
+        db = MagicMock()
+
+        create_notification_sync(
+            db, user_id="alice", kind="approval_request", title="Approval needed",
+        )
+
+        db.notification.find_one.assert_not_called()
+        db.notification.insert_one.assert_called_once()
+
+    def test_never_raises_when_mongo_is_down(self):
+        # Callers are tasks that already did real work; a failed bell write
+        # must not fail (or retry) the task.
+        db = MagicMock()
+        db.notification.find_one.side_effect = RuntimeError("mongo down")
+
+        create_notification_sync(
+            db,
+            user_id="alice",
+            kind="workflow_failed",
+            title="Workflow failed: WF",
+            coalesce_key="workflow_failed:wf-1",
+        )  # must not raise
 
 
 class TestListNotifications:

--- a/backend/tests/test_output_handlers.py
+++ b/backend/tests/test_output_handlers.py
@@ -36,6 +36,18 @@ class TestShouldSendNotification:
 
         assert should_send_notification({"status": "failed"}, {"conditions": "failure"}) is True
 
+    def test_failure_matches_error(self):
+        # WorkflowResult records a failed run as "error", not "failed". Matching
+        # only "failed" is why "notify me on failure" never fired for workflows.
+        from app.services.output_handlers import should_send_notification
+
+        assert should_send_notification({"status": "error"}, {"conditions": "failure"}) is True
+
+    def test_success_rejects_error(self):
+        from app.services.output_handlers import should_send_notification
+
+        assert should_send_notification({"status": "error"}, {"conditions": "success"}) is False
+
     def test_failure_rejects_completed(self):
         from app.services.output_handlers import should_send_notification
 

--- a/frontend/src/api/notifications.ts
+++ b/frontend/src/api/notifications.ts
@@ -7,6 +7,10 @@ export interface Notification {
   title: string
   body: string | null
   link: string | null
+  /** 'info' for the ordinary event stream, 'error' for failures. */
+  severity: string
+  /** Repeat count for coalesced events — 1 for a one-off. */
+  occurrences: number
   item_kind: string | null
   item_id: string | null
   item_name: string | null

--- a/frontend/src/components/layout/NotificationBell.test.ts
+++ b/frontend/src/components/layout/NotificationBell.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import { parseNotificationLink } from './NotificationBell'
+
+describe('parseNotificationLink', () => {
+  it('keeps a plain path as-is', () => {
+    expect(parseNotificationLink('/verification')).toEqual({
+      to: '/verification',
+      search: {},
+    })
+  })
+
+  it('splits workspace deep-links into path and search', () => {
+    // Failure notifications route into the workspace by query param; passing
+    // the whole string as `to` would drop them.
+    expect(parseNotificationLink('/?workflow=wf-123')).toEqual({
+      to: '/',
+      search: { workflow: 'wf-123' },
+    })
+  })
+
+  it('handles multiple params', () => {
+    expect(parseNotificationLink('/?mode=automations&automation=a-1')).toEqual({
+      to: '/',
+      search: { mode: 'automations', automation: 'a-1' },
+    })
+  })
+
+  it('decodes encoded values', () => {
+    expect(parseNotificationLink('/?extraction=a%20b').search).toEqual({
+      extraction: 'a b',
+    })
+  })
+
+  it('falls back to root for a bare query string', () => {
+    expect(parseNotificationLink('?tab=library')).toEqual({
+      to: '/',
+      search: { tab: 'library' },
+    })
+  })
+})

--- a/frontend/src/components/layout/NotificationBell.tsx
+++ b/frontend/src/components/layout/NotificationBell.tsx
@@ -1,10 +1,12 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { Bell, CheckCheck, Headphones, Inbox, MessageSquare, ShieldCheck, ShieldX, RotateCcw, Eye, Share2 } from 'lucide-react'
+import { AlertTriangle, Bell, CheckCheck, FileX, Headphones, Inbox, MessageSquare, ShieldCheck, ShieldX, RotateCcw, Eye, Share2, Timer, XOctagon } from 'lucide-react'
 import { useNavigate } from '@tanstack/react-router'
 import { listNotifications, markRead, markAllRead, getUnreadCount } from '../../api/notifications'
 import type { Notification } from '../../api/notifications'
 import { relativeTime } from '../../utils/time'
 import { openSupportPanel } from '../../utils/supportPanel'
+
+const FAILURE_RED = '#dc2626'
 
 const kindIcons: Record<string, typeof ShieldCheck> = {
   verification_submitted: Inbox,
@@ -17,6 +19,10 @@ const kindIcons: Record<string, typeof ShieldCheck> = {
   support_reply: MessageSquare,
   support_status: Headphones,
   team_share: Share2,
+  workflow_failed: XOctagon,
+  extraction_failed: AlertTriangle,
+  document_failed: FileX,
+  automation_failed: Timer,
 }
 
 const kindColors: Record<string, string> = {
@@ -30,6 +36,10 @@ const kindColors: Record<string, string> = {
   support_reply: '#2563eb',
   support_status: '#059669',
   team_share: '#f1b300',
+  workflow_failed: FAILURE_RED,
+  extraction_failed: FAILURE_RED,
+  document_failed: FAILURE_RED,
+  automation_failed: FAILURE_RED,
 }
 
 const SUPPORT_KINDS = new Set([
@@ -43,6 +53,25 @@ function extractTicketUuid(link: string | null): string | undefined {
   if (!link) return undefined
   const match = link.match(/ticket=([a-f0-9]+)/)
   return match?.[1]
+}
+
+/**
+ * Split a stored link into the pathname and search object the router expects.
+ *
+ * Failure notifications deep-link into the workspace via query params
+ * (`/?workflow=<id>`, `/?mode=automations&automation=<id>`), and passing the
+ * whole string as `to` leaves the params on the floor.
+ */
+export function parseNotificationLink(link: string): {
+  to: string
+  search: Record<string, string>
+} {
+  const [path, query] = link.split('?')
+  const search: Record<string, string> = {}
+  if (query) {
+    for (const [key, value] of new URLSearchParams(query)) search[key] = value
+  }
+  return { to: path || '/', search }
 }
 
 export function NotificationBell() {
@@ -107,7 +136,8 @@ export function NotificationBell() {
     }
 
     if (n.link) {
-      navigate({ to: n.link })
+      const { to, search } = parseNotificationLink(n.link)
+      navigate({ to, search })
       setOpen(false)
     }
   }
@@ -154,15 +184,16 @@ export function NotificationBell() {
               </div>
             ) : (
               notifications.map(n => {
-                const Icon = kindIcons[n.kind] || Bell
-                const color = kindColors[n.kind] || '#6b7280'
+                const isFailure = n.severity === 'error'
+                const Icon = kindIcons[n.kind] || (isFailure ? AlertTriangle : Bell)
+                const color = kindColors[n.kind] || (isFailure ? FAILURE_RED : '#6b7280')
                 return (
                   <button
                     key={n.uuid}
                     onClick={() => handleMarkRead(n)}
                     className={`w-full text-left flex items-start gap-3 px-4 py-3 hover:bg-gray-50 transition-colors border-b border-gray-50 ${
                       n.read ? 'opacity-60' : ''
-                    }`}
+                    } ${isFailure && !n.read ? 'bg-red-50/60' : ''}`}
                   >
                     <Icon className="h-4 w-4 shrink-0 mt-0.5" style={{ color }} />
                     <div className="min-w-0 flex-1">
@@ -172,12 +203,21 @@ export function NotificationBell() {
                       {n.body && (
                         <p className="text-xs text-gray-500 mt-0.5 line-clamp-2">{n.body}</p>
                       )}
-                      {n.created_at && (
-                        <p className="text-xs text-gray-500 mt-1">{relativeTime(n.created_at)}</p>
-                      )}
+                      <p className="text-xs text-gray-500 mt-1">
+                        {n.created_at && relativeTime(n.created_at)}
+                        {n.occurrences > 1 && (
+                          <span className="ml-1 text-gray-400">
+                            {n.created_at && '· '}
+                            {`${n.occurrences} occurrences`}
+                          </span>
+                        )}
+                      </p>
                     </div>
                     {!n.read && (
-                      <span className="h-2 w-2 rounded-full bg-blue-500 shrink-0 mt-1.5" />
+                      <span
+                        className="h-2 w-2 rounded-full shrink-0 mt-1.5"
+                        style={{ backgroundColor: isFailure ? FAILURE_RED : '#3b82f6' }}
+                      />
                     )}
                   </button>
                 )


### PR DESCRIPTION
## The problem

Notifications only ever carried *successful* events — approvals, verification decisions, catalog updates, team shares. Nothing told a user that a workflow run died, a document never finished processing, an extraction errored, or a scheduled automation had been failing every night for weeks. The only way to find out was to go looking.

Closes the support ticket "No notifications for any kind of failure".

## What this adds

Four failure kinds on the existing notification system: `workflow_failed`, `extraction_failed`, `document_failed`, `automation_failed`. Emitters live in `services/failure_notifications.py` and are called from the Celery failure paths.

Three rules the emitters hold to:

- **Never raise.** Callers already did real work; a failed bell write must not fail or retry the task.
- **Only fire on the final attempt.** These tasks carry `autoretry_for`, so a mid-retry emit would report a failure for a run that is about to succeed (`is_final_attempt`).
- **Coalesce.** Repeats fold into one unread row with an `occurrences` count, so a weekly automation failing for a month is one entry, not thirty. Documents coalesce *per user*, so a 50-file upload with a dozen bad files reads as "12 documents failed to process".

For automation-triggered runs the recipient is the **automation's** owner — they set the schedule and need not own the workflow.

## Two bugs this also fixes

The ticket says the notification system "already exists and is used in several places". It does — but the failure half of it was dead:

1. **`should_send_notification` never matched a real workflow failure.** It compared `status == "failed"`, but `WorkflowResult` records failures as `"error"`. The per-automation "notify me on failure" email/Teams option in the UI had never fired for any workflow failure. Added `is_failed_status()` covering both spellings, since trigger events and the activity rail use `"failed"`.

2. **`process_outputs` was only dispatched from the success path.** Even with the comparison fixed, a failed run never reached the notification code. It is now dispatched on failure too, with storage/OneDrive/chaining gated on success — a failed run has no output worth writing or handing downstream. A passive run that died also left its `WorkflowResult` stuck in `"running"` forever; it is now recorded as failed and linked back to its trigger event so the right automation's config resolves.

Separately, `process_extraction_outputs` no longer hard-codes `status: "completed"` when every input document errored.

## Frontend

Failure kinds render red with an occurrence count. `parseNotificationLink` splits query strings so workspace deep-links (`/?workflow=<id>`, `/?mode=automations&automation=<id>`) actually carry their params into the router instead of being passed whole as a path.

## Notes for review

- `Notification.occurrences` is deliberately not named `count` — that shadows Beanie's `Document.count`.
- New failure kinds must be added to `notification_service.FAILURE_KINDS` (drives `severity="error"`, which is what makes the bell render red) and to the icon/color maps in `NotificationBell.tsx`. A test asserts the set membership so this is hard to forget.
- **Out of scope:** email digests. This is in-app plus the now-working opt-in per-automation email, so a user who never opens the app still won't learn about a failing nightly automation. That may be the natural follow-up.

## Verification

- `make backend-ci` — green (2949 passed / 165 skipped, 56.98% coverage, tier-1 integration 14/14)
- `make backend-static` — ruff + bandit clean
- `make frontend-ci` — 288 tests, 0 lint errors, build OK
- 35 new tests: 17 emitter, 13 wiring/trigger-site, 5 link parsing

🤖 Generated with [Claude Code](https://claude.com/claude-code)