### PR TITLE
fix: ground chat when no document or knowledge base is attached

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- **Chat with nothing attached could present invented document contents as fact.** The system-prompt chain in `chat_stream` covered every grounded context — retrieved KB sources, document/attachment text, a requested-but-empty KB, first-session onboarding, explicit help — and then fell through to `system_prompt = None` for an ordinary chat with nothing attached. `create_chat_agent` turns a falsey prompt into `DEFAULT_CHAT_SYSTEM_PROMPT`, which carries no grounding rule at all, so "What is the total amount requested in this proposal?" could be answered with a specific figure and a line-item budget breakdown when no proposal existed in the conversation; the model disclosed it had no document only when asked for the source page. Reproduced on both an 8B and a 30B local model, so it was the prompt context rather than model capability. The no-context branch now selects a dedicated `NO_DOCUMENT_SYSTEM_PROMPT` that states no document is attached, forbids inventing document-specific figures, quotations, dates, citations or page references, and asks the user to attach the document or select a knowledge base — while still allowing general-knowledge answers, clearly marked as general. This mirrors the guard the adjacent empty-KB branch already had for exactly the same hazard. The selection chain moved into a pure `select_chat_system_prompt()` helper so every branch is unit-testable; behaviour for the KB, document, empty-KB, first-session and help branches is unchanged.
+
 ## [v4.9.0] - 2026-07-23
 
 ### Fixed

--- a/backend/app/services/chat_service.py
+++ b/backend/app/services/chat_service.py
@@ -35,6 +35,7 @@ from app.services.llm_service import (
     FIRST_SESSION_SYSTEM_PROMPT,
     HELP_CHAT_SYSTEM_PROMPT,
     KB_CHAT_SYSTEM_PROMPT,
+    NO_DOCUMENT_SYSTEM_PROMPT,
     VANDALIZER_CONTEXT,
 )
 
@@ -179,6 +180,53 @@ def _extract_event_content(event) -> tuple[str | None, bool]:
         if isinstance(event.delta, ThinkingPartDelta):
             return event.delta.content_delta or "", True
     return None, False
+
+
+def select_chat_system_prompt(
+    *,
+    kb_sources: list[dict],
+    have_context: bool,
+    kb_uuid: Optional[str],
+    is_first_session: bool,
+    include_onboarding_context: bool,
+    manifest_block: str = "",
+) -> str:
+    """Pick the system prompt for a chat turn from its context state.
+
+    Extracted from ``chat_stream`` so each branch is unit-testable: the choice
+    is pure, while the generator around it is not.
+
+    Ordered most-grounded first. Every branch returns a prompt that tells the
+    model what it does and does not have — none may return ``None``, because
+    ``create_chat_agent`` turns a falsey prompt into
+    ``DEFAULT_CHAT_SYSTEM_PROMPT``, which carries no grounding rule at all and
+    lets the model answer document-specific questions from invention.
+    """
+    if kb_sources:
+        # The manifest rides on the system prompt (re-sent every turn) so the
+        # model can distinguish "exists here but wasn't retrieved" from "not
+        # in this project" on follow-ups too.
+        return KB_CHAT_SYSTEM_PROMPT + manifest_block
+    if have_context:
+        return DOCUMENT_CHAT_SYSTEM_PROMPT
+    if kb_uuid:
+        # A project/KB chat was requested but retrieval returned nothing (empty KB,
+        # docs not indexed yet, or no match). Tell it the KB was empty for this
+        # query while still allowing general-knowledge answers.
+        return build_project_kb_empty_prompt(manifest_block)
+    if is_first_session:
+        # First-session onboarding: conversational value discovery.
+        # Do NOT inject VANDALIZER_CONTEXT here — it's a technical how-to dump
+        # that causes the LLM to skip the conversation and spit out directions.
+        # The FIRST_SESSION_SYSTEM_PROMPT already has everything it needs.
+        return FIRST_SESSION_SYSTEM_PROMPT
+    if include_onboarding_context:
+        return HELP_CHAT_SYSTEM_PROMPT
+    # Nothing attached at all — no documents, no attachments, no KB, no
+    # onboarding. The model must be told so explicitly rather than left with
+    # the generic prompt, which would let it answer "what is the total in this
+    # proposal?" as though a proposal were present.
+    return NO_DOCUMENT_SYSTEM_PROMPT
 
 
 async def chat_stream(
@@ -348,30 +396,15 @@ async def chat_stream(
     # must cite by filename, distinguish grounded answers from general knowledge,
     # and admit when the retrieved set doesn't actually contain the answer.
     have_context = bool(doc_segments or attachment_segments)
-    if kb_sources:
-        # The manifest rides on the system prompt (re-sent every turn) so the
-        # model can distinguish "exists here but wasn't retrieved" from "not
-        # in this project" on follow-ups too.
-        system_prompt: Optional[str] = (
-            KB_CHAT_SYSTEM_PROMPT + _build_manifest_block(kb_manifest)
-        )
-    elif have_context:
-        system_prompt = DOCUMENT_CHAT_SYSTEM_PROMPT
-    elif kb_uuid:
-        # A project/KB chat was requested but retrieval returned nothing (empty KB,
-        # docs not indexed yet, or no match). Do NOT fall through to system_prompt=None
-        # — that lets the model freely hallucinate document contents. Tell it the KB
-        # was empty for this query while still allowing general-knowledge answers.
-        system_prompt = build_project_kb_empty_prompt(
-            _build_manifest_block(kb_manifest)
-        )
-    elif is_first_session:
-        # First-session onboarding: conversational value discovery.
-        # Do NOT inject VANDALIZER_CONTEXT here — it's a technical how-to dump
-        # that causes the LLM to skip the conversation and spit out directions.
-        # The FIRST_SESSION_SYSTEM_PROMPT already has everything it needs.
-        system_prompt = FIRST_SESSION_SYSTEM_PROMPT
-    elif include_onboarding_context:
+    system_prompt: Optional[str] = select_chat_system_prompt(
+        kb_sources=kb_sources,
+        have_context=have_context,
+        kb_uuid=kb_uuid,
+        is_first_session=is_first_session,
+        include_onboarding_context=include_onboarding_context,
+        manifest_block=_build_manifest_block(kb_manifest),
+    )
+    if system_prompt == HELP_CHAT_SYSTEM_PROMPT:
         # Inject Vandalizer help context only when explicitly requested
         # (triggered by the placeholder pills in the chat UI).
         doc_segments.append(DocumentSegment(
@@ -382,9 +415,6 @@ async def chat_stream(
                 "--- END ONBOARDING CONTEXT ---"
             ),
         ))
-        system_prompt = HELP_CHAT_SYSTEM_PROMPT
-    else:
-        system_prompt = None  # uses default
 
     # Resolve the model's context window and compact oversize components.
     model_config = await get_llm_model_by_name(model_name)

--- a/backend/app/services/llm_service.py
+++ b/backend/app/services/llm_service.py
@@ -660,6 +660,26 @@ DEFAULT_CHAT_SYSTEM_PROMPT = VANDALIZER_IDENTITY_PREAMBLE + (
     "- Keep answers under 150 words unless the user explicitly asks for detail.\n"
 )
 
+NO_DOCUMENT_SYSTEM_PROMPT = VANDALIZER_IDENTITY_PREAMBLE + (
+    "You are a helpful, concise assistant. **No document, attachment, or knowledge "
+    "base is attached to this chat** — you have not been shown any document text.\n\n"
+    "## How to answer\n"
+    "- **Never invent, summarize, quote, or describe the contents of a document.** "
+    "Nothing is attached to this conversation, so you cannot speak to what any file, "
+    "proposal, budget, award notice, or page says.\n"
+    "- If the user asks about \"this proposal\", \"the attached document\", a budget "
+    "figure, an award condition, a page, or any other source material, tell them "
+    "plainly that nothing is attached to this chat and ask them to attach the document "
+    "or select a knowledge base. Do NOT offer a figure, date, quotation, citation, or "
+    "page reference as though you had read it.\n"
+    "- **You can still answer general questions** from your own knowledge — go ahead "
+    "and help, but make clear that answer is general knowledge and is NOT based on any "
+    "document of theirs.\n\n"
+    "## Format\n"
+    "- Be concise. Short Markdown bullets — no walls of text.\n"
+    "- Do NOT restate the question.\n"
+)
+
 COMPACT_SYSTEM_PROMPT = (
     "You are a conversation summarizer. Given a conversation history, produce a concise "
     "summary that preserves all key facts, decisions, context, and user preferences mentioned. "

--- a/backend/tests/test_chat_service.py
+++ b/backend/tests/test_chat_service.py
@@ -298,3 +298,167 @@ class TestCitationPersistence:
         args, kwargs = conversation.add_message.await_args
         assert args[0] == ChatRole.ASSISTANT
         assert kwargs["citations"] == citations
+
+
+# ---------------------------------------------------------------------------
+# System prompt selection
+# ---------------------------------------------------------------------------
+
+
+class TestChatSystemPromptSelection:
+    """Every context state must resolve to a grounded prompt.
+
+    The no-context branch used to fall through to ``system_prompt=None``, which
+    ``create_chat_agent`` turns into ``DEFAULT_CHAT_SYSTEM_PROMPT`` — a prompt
+    carrying no grounding rule at all. That let "what is the total requested in
+    this proposal?" be answered from invention when no proposal was attached.
+    """
+
+    def _select(self, **overrides):
+        from app.services.chat_service import select_chat_system_prompt
+        kwargs = dict(
+            kb_sources=[],
+            have_context=False,
+            kb_uuid=None,
+            is_first_session=False,
+            include_onboarding_context=False,
+            manifest_block="",
+        )
+        kwargs.update(overrides)
+        return select_chat_system_prompt(**kwargs)
+
+    def test_no_context_selects_the_no_document_prompt(self):
+        from app.services.llm_service import NO_DOCUMENT_SYSTEM_PROMPT
+        assert self._select() == NO_DOCUMENT_SYSTEM_PROMPT
+
+    def test_no_context_never_resolves_to_the_ungrounded_default(self):
+        from app.services.llm_service import DEFAULT_CHAT_SYSTEM_PROMPT
+        selected = self._select()
+        assert selected
+        assert selected != DEFAULT_CHAT_SYSTEM_PROMPT
+
+    def test_retrieved_kb_sources_select_the_kb_prompt(self):
+        from app.services.llm_service import KB_CHAT_SYSTEM_PROMPT
+        assert self._select(kb_sources=[{"document_title": "budget.xlsx"}]) == (
+            KB_CHAT_SYSTEM_PROMPT
+        )
+
+    def test_kb_prompt_carries_the_manifest_block(self):
+        from app.services.llm_service import KB_CHAT_SYSTEM_PROMPT
+        # Deliberately not a realistic filename: KB_CHAT_SYSTEM_PROMPT cites
+        # "budget.xlsx" as an example, so asserting on that would pass even if
+        # the manifest were dropped entirely.
+        sentinel = "manifest-sentinel-9f3a2c.pdf"
+        selected = self._select(
+            kb_sources=[{"document_title": sentinel}],
+            manifest_block=f"\n--- FILES ---\n{sentinel}\n",
+        )
+        assert selected.startswith(KB_CHAT_SYSTEM_PROMPT)
+        assert sentinel in selected
+
+    def test_document_context_selects_the_document_prompt(self):
+        from app.services.llm_service import DOCUMENT_CHAT_SYSTEM_PROMPT
+        assert self._select(have_context=True) == DOCUMENT_CHAT_SYSTEM_PROMPT
+
+    def test_requested_kb_with_no_retrieval_selects_the_empty_kb_prompt(self):
+        from app.services.llm_service import build_project_kb_empty_prompt
+        assert self._select(kb_uuid="kb-1") == build_project_kb_empty_prompt("")
+
+    def test_first_session_selects_the_onboarding_prompt(self):
+        from app.services.llm_service import FIRST_SESSION_SYSTEM_PROMPT
+        assert self._select(is_first_session=True) == FIRST_SESSION_SYSTEM_PROMPT
+
+    def test_explicit_onboarding_selects_the_help_prompt(self):
+        from app.services.llm_service import HELP_CHAT_SYSTEM_PROMPT
+        assert self._select(include_onboarding_context=True) == HELP_CHAT_SYSTEM_PROMPT
+
+    def test_retrieved_sources_take_precedence_over_document_context(self):
+        from app.services.llm_service import KB_CHAT_SYSTEM_PROMPT
+        assert self._select(
+            kb_sources=[{"document_title": "a.pdf"}], have_context=True,
+        ) == KB_CHAT_SYSTEM_PROMPT
+
+    def test_document_context_takes_precedence_over_an_empty_kb(self):
+        from app.services.llm_service import DOCUMENT_CHAT_SYSTEM_PROMPT
+        assert self._select(have_context=True, kb_uuid="kb-1") == (
+            DOCUMENT_CHAT_SYSTEM_PROMPT
+        )
+
+    def test_an_empty_kb_still_outranks_onboarding_branches(self):
+        from app.services.llm_service import build_project_kb_empty_prompt
+        assert self._select(
+            kb_uuid="kb-1", is_first_session=True, include_onboarding_context=True,
+        ) == build_project_kb_empty_prompt("")
+
+
+class TestNoDocumentPromptContent:
+    """The no-document prompt must say the four things the branch depends on.
+
+    Asserted as behavioural clauses rather than exact strings so the wording can
+    be revised without breaking the suite.
+    """
+
+    def _prompt(self) -> str:
+        from app.services.llm_service import NO_DOCUMENT_SYSTEM_PROMPT
+        return NO_DOCUMENT_SYSTEM_PROMPT.lower()
+
+    def test_states_that_no_document_is_available(self):
+        assert "no document" in self._prompt()
+
+    def test_forbids_inventing_document_specific_content(self):
+        prompt = self._prompt()
+        assert "invent" in prompt or "fabricat" in prompt
+
+    def test_tells_the_model_to_ask_for_the_source(self):
+        assert "attach" in self._prompt()
+
+    def test_still_permits_general_knowledge_answers(self):
+        assert "general" in self._prompt()
+
+    def test_carries_the_shared_identity_preamble(self):
+        from app.services.llm_service import (
+            NO_DOCUMENT_SYSTEM_PROMPT,
+            VANDALIZER_IDENTITY_PREAMBLE,
+        )
+        assert NO_DOCUMENT_SYSTEM_PROMPT.startswith(VANDALIZER_IDENTITY_PREAMBLE)
+
+
+class TestNoDocumentGroundingEveryTurn:
+    """The no-document grounding must survive follow-up turns.
+
+    Same failure mode as TestChatAgentGroundingEveryTurn: a static
+    ``system_prompt`` is injected by pydantic-ai only when message_history is
+    empty, so a grounding rule delivered that way silently disappears on the
+    second question — exactly when a user follows up on a fabricated answer.
+    """
+
+    @pytest.mark.asyncio
+    async def test_no_document_prompt_delivered_on_followup_turn(self, monkeypatch):
+        from pydantic_ai.models.function import FunctionModel
+        from pydantic_ai.messages import ModelResponse, TextPart
+        from app.services import llm_service
+
+        seen: list = []
+
+        def fn(messages, info):
+            seen.append(getattr(messages[-1], "instructions", "NO_ATTR"))
+            return ModelResponse(parts=[TextPart("ok")])
+
+        monkeypatch.setattr(llm_service, "get_agent_model", lambda *a, **k: FunctionModel(fn))
+        monkeypatch.setattr(llm_service, "build_thinking_model_settings", lambda *a, **k: {})
+        agent = llm_service.create_chat_agent(
+            "test-model", system_prompt=llm_service.NO_DOCUMENT_SYSTEM_PROMPT,
+        )
+
+        first = await agent.run("what is the total requested in this proposal?")
+        await agent.run("what page did you get that from?", message_history=first.new_messages())
+
+        # pydantic-ai strips surrounding whitespace from instructions, so compare
+        # stripped rather than asserting the constant verbatim.
+        expected = llm_service.NO_DOCUMENT_SYSTEM_PROMPT.strip()
+        assert len(seen) == 2, f"expected two model requests; saw {len(seen)}"
+        assert seen[0] == expected, "grounding missing on the first turn"
+        assert seen[1] == expected, (
+            "grounding must persist onto the follow-up turn — this is the turn "
+            f"where a user challenges a fabricated answer; saw {seen[1]!r}"
+        )


### PR DESCRIPTION
## Summary

The system-prompt chain in `chat_stream` covers every grounded context — retrieved KB
sources, document or attachment text, a requested-but-empty KB, first-session onboarding,
explicit help — and then falls through to `system_prompt = None` for an ordinary chat with
nothing attached. `create_chat_agent` turns a falsey prompt into
`DEFAULT_CHAT_SYSTEM_PROMPT`, which carries no grounding rule at all, so a
document-specific question could be answered from invention: *"What is the total amount
requested in this proposal?"* returned a specific figure and a line-item budget breakdown
with no proposal in the conversation, and the missing document was disclosed only when the
source page was challenged.

This adds a dedicated no-context prompt so the model is told what it does and does not
have. Reproduced on both an 8B and a 30B local model, so it is the prompt context rather
than model capability.

The adjacent empty-KB branch already guards this exact hazard — its comment reads *"Do NOT
fall through to system_prompt=None — that lets the model freely hallucinate document
contents."* This applies the same principle to the last remaining branch.

Reported in #586.

## Changes

- **`backend/app/services/llm_service.py`** — new `NO_DOCUMENT_SYSTEM_PROMPT`, built on
  `VANDALIZER_IDENTITY_PREAMBLE` like its siblings and modelled on
  `PROJECT_KB_EMPTY_SYSTEM_PROMPT`, which addresses the same shape of problem. It states
  that nothing is attached, forbids inventing document-specific figures, quotations, dates,
  citations or page references, and asks the user to attach the document or select a
  knowledge base — while still permitting general-knowledge answers, clearly marked as
  general.
- **`backend/app/services/chat_service.py`** — the final `else` now selects that prompt.
- **`CHANGELOG.md`** — entry under `[Unreleased] → Fixed`.

### One refactor, flagged deliberately

The selection chain moved out of `chat_stream` into a pure
`select_chat_system_prompt()` helper. **Behaviour is identical** — same branch order, every
original comment preserved, and the onboarding context injection stays in the caller so its
side effect on `doc_segments` is unchanged.

I did this because it is what makes the branches testable: selection previously lived
inside a long streaming async generator, and this module's own test suite states it focuses
on "the deterministic parsing helpers that can be unit-tested without LLM calls". It is the
difference between testing one prompt constant and regression-testing all six branches.

**Happy to drop it** and change only the `else` branch if you would rather keep this PR to
the one-line fix — that costs the six selection tests but nothing else. Say the word.

## Test Plan

- [x] Shared checks pass (`make ci`)
- [ ] Release check passes if packaging or deployment changed (`make release-check`) — n/a, no packaging or deployment change
- [x] Manually tested the affected feature(s)
- [x] Updated `CHANGELOG.md` for user-facing or operator-facing changes
- [ ] Updated deploy/release docs — n/a, install and release paths unchanged

Added coverage in **`backend/tests/test_chat_service.py`** (17 cases):

- **Selection** — each of the six branches, including that no-context resolves to the new
  prompt and never to `DEFAULT_CHAT_SYSTEM_PROMPT`; plus precedence between them (retrieved
  sources over document context, document context over an empty KB, an empty KB over both
  onboarding branches).
- **Prompt content** — asserted as behavioural clauses rather than exact strings, so the
  wording can be revised without breaking the suite: states no document is available,
  forbids invention, asks for the source, still permits general knowledge, and carries the
  shared identity preamble.
- **Multi-turn delivery** — the grounding must survive the follow-up turn, which is exactly
  when a user challenges a fabricated answer. Follows the existing
  `TestChatAgentGroundingEveryTurn` approach using pydantic-ai's `FunctionModel`.

Each test was written before the code and observed failing first. The change was then
checked against five deliberately wrong implementations — restoring the `None`
fall-through, bypassing the empty-KB branch, dropping the manifest from the KB prompt,
removing the do-not-invent clause, and passing grounding as `system_prompt` instead of
`instructions` so it reaches the model only on the first turn. All five are caught.

One of those initially survived, which was worth fixing: a test asserted that
`"budget.xlsx"` appeared in the KB prompt once the manifest was appended — but
`KB_CHAT_SYSTEM_PROMPT` already cites `budget.xlsx` as an example filename, so the
assertion held whether or not the manifest was there. It now uses a sentinel filename that
cannot collide.

## Related Issues

Closes #586
