### PR TITLE
fix(frontend): self-host Public Sans so offline deploys don't hang

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -31,9 +31,12 @@
         }
       })()
     </script>
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Public+Sans:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
+    <!--
+      Public Sans is self-hosted (see @fontsource-variable/public-sans, imported
+      from src/main.tsx). Do NOT add a fonts.googleapis.com <link> here: a
+      render-blocking stylesheet on a third-party host freezes the SPA for the
+      length of the browser's connect timeout on offline / air-gapped installs.
+    -->
     <title>Vandalizer</title>
   </head>
   <body>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@fontsource-variable/public-sans": "^5.3.0",
         "@sentry/react": "^10.63.0",
         "@tailwindcss/vite": "^4.3.1",
         "@tanstack/react-query": "^5.101.4",
@@ -690,6 +691,15 @@
         "@noble/hashes": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@fontsource-variable/public-sans": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/public-sans/-/public-sans-5.3.0.tgz",
+      "integrity": "sha512-AVfkmAt50BMXWpOO21FAntiJFKGX6xTc2dSL8dxtDteONe9IuRXJWGbs0EbG955vAMCq23ENeuopuW87cGWDSQ==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@humanfs/core": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
     "ci": "npm run typecheck && npm run lint && npm run test:coverage && npm run build"
   },
   "dependencies": {
+    "@fontsource-variable/public-sans": "^5.3.0",
     "@sentry/react": "^10.63.0",
     "@tailwindcss/vite": "^4.3.1",
     "@tanstack/react-query": "^5.101.4",
@@ -47,7 +48,6 @@
     "@vitejs/plugin-react": "^6.0.1",
     "@vitest/coverage-v8": "^4.1.10",
     "axe-core": "^4.10.2",
-    "vitest-axe": "^1.0.0-pre.5",
     "eslint": "^10.3.0",
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.5.3",
@@ -56,6 +56,7 @@
     "typescript": "~6.0.3",
     "typescript-eslint": "^8.62.1",
     "vite": "^8.1.3",
-    "vitest": "^4.1.0"
+    "vitest": "^4.1.0",
+    "vitest-axe": "^1.0.0-pre.5"
   }
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -25,7 +25,10 @@ html {
   --highlight-on-light: #806600;
   --ui-radius: 12px;
   --rail-w: 220px;
-  font-family: "Public Sans", Arial, sans-serif;
+  /* "Public Sans Variable" is the family name shipped by
+     @fontsource-variable/public-sans (bundled, no network). Plain
+     "Public Sans" stays as a fallback for a locally installed copy. */
+  font-family: "Public Sans Variable", "Public Sans", Arial, sans-serif;
 }
 
 /* Global keyboard focus indicator */

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,6 +1,10 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { initSentry } from './lib/sentry'
+// Self-hosted Public Sans (variable, wght 100-900). Bundled by Vite so the SPA
+// has no third-party font request at runtime — offline installs must not block
+// on fonts.googleapis.com.
+import '@fontsource-variable/public-sans'
 import './index.css'
 import App from './App.tsx'
 


### PR DESCRIPTION
## Problem

`frontend/index.html` render-blocked on a `fonts.googleapis.com` stylesheet. On a network with no upstream internet — a conference hotspot, an air-gapped install — the SPA appeared frozen for 30–90s while the browser timed out the connect.

Reported via support ticket (Nathan Layman).

## Fix

Self-host the font instead. Added `@fontsource-variable/public-sans` and imported it from `main.tsx`, so Vite bundles the woff2 files as local hashed assets under `/assets/`. Both `preconnect` hints and the third-party stylesheet are gone from `index.html`, replaced with a comment so they don't get re-added.

**Why the variable font** over the five static weights: one 26 KB latin file covers wght 100–900, which serves every weight the old Google request asked for (300/400/500/600/700) in fewer bytes than a single static family would. Only the three normal-style subsets ship (53 KB total) — nothing imports the italic CSS, and the old request had no italic axis either, so rendering is unchanged.

Fontsource ships the family as `"Public Sans Variable"`, so `index.css` now declares `"Public Sans Variable", "Public Sans", Arial, sans-serif` — plain `"Public Sans"` stays as a fallback for a locally installed copy.

## Verification

- `npm run build` passes (includes `tsc -b`); emits `public-sans-{latin,latin-ext,vietnamese}-wght-normal-*.woff2` into `dist/assets/`, with `@font-face` srcs pointing at `/assets/...`.
- Grepping the shipped output for `http(s)://` returns **zero external origins** in `dist/index.html` and the built CSS.
- Same grep across `src/`, `index.html`, and `nginx.conf` for `cdn.`/`unpkg`/`jsdelivr`/`gstatic` found nothing — fonts were the only external render-blocking dependency.
- `nginx.conf:72` already includes `woff2` in the 1-year-cache block, so no server config change was needed.
- `npm run lint`: 0 errors (20 pre-existing `exhaustive-deps` warnings in unrelated files).
- Vitest: the full suite is flaky on my machine under parallel load (2 failures on one run, 10 on another, across `a11y` / `SupportCenter.TagEditor` / `ExploreTab` / `ItemPickerModal` / `RunHistoryTab`). Those 5 files pass 23/23 run on their own. No test imports `main.tsx` or `index.css`, so this change can't reach them — flagging rather than claiming a green suite. CI will be the real signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)