### PR TITLE
feat(optimization): surface tuning suggestions and failures in the app

### DIFF
--- a/backend/app/models/extraction_optimization_run.py
+++ b/backend/app/models/extraction_optimization_run.py
@@ -168,6 +168,10 @@ class ExtractionOptimizationRun(Document):
     options: dict = Field(default_factory=dict)
     # Shape: {"apply_on_finish": bool, "include_judge": bool, "advanced": {...}}
 
+    # Optimizer-inbox triage — see the same fields on ``KBOptimizationRun``.
+    dismissed_at: Optional[datetime.datetime] = None
+    dismissed_by: Optional[str] = None
+
     error_message: Optional[str] = None
 
     class Settings:

--- a/backend/app/models/kb_optimization_run.py
+++ b/backend/app/models/kb_optimization_run.py
@@ -211,6 +211,12 @@ class KBOptimizationRun(Document):
     # Shape documented on ``build_apply_preview``.
     apply_preview: Optional[dict] = None
 
+    # Optimizer-inbox triage. A candidate the user reviewed and rejected is
+    # dismissed rather than deleted, so the run stays auditable (and visible in
+    # the per-KB history + admin activity view) while dropping out of the inbox.
+    dismissed_at: Optional[datetime.datetime] = None
+    dismissed_by: Optional[str] = None
+
     error_message: Optional[str] = None
     # Structured failure classification — populated alongside ``error_message``
     # so the UI can render plain-English remediation (e.g. "Add documents to

--- a/backend/app/models/workflow_optimization_run.py
+++ b/backend/app/models/workflow_optimization_run.py
@@ -119,6 +119,10 @@ class WorkflowOptimizationRun(Document):
     options: dict = Field(default_factory=dict)
     # Shape: {"apply_on_finish": bool, "include_judge": bool, "advanced": {...}}
 
+    # Optimizer-inbox triage — see the same fields on ``KBOptimizationRun``.
+    dismissed_at: Optional[datetime.datetime] = None
+    dismissed_by: Optional[str] = None
+
     error_message: Optional[str] = None
 
     class Settings:

--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -2044,6 +2044,229 @@ async def quality_contract(
 
 
 # ---------------------------------------------------------------------------
+# 18b. GET /optimizer/activity  - Fleet-wide optimizer runs (read-only)
+#
+# The per-item optimizer panels only ever show one item's runs, and the user
+# inbox is access-scoped to what its caller owns. Neither answers "is the
+# optimizer healthy?" — which is how a ten-day run of failures stayed invisible.
+# This endpoint is the operator view: every run across all three surfaces, with
+# failure reasons rolled up. Read-only by construction — no apply/dismiss here,
+# because acting on someone else's item is theirs to do from their inbox.
+# ---------------------------------------------------------------------------
+
+OPTIMIZER_SURFACES = ("kb", "extraction", "workflow")
+
+
+def _failure_reason(run) -> str:
+    """Group key for the failure rollup.
+
+    Prefers the structured ``error_code`` (KB runs set one); otherwise uses a
+    truncated message, since raw exception strings carry ids that would make
+    every failure look unique.
+    """
+    code = getattr(run, "error_code", None)
+    if code:
+        return str(code)
+    message = (getattr(run, "error_message", None) or "").strip()
+    if not message:
+        return "unknown"
+    return message[:120]
+
+
+@router.get("/optimizer/activity")
+async def optimizer_activity(
+    days: int = Query(default=14, ge=1, le=MAX_ANALYTICS_DAYS),
+    surface: Optional[str] = Query(default=None, description="kb | extraction | workflow"),
+    status: Optional[str] = Query(
+        default=None, description="queued | running | completed | failed | cancelled",
+    ),
+    trigger: Optional[str] = Query(
+        default=None, description="'auto' (signal/alert-triggered) or 'user'",
+    ),
+    limit: int = Query(default=100, ge=1, le=500),
+    user: User = Depends(get_current_user),
+):
+    """Every optimizer run in the window, newest first, with a health summary."""
+    await _require_admin(user)
+
+    from app.models.extraction_optimization_run import ExtractionOptimizationRun
+    from app.models.kb_optimization_run import KBOptimizationRun
+    from app.models.knowledge import KnowledgeBase
+    from app.models.search_set import SearchSet
+    from app.models.workflow import Workflow
+    from app.models.workflow_optimization_run import WorkflowOptimizationRun
+    from app.routers.optimizer_inbox import (
+        extraction_run_is_live,
+        kb_run_is_live,
+        workflow_run_is_live,
+    )
+
+    if surface and surface not in OPTIMIZER_SURFACES:
+        raise HTTPException(
+            status_code=400,
+            detail=f"surface must be one of {', '.join(OPTIMIZER_SURFACES)}",
+        )
+
+    cutoff = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=days)
+    query: dict = {"started_at": {"$gte": cutoff}}
+    if status:
+        query["status"] = status
+    if trigger == "auto":
+        query["options.shadow_trigger"] = {"$exists": True}
+    elif trigger == "user":
+        query["options.shadow_trigger"] = {"$exists": False}
+
+    async def _fetch(model):
+        return await model.find(query).sort("-started_at").limit(limit).to_list()
+
+    kb_runs = [] if surface not in (None, "kb") else await _fetch(KBOptimizationRun)
+    ex_runs = [] if surface not in (None, "extraction") else await _fetch(ExtractionOptimizationRun)
+    wf_runs = [] if surface not in (None, "workflow") else await _fetch(WorkflowOptimizationRun)
+
+    # Bulk-resolve parent items (for display names and live-config checks) and
+    # owners (for "who launched this"), so the row loop stays query-free.
+    kb_by_uuid = {}
+    if kb_runs:
+        kbs = await KnowledgeBase.find(
+            {"uuid": {"$in": list({r.kb_uuid for r in kb_runs if r.kb_uuid})}},
+        ).to_list()
+        kb_by_uuid = {k.uuid: k for k in kbs}
+
+    ss_by_uuid = {}
+    if ex_runs:
+        sets = await SearchSet.find(
+            {"uuid": {"$in": list({r.search_set_uuid for r in ex_runs if r.search_set_uuid})}},
+        ).to_list()
+        ss_by_uuid = {s.uuid: s for s in sets}
+
+    wf_by_id: dict = {}
+    if wf_runs:
+        object_ids = []
+        for r in wf_runs:
+            try:
+                object_ids.append(BsonObjectId(r.workflow_id))
+            except Exception:
+                continue
+        if object_ids:
+            workflows = await Workflow.find({"_id": {"$in": object_ids}}).to_list()
+            wf_by_id = {str(w.id): w for w in workflows}
+
+    all_runs = [
+        ("kb", r, r.kb_uuid, kb_by_uuid.get(r.kb_uuid), kb_run_is_live(r))
+        for r in kb_runs
+    ] + [
+        ("extraction", r, r.search_set_uuid, ss_by_uuid.get(r.search_set_uuid),
+         extraction_run_is_live(r, ss_by_uuid.get(r.search_set_uuid)))
+        for r in ex_runs
+    ] + [
+        ("workflow", r, r.workflow_id, wf_by_id.get(r.workflow_id),
+         workflow_run_is_live(r, wf_by_id.get(r.workflow_id)))
+        for r in wf_runs
+    ]
+
+    user_ids = {getattr(r, "user_id", None) for _, r, _, _, _ in all_runs}
+    user_ids.discard(None)
+    owners = await User.find({"user_id": {"$in": list(user_ids)}}).to_list() if user_ids else []
+    email_by_user = {u.user_id: u.email for u in owners}
+
+    rows = []
+    by_status: dict[str, int] = {}
+    by_surface: dict[str, int] = {}
+    failure_counts: dict[str, int] = {}
+    auto_triggered = pending_review = applied_count = dismissed_count = 0
+    tokens_used_total = 0
+
+    for kind, run, item_id, item_doc, is_live in all_runs:
+        options = run.options or {}
+        shadow_trigger = options.get("shadow_trigger")
+        dismissed_at = getattr(run, "dismissed_at", None)
+        tied = bool(getattr(run, "tied_with_baseline", False))
+        item_name = (
+            (getattr(item_doc, "name", None) or getattr(item_doc, "title", None))
+            if item_doc is not None else None
+        )
+
+        by_status[run.status] = by_status.get(run.status, 0) + 1
+        by_surface[kind] = by_surface.get(kind, 0) + 1
+        if shadow_trigger:
+            auto_triggered += 1
+        if is_live:
+            applied_count += 1
+        if dismissed_at is not None:
+            dismissed_count += 1
+        if run.status == "failed":
+            reason = _failure_reason(run)
+            failure_counts[reason] = failure_counts.get(reason, 0) + 1
+        if (
+            run.status == "completed" and not is_live and not tied
+            and dismissed_at is None and getattr(run, "best_config", None)
+        ):
+            pending_review += 1
+        tokens_used_total += int(getattr(run, "tokens_used", 0) or 0)
+
+        rows.append({
+            "surface": kind,
+            "run_uuid": run.uuid,
+            "item_id": item_id,
+            # Null name = the tuned item has since been deleted.
+            "item_name": item_name,
+            "item_deleted": item_doc is None,
+            "user_id": getattr(run, "user_id", None),
+            "user_email": email_by_user.get(getattr(run, "user_id", None)),
+            "status": run.status,
+            "trigger": shadow_trigger,
+            "trigger_detail": options.get("shadow_trigger_detail") or {},
+            "started_at": run.started_at.isoformat() if run.started_at else None,
+            "completed_at": run.completed_at.isoformat() if run.completed_at else None,
+            "baseline_score": getattr(run, "baseline_default_score", None),
+            "optimized_score": getattr(run, "optimized_score", None),
+            "tied_with_baseline": tied,
+            "tokens_used": getattr(run, "tokens_used", 0),
+            "token_budget": getattr(run, "token_budget", 0),
+            "actual_cost_usd": getattr(run, "actual_cost_usd", None),
+            "stopped_reason": getattr(run, "stopped_reason", None),
+            "error_message": getattr(run, "error_message", None),
+            "error_code": getattr(run, "error_code", None),
+            "phase": getattr(run, "phase", None),
+            "progress_message": getattr(run, "progress_message", None),
+            "is_live": is_live,
+            "dismissed_at": dismissed_at.isoformat() if dismissed_at else None,
+        })
+
+    rows.sort(key=lambda r: r.get("started_at") or "", reverse=True)
+
+    return {
+        "runs": rows[:limit],
+        "summary": {
+            "window_days": days,
+            "total": len(rows),
+            "by_status": by_status,
+            "by_surface": by_surface,
+            "auto_triggered": auto_triggered,
+            "user_launched": len(rows) - auto_triggered,
+            "failed": by_status.get("failed", 0),
+            "applied": applied_count,
+            "dismissed": dismissed_count,
+            # Completed candidates nobody has acted on — the backlog the
+            # support ticket was about.
+            "pending_review": pending_review,
+            "tokens_used": tokens_used_total,
+            "failure_reasons": [
+                {"reason": reason, "count": count}
+                for reason, count in sorted(
+                    failure_counts.items(), key=lambda kv: kv[1], reverse=True,
+                )
+            ],
+            # True when a per-surface fetch hit the cap, so the UI can say the
+            # summary is a floor rather than an exact fleet total.
+            "truncated": any(
+                len(runs) >= limit for runs in (kb_runs, ex_runs, wf_runs)
+            ),
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
 # 19. GET /admin/teams/all  - All teams (admin management view)
 # ---------------------------------------------------------------------------
 

--- a/backend/app/routers/optimizer_inbox.py
+++ b/backend/app/routers/optimizer_inbox.py
@@ -1,157 +1,470 @@
-"""Optimizer Inbox  - unified shadow-run candidate list (Phase 6 of loop closure).
+"""Optimizer Inbox  - unified tuning-suggestion triage (Phase 6 of loop closure).
 
-Phase 5 + 6 trigger optimizer runs in *shadow* mode in response to quality
-alerts and report-only signals. These runs land in the user's inbox with
-their winning config + ``apply_preview`` already computed — the user can
-review, apply, dismiss, or re-tune from one place rather than checking
-each KB / SearchSet / workflow individually.
+Phases 5 + 6 trigger optimizer runs in *shadow* mode in response to quality
+alerts and report-only signals. Those runs finish with a winning config and an
+``apply_preview`` already computed, but nothing ever asked the user to look at
+them — the candidates piled up invisibly, and so did the failures.
+
+This router is the read/triage surface for all three optimizer families:
+
+- ``GET  /inbox``                              — candidates + failures the caller can see
+- ``GET  /inbox/count``                        — badge counts only (cheap)
+- ``POST /inbox/{surface}/{run_uuid}/dismiss`` — reject a candidate
+- ``POST /inbox/{surface}/{run_uuid}/restore`` — un-dismiss it
+
+Applying a candidate deliberately stays on the per-surface endpoints
+(``/api/workflows/{id}/optimize/{run}/apply`` and friends) so the inbox
+inherits their governance gates — tied-with-baseline, cross-field thresholds,
+previous-override snapshots and quality-timeline recording — instead of
+growing a second, weaker apply path.
 """
 
 from __future__ import annotations
 
 import datetime
-from typing import Literal
+import logging
+from typing import Any, Literal, Optional
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException, Query
 
 from app.dependencies import get_current_user
 from app.models.extraction_optimization_run import ExtractionOptimizationRun
 from app.models.kb_optimization_run import KBOptimizationRun
 from app.models.user import User
 from app.models.workflow_optimization_run import WorkflowOptimizationRun
+from app.services import access_control, organization_service
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
 
 SurfaceKind = Literal["kb", "extraction", "workflow"]
 
-# Inbox window: shadow runs older than this are considered stale and dropped
-# from the inbox response (they're still in the per-surface history view).
+# Inbox window: runs older than this drop out of the inbox (they're still in
+# the per-surface history view and in the admin activity view).
 INBOX_LOOKBACK = datetime.timedelta(days=14)
 
+# Per-surface cap on the runs we pull before access filtering. The inbox is a
+# triage list, not an archive — anything past this is reachable from history.
+PER_SURFACE_LIMIT = 50
 
-def _summarize_kb(run: KBOptimizationRun) -> dict:
+# Categories the UI groups rows by. ``needs_review`` is the only one that
+# carries an action; the rest are informational.
+InboxCategory = Literal[
+    "needs_review",   # completed, has a config to promote, nobody has acted on it
+    "no_change",      # completed but statistically tied with current settings
+    "applied",        # winner is live on the item
+    "failed",         # the tuning run itself blew up
+    "in_flight",      # queued / running
+    "cancelled",
+    "dismissed",
+]
+
+
+class _AccessCache:
+    """Per-request cache of the expensive access-control preamble.
+
+    ``get_team_access_context`` and ``get_user_org_ancestry`` each cost queries,
+    and the inbox resolves up to ``3 × PER_SURFACE_LIMIT`` runs that usually
+    point at a much smaller set of distinct items. Resolve each item once.
+    """
+
+    def __init__(self, user: User) -> None:
+        self.user = user
+        self._team_access: Any = None
+        # ``get_user_org_ancestry`` legitimately returns None, so track loaded
+        # state separately rather than treating None as "not cached yet".
+        self._org_ancestry: Optional[list[str]] = None
+        self._org_loaded = False
+        # (surface, item_id) -> (doc, can_manage) | None when not visible
+        self._items: dict[tuple[str, str], Optional[tuple[Any, bool]]] = {}
+
+    async def team_access(self) -> Any:
+        if self._team_access is None:
+            self._team_access = await access_control.get_team_access_context(self.user)
+        return self._team_access
+
+    async def org_ancestry(self) -> Optional[list[str]]:
+        if not self._org_loaded:
+            self._org_ancestry = await organization_service.get_user_org_ancestry(self.user)
+            self._org_loaded = True
+        return self._org_ancestry
+
+    async def resolve(
+        self, surface: SurfaceKind, item_id: str,
+    ) -> Optional[tuple[Any, bool]]:
+        """Return ``(parent_doc, can_manage)`` or ``None`` when not visible.
+
+        Manage access is checked first because it's the common case for an
+        owner and answers both questions in one lookup; the view-only fallback
+        exists so a team member who can see (but not change) an item still
+        learns that a candidate or failure exists.
+        """
+        key = (surface, item_id)
+        if key in self._items:
+            return self._items[key]
+        resolved = await self._resolve_uncached(surface, item_id)
+        self._items[key] = resolved
+        return resolved
+
+    async def _resolve_uncached(
+        self, surface: SurfaceKind, item_id: str,
+    ) -> Optional[tuple[Any, bool]]:
+        if not item_id:
+            return None
+        try:
+            if surface == "kb":
+                ancestry = await self.org_ancestry()
+                access = await self.team_access()
+                doc = await access_control.get_authorized_knowledge_base(
+                    item_id, self.user, manage=True,
+                    user_org_ancestry=ancestry, team_access=access,
+                )
+                if doc is not None:
+                    return (doc, True)
+                doc = await access_control.get_authorized_knowledge_base(
+                    item_id, self.user, user_org_ancestry=ancestry, team_access=access,
+                )
+                return (doc, False) if doc is not None else None
+
+            if surface == "workflow":
+                access = await self.team_access()
+                doc = await access_control.get_authorized_workflow(
+                    item_id, self.user, manage=True, team_access=access,
+                )
+                if doc is not None:
+                    return (doc, True)
+                doc = await access_control.get_authorized_workflow(
+                    item_id, self.user, team_access=access,
+                )
+                return (doc, False) if doc is not None else None
+
+            doc = await access_control.get_authorized_search_set(
+                item_id, self.user, manage=True,
+            )
+            if doc is not None:
+                return (doc, True)
+            doc = await access_control.get_authorized_search_set(item_id, self.user)
+            return (doc, False) if doc is not None else None
+        except Exception:
+            # A malformed id (e.g. a non-ObjectId workflow_id from an old run)
+            # must not take down the whole inbox — just hide that row.
+            logger.warning(
+                "Inbox access resolution failed for %s/%s", surface, item_id, exc_info=True,
+            )
+            return None
+
+
+def _item_name(surface: SurfaceKind, doc: Any) -> str:
+    """Display name for the tuned item. KB/SearchSet use ``title``; Workflow ``name``."""
+    if surface == "workflow":
+        return getattr(doc, "name", None) or getattr(doc, "title", None) or "Untitled workflow"
+    return getattr(doc, "title", None) or getattr(doc, "name", None) or "Untitled"
+
+
+def _iso(value: Optional[datetime.datetime]) -> Optional[str]:
+    return value.isoformat() if value else None
+
+
+def _categorize(
+    *, status: str, dismissed: bool, is_live: bool,
+    tied: bool, has_config: bool,
+) -> InboxCategory:
+    if dismissed:
+        return "dismissed"
+    if status in ("queued", "running"):
+        return "in_flight"
+    if status == "failed":
+        return "failed"
+    if status == "cancelled":
+        return "cancelled"
+    if is_live:
+        return "applied"
+    if tied or not has_config:
+        return "no_change"
+    return "needs_review"
+
+
+def _base_summary(
+    *,
+    surface: SurfaceKind,
+    run: Any,
+    item_id: str,
+    item_name: str,
+    can_manage: bool,
+    is_live: bool,
+    applied_at: Optional[str],
+    reverted_at: Optional[str],
+    link: str,
+) -> dict:
+    """Fields every surface reports identically, so the inbox UI is one table."""
+    options = run.options or {}
+    tied = bool(getattr(run, "tied_with_baseline", False))
+    has_config = bool(getattr(run, "best_config", None)) or bool(
+        getattr(run, "best_per_step_config", None)
+    )
+    dismissed_at = getattr(run, "dismissed_at", None)
     return {
-        "surface": "kb",
+        "surface": surface,
         "run_uuid": run.uuid,
-        "item_id": run.kb_uuid,
+        "item_id": item_id,
+        "item_name": item_name,
         "status": run.status,
-        "completed_at": run.completed_at.isoformat() if run.completed_at else None,
-        "score": run.optimized_score,
-        "baseline_score": run.baseline_default_score,
-        "trigger": (run.options or {}).get("shadow_trigger"),
-        "trigger_detail": (run.options or {}).get("shadow_trigger_detail") or {},
-        "tied_with_baseline": run.tied_with_baseline,
-        "apply_preview": run.apply_preview,
-        "applied_at": run.applied_at.isoformat() if run.applied_at else None,
-        "reverted_at": run.reverted_at.isoformat() if run.reverted_at else None,
-        # Direct link target for the UI to deep-link the autovalidate panel.
-        "link": f"/?mode=knowledge&kb={run.kb_uuid}&run={run.uuid}",
-    }
-
-
-def _summarize_extraction(run: ExtractionOptimizationRun) -> dict:
-    return {
-        "surface": "extraction",
-        "run_uuid": run.uuid,
-        "item_id": run.search_set_uuid,
-        "status": run.status,
-        "completed_at": run.completed_at.isoformat() if run.completed_at else None,
-        "score": run.optimized_score,
-        "baseline_score": run.baseline_default_score,
-        "trigger": (run.options or {}).get("shadow_trigger"),
-        "trigger_detail": (run.options or {}).get("shadow_trigger_detail") or {},
-        "tied_with_baseline": getattr(run, "tied_with_baseline", False),
-        "apply_preview": getattr(run, "apply_preview", None),
-        # Extraction tracks applied state via previous_override being non-null
-        # rather than a dedicated applied_at column.
-        "applied_at": (
-            run.completed_at.isoformat()
-            if run.previous_override is not None and run.completed_at
-            else None
+        "category": _categorize(
+            status=run.status, dismissed=dismissed_at is not None,
+            is_live=is_live, tied=tied, has_config=has_config,
         ),
-        "reverted_at": None,
-        "link": f"/?mode=extractions&searchSet={run.search_set_uuid}&run={run.uuid}",
+        "started_at": _iso(getattr(run, "started_at", None)),
+        "completed_at": _iso(getattr(run, "completed_at", None)),
+        "score": getattr(run, "optimized_score", None),
+        "baseline_score": getattr(run, "baseline_default_score", None),
+        # Null for user-launched runs — the UI reads that as "you asked for this".
+        "trigger": options.get("shadow_trigger"),
+        "trigger_detail": options.get("shadow_trigger_detail") or {},
+        "tied_with_baseline": tied,
+        "apply_preview": getattr(run, "apply_preview", None),
+        "suggestion_count": len(getattr(run, "suggestions", None) or []),
+        "applied_at": applied_at,
+        "reverted_at": reverted_at,
+        "is_live": is_live,
+        # Apply/dismiss are hidden without manage rights on the parent item.
+        "can_manage": can_manage,
+        "dismissed_at": _iso(dismissed_at),
+        # Failure detail — the whole reason failed runs are in here.
+        "error_message": getattr(run, "error_message", None),
+        "error_code": getattr(run, "error_code", None),
+        "error_context": getattr(run, "error_context", None),
+        "stopped_reason": getattr(run, "stopped_reason", None),
+        "phase": getattr(run, "phase", None),
+        "progress_message": getattr(run, "progress_message", None),
+        "judge_model": getattr(run, "judge_model", None),
+        "overfitting_warning": bool(getattr(run, "overfitting_warning", False)),
+        "link": link,
     }
 
 
-def _summarize_workflow(run: WorkflowOptimizationRun) -> dict:
+def kb_run_is_live(run: Any) -> bool:
+    """True when this run's winning config is the KB's current override."""
+    return getattr(run, "applied_at", None) is not None and getattr(run, "reverted_at", None) is None
+
+
+def extraction_run_is_live(run: Any, search_set: Any) -> bool:
+    """True when the search set's live override is this run's winning config.
+
+    SearchSet applies overwrite ``extraction_config_override`` outright without
+    stamping a source run, so identity has to be established by comparison.
+    """
+    if not getattr(run, "best_config", None) or search_set is None:
+        return False
+    return bool(getattr(search_set, "extraction_config_override", None) == run.best_config)
+
+
+def workflow_run_is_live(run: Any, workflow: Any) -> bool:
+    """True when the workflow's ``config_override`` came from this run."""
+    if workflow is None:
+        return False
+    override = getattr(workflow, "config_override", None) or {}
+    return bool(override.get("from_run_uuid") == run.uuid)
+
+
+def _summarize_kb(run: KBOptimizationRun, doc: Any, can_manage: bool) -> dict:
+    is_live = kb_run_is_live(run)
+    return _base_summary(
+        surface="kb", run=run, item_id=run.kb_uuid, item_name=_item_name("kb", doc),
+        can_manage=can_manage, is_live=is_live,
+        applied_at=_iso(run.applied_at), reverted_at=_iso(run.reverted_at),
+        link=f"/?mode=knowledge&kb={run.kb_uuid}",
+    )
+
+
+def _summarize_extraction(run: ExtractionOptimizationRun, doc: Any, can_manage: bool) -> dict:
+    is_live = extraction_run_is_live(run, doc)
+    # ``previous_override`` non-null means an apply happened at some point,
+    # even if a later run has since replaced the live config.
+    applied = run.previous_override is not None
+    return _base_summary(
+        surface="extraction", run=run, item_id=run.search_set_uuid,
+        item_name=_item_name("extraction", doc),
+        can_manage=can_manage, is_live=is_live,
+        applied_at=_iso(getattr(doc, "extraction_config_override_set_at", None)) if applied else None,
+        reverted_at=None,
+        link=f"/?extraction={run.search_set_uuid}",
+    )
+
+
+def _summarize_workflow(run: WorkflowOptimizationRun, doc: Any, can_manage: bool) -> dict:
+    is_live = workflow_run_is_live(run, doc)
+    return _base_summary(
+        surface="workflow", run=run, item_id=run.workflow_id,
+        item_name=_item_name("workflow", doc),
+        can_manage=can_manage, is_live=is_live,
+        applied_at=_iso(getattr(doc, "config_override_set_at", None)) if is_live else None,
+        reverted_at=None,
+        link=f"/?workflow={run.workflow_id}",
+    )
+
+
+def _window_filter(cutoff: datetime.datetime) -> dict:
+    """Runs the inbox cares about: auto-triggered candidates, plus failures.
+
+    Auto-triggered (shadow) runs are in because nobody asked for them, so the
+    inbox is the only place they can surface. Failed runs are in regardless of
+    trigger because a run that died is invisible the moment the user navigates
+    away from the panel that launched it. Completed *user-launched* runs stay
+    out — those are already restored in the item's own Validate & improve tab,
+    and folding them in would turn triage into a firehose.
+    """
     return {
-        "surface": "workflow",
-        "run_uuid": run.uuid,
-        "item_id": run.workflow_id,
-        "status": run.status,
-        "completed_at": run.completed_at.isoformat() if run.completed_at else None,
-        "score": run.optimized_score,
-        "baseline_score": run.baseline_default_score,
-        "trigger": (run.options or {}).get("shadow_trigger"),
-        "trigger_detail": (run.options or {}).get("shadow_trigger_detail") or {},
-        "tied_with_baseline": run.tied_with_baseline,
-        "apply_preview": getattr(run, "apply_preview", None),
-        "applied_at": None,
-        "reverted_at": None,
-        "link": f"/?mode=workspace&workflow={run.workflow_id}&run={run.uuid}",
+        "started_at": {"$gte": cutoff},
+        "$or": [
+            {"options.shadow_trigger": {"$exists": True}},
+            {"status": "failed"},
+        ],
+    }
+
+
+async def _collect(
+    user: User, *, days: int, include_dismissed: bool,
+) -> list[dict]:
+    cutoff = datetime.datetime.now(tz=datetime.timezone.utc) - datetime.timedelta(days=days)
+    query = _window_filter(cutoff)
+
+    kb_runs = await KBOptimizationRun.find(query).sort("-started_at").limit(PER_SURFACE_LIMIT).to_list()
+    ex_runs = await ExtractionOptimizationRun.find(query).sort("-started_at").limit(PER_SURFACE_LIMIT).to_list()
+    wf_runs = await WorkflowOptimizationRun.find(query).sort("-started_at").limit(PER_SURFACE_LIMIT).to_list()
+
+    cache = _AccessCache(user)
+    items: list[dict] = []
+
+    per_surface: tuple[tuple[SurfaceKind, list, str, Any], ...] = (
+        ("kb", kb_runs, "kb_uuid", _summarize_kb),
+        ("extraction", ex_runs, "search_set_uuid", _summarize_extraction),
+        ("workflow", wf_runs, "workflow_id", _summarize_workflow),
+    )
+    for surface, runs, item_attr, summarize in per_surface:
+        for run in runs:
+            if getattr(run, "dismissed_at", None) is not None and not include_dismissed:
+                continue
+            resolved = await cache.resolve(surface, getattr(run, item_attr, ""))
+            if resolved is None:
+                # Item deleted, or the caller has no access to it.
+                continue
+            doc, can_manage = resolved
+            items.append(summarize(run, doc, can_manage))
+
+    # Newest activity first; in-flight runs (no completed_at) sort by start.
+    items.sort(key=lambda d: d.get("completed_at") or d.get("started_at") or "", reverse=True)
+    return items
+
+
+def _counts(items: list[dict]) -> dict:
+    by_category: dict[str, int] = {}
+    for it in items:
+        by_category[it["category"]] = by_category.get(it["category"], 0) + 1
+    return {
+        "total": len(items),
+        "needs_review": by_category.get("needs_review", 0),
+        "failed": by_category.get("failed", 0),
+        "in_flight": by_category.get("in_flight", 0),
+        "applied": by_category.get("applied", 0),
+        "no_change": by_category.get("no_change", 0),
+        "dismissed": by_category.get("dismissed", 0),
+        # Retained for the pre-existing client contract.
+        "pending_review": by_category.get("needs_review", 0),
     }
 
 
 @router.get("/inbox")
-async def list_shadow_inbox(
+async def list_optimizer_inbox(
+    include_dismissed: bool = Query(
+        False, description="Include candidates the user already dismissed.",
+    ),
+    days: int = Query(
+        INBOX_LOOKBACK.days, ge=1, le=90,
+        description="Lookback window in days.",
+    ),
     user: User = Depends(get_current_user),
 ) -> dict:
-    """Return shadow optimizer runs across KB/extraction/workflow.
+    """Tuning suggestions and tuning failures for items the caller can see.
 
-    Filters:
-      - Triggered by a Phase 5 signal or Phase 6 alert (``options.shadow_trigger`` set)
-      - Within ``INBOX_LOOKBACK`` (stale candidates drop out)
-      - Owned by the current user (system-triggered runs use user_id="system",
-        and are visible to everyone via the team scope of their parent item;
-        for v1 we surface only the requester's own runs so the inbox stays
-        focused — wider sharing is a Phase 7 concern).
-
-    Sort: newest completed first; in-flight runs included so the user can
-    see "tuning in progress" candidates too.
+    Every row is access-filtered against the parent KB / search set / workflow,
+    so this endpoint leaks nothing the caller couldn't already open, and rows
+    carry ``can_manage`` so the UI only offers Apply where it would succeed.
     """
-    cutoff = datetime.datetime.now(tz=datetime.timezone.utc) - INBOX_LOOKBACK
-
-    # Each query is the same shape: shadow_trigger set AND started_at recent.
-    # ``user_id`` filter is inclusive — surface both runs the user kicked off
-    # and system-triggered runs they have access to. Access-control on the
-    # parent item is the source of truth; this endpoint just gathers UUIDs.
-    common_filter: dict = {
-        "options.shadow_trigger": {"$exists": True},
-        "started_at": {"$gte": cutoff},
-    }
-
-    kb_runs = await KBOptimizationRun.find(common_filter).sort("-started_at").limit(50).to_list()
-    ex_runs = await ExtractionOptimizationRun.find(common_filter).sort("-started_at").limit(50).to_list()
-    wf_runs = await WorkflowOptimizationRun.find(common_filter).sort("-started_at").limit(50).to_list()
-
-    items: list[dict] = []
-    items.extend(_summarize_kb(r) for r in kb_runs)
-    items.extend(_summarize_extraction(r) for r in ex_runs)
-    items.extend(_summarize_workflow(r) for r in wf_runs)
-
-    # Newest first across surfaces; missing completed_at sorts last.
-    items.sort(
-        key=lambda d: d.get("completed_at") or "",
-        reverse=True,
-    )
-
-    pending = [
-        it for it in items
-        if it["status"] == "completed"
-        and not it.get("applied_at")
-        and not it.get("tied_with_baseline")
-    ]
-
+    items = await _collect(user, days=days, include_dismissed=include_dismissed)
     return {
         "items": items,
-        "counts": {
-            "total": len(items),
-            "pending_review": len(pending),
-            "in_flight": sum(1 for it in items if it["status"] in ("queued", "running")),
-            "applied": sum(1 for it in items if it.get("applied_at")),
-        },
-        # Quietly bubble up the lookback so the UI can render "showing last 14 days".
-        "lookback_days": INBOX_LOOKBACK.days,
+        "counts": _counts(items),
+        "lookback_days": days,
     }
+
+
+@router.get("/inbox/count")
+async def optimizer_inbox_count(
+    user: User = Depends(get_current_user),
+) -> dict:
+    """Badge counts for the nav entry point — same filtering, no row payload."""
+    items = await _collect(user, days=INBOX_LOOKBACK.days, include_dismissed=False)
+    return _counts(items)
+
+
+async def _load_run_for_write(
+    surface: str, run_uuid: str, user: User,
+) -> tuple[Any, _AccessCache]:
+    """Fetch a run by (surface, uuid) and assert manage rights on its item."""
+    if surface == "kb":
+        run = await KBOptimizationRun.find_one(KBOptimizationRun.uuid == run_uuid)
+        item_id = getattr(run, "kb_uuid", "")
+    elif surface == "extraction":
+        run = await ExtractionOptimizationRun.find_one(
+            ExtractionOptimizationRun.uuid == run_uuid,
+        )
+        item_id = getattr(run, "search_set_uuid", "")
+    elif surface == "workflow":
+        run = await WorkflowOptimizationRun.find_one(
+            WorkflowOptimizationRun.uuid == run_uuid,
+        )
+        item_id = getattr(run, "workflow_id", "")
+    else:
+        raise HTTPException(status_code=400, detail=f"Unknown surface '{surface}'")
+
+    if not run:
+        raise HTTPException(status_code=404, detail="Optimization run not found")
+
+    cache = _AccessCache(user)
+    resolved = await cache.resolve(surface, item_id)  # type: ignore[arg-type]
+    if resolved is None or not resolved[1]:
+        # Same response for "not yours" and "view-only" — don't confirm existence
+        # of items the caller can't manage.
+        raise HTTPException(status_code=404, detail="Optimization run not found")
+    return run, cache
+
+
+@router.post("/inbox/{surface}/{run_uuid}/dismiss")
+async def dismiss_optimizer_candidate(
+    surface: str, run_uuid: str, user: User = Depends(get_current_user),
+) -> dict:
+    """Drop a candidate out of the inbox without deleting the run.
+
+    The run stays in the item's history and in the admin activity view, so a
+    dismissal is a triage decision, not a cover-up.
+    """
+    run, _ = await _load_run_for_write(surface, run_uuid, user)
+    run.dismissed_at = datetime.datetime.now(tz=datetime.timezone.utc)
+    run.dismissed_by = user.user_id
+    await run.save()
+    logger.info("Optimizer candidate %s/%s dismissed by %s", surface, run_uuid, user.user_id)
+    return {"ok": True, "dismissed_at": _iso(run.dismissed_at)}
+
+
+@router.post("/inbox/{surface}/{run_uuid}/restore")
+async def restore_optimizer_candidate(
+    surface: str, run_uuid: str, user: User = Depends(get_current_user),
+) -> dict:
+    """Undo a dismissal (the row returns to its natural category)."""
+    run, _ = await _load_run_for_write(surface, run_uuid, user)
+    run.dismissed_at = None
+    run.dismissed_by = None
+    await run.save()
+    return {"ok": True}

--- a/backend/tests/test_admin_optimizer_activity.py
+++ b/backend/tests/test_admin_optimizer_activity.py
@@ -1,0 +1,290 @@
+"""Tests for GET /api/admin/optimizer/activity — the read-only operator view
+of every optimizer run, which is what makes silent tuning failures visible.
+"""
+
+import datetime
+import secrets
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.config import Settings
+from app.utils.security import create_access_token
+
+
+_TEST_SETTINGS = Settings(jwt_secret_key="test-secret-key", environment="development")
+_NOW = datetime.datetime(2026, 7, 20, 12, 0, tzinfo=datetime.timezone.utc)
+_WF_ID = "507f1f77bcf86cd799439011"
+
+
+def _make_user(user_id="admin1", *, is_admin=True, is_staff=False):
+    user = MagicMock()
+    user.id = "fake-id"
+    user.user_id = user_id
+    user.email = f"{user_id}@example.com"
+    user.name = "Admin User"
+    user.is_admin = is_admin
+    user.is_staff = is_staff
+    user.is_examiner = False
+    user.current_team = None
+    user.is_demo_user = False
+    user.token_version = 0
+    user.demo_status = None
+    user.api_token_hash = None
+    user.api_token_created_at = None
+    user.api_token_expires_at = None
+    return user
+
+
+def _auth(user_id="admin1"):
+    token = create_access_token(user_id, _TEST_SETTINGS)
+    csrf = secrets.token_urlsafe(32)
+    return {"access_token": token, "csrf_token": csrf}, {"X-CSRF-Token": csrf}
+
+
+@pytest.fixture
+async def client():
+    with patch("app.main.init_db", new_callable=AsyncMock):
+        from app.main import app
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        ) as ac:
+            yield ac
+
+
+def _run(**overrides):
+    base = dict(
+        uuid="run-1",
+        status="completed",
+        user_id="user1",
+        started_at=_NOW,
+        completed_at=_NOW,
+        optimized_score=0.82,
+        baseline_default_score=0.70,
+        options={},
+        tied_with_baseline=False,
+        best_config={"model": "m"},
+        dismissed_at=None,
+        applied_at=None,
+        reverted_at=None,
+        previous_override=None,
+        error_message=None,
+        error_code=None,
+        stopped_reason="all_trials_complete",
+        phase="done",
+        progress_message="",
+        tokens_used=1500,
+        token_budget=200000,
+        actual_cost_usd=0.4,
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def _find_chain(items):
+    chain = MagicMock()
+    chain.sort.return_value = chain
+    chain.limit.return_value = chain
+    chain.to_list = AsyncMock(return_value=items)
+    return chain
+
+
+class _AdminHarness:
+    def __init__(self, *, kb=(), extraction=(), workflow=(), kbs=None, sets=None,
+                 workflows=None, is_admin=True, is_staff=False):
+        self.kb, self.extraction, self.workflow = list(kb), list(extraction), list(workflow)
+        self.kbs = [SimpleNamespace(uuid="kb-1", title="Compliance KB")] if kbs is None else kbs
+        self.sets = [] if sets is None else sets
+        self.workflows = (
+            [SimpleNamespace(id=_WF_ID, name="Proposal intake", config_override=None,
+                             config_override_set_at=None)]
+            if workflows is None else workflows
+        )
+        self.is_admin, self.is_staff = is_admin, is_staff
+        self._stack = []
+
+    def __enter__(self):
+        user = _make_user(is_admin=self.is_admin, is_staff=self.is_staff)
+        MockKB, MockEx, MockWf = MagicMock(), MagicMock(), MagicMock()
+        MockKB.find = MagicMock(return_value=_find_chain(self.kb))
+        MockEx.find = MagicMock(return_value=_find_chain(self.extraction))
+        MockWf.find = MagicMock(return_value=_find_chain(self.workflow))
+        self.MockKB, self.MockEx, self.MockWf = MockKB, MockEx, MockWf
+
+        MockKBModel, MockSetModel, MockWfModel = MagicMock(), MagicMock(), MagicMock()
+        MockKBModel.find = MagicMock(return_value=_find_chain(self.kbs))
+        MockSetModel.find = MagicMock(return_value=_find_chain(self.sets))
+        MockWfModel.find = MagicMock(return_value=_find_chain(self.workflows))
+
+        patches = [
+            patch("app.dependencies.decode_token", return_value={"sub": "admin1", "type": "access"}),
+            patch("app.dependencies.User"),
+            patch("app.models.kb_optimization_run.KBOptimizationRun", MockKB),
+            patch("app.models.extraction_optimization_run.ExtractionOptimizationRun", MockEx),
+            patch("app.models.workflow_optimization_run.WorkflowOptimizationRun", MockWf),
+            patch("app.models.knowledge.KnowledgeBase", MockKBModel),
+            patch("app.models.search_set.SearchSet", MockSetModel),
+            patch("app.models.workflow.Workflow", MockWfModel),
+            patch("app.routers.admin.User"),
+        ]
+        entered = [p.__enter__() for p in patches]
+        self._stack = patches
+        entered[1].find_one = AsyncMock(return_value=user)
+        # Owner-email lookup inside the endpoint.
+        entered[-1].find = MagicMock(
+            return_value=_find_chain([SimpleNamespace(user_id="user1", email="user1@example.com")]),
+        )
+        return self
+
+    def __exit__(self, *exc):
+        for p in reversed(self._stack):
+            p.__exit__(*exc)
+        return False
+
+
+class TestOptimizerActivity:
+    @pytest.mark.asyncio
+    async def test_non_admin_is_forbidden(self, client):
+        cookies, headers = _auth()
+        with _AdminHarness(is_admin=False):
+            resp = await client.get(
+                "/api/admin/optimizer/activity", cookies=cookies, headers=headers,
+            )
+        assert resp.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_staff_can_read(self, client):
+        cookies, headers = _auth()
+        with _AdminHarness(is_admin=False, is_staff=True):
+            resp = await client.get(
+                "/api/admin/optimizer/activity", cookies=cookies, headers=headers,
+            )
+        assert resp.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_failures_are_rolled_up_by_reason(self, client):
+        cookies, headers = _auth()
+        runs = [
+            _run(uuid="a", kb_uuid="kb-1", status="failed",
+                 error_code="judge_unavailable", error_message="judge down"),
+            _run(uuid="b", kb_uuid="kb-1", status="failed",
+                 error_code="judge_unavailable", error_message="judge down again"),
+            _run(uuid="c", kb_uuid="kb-1", status="failed",
+                 error_code=None, error_message="Something else entirely"),
+        ]
+        with _AdminHarness(kb=runs):
+            resp = await client.get(
+                "/api/admin/optimizer/activity", cookies=cookies, headers=headers,
+            )
+
+        summary = resp.json()["summary"]
+        assert summary["failed"] == 3
+        assert summary["failure_reasons"][0] == {"reason": "judge_unavailable", "count": 2}
+        assert {"reason": "Something else entirely", "count": 1} in summary["failure_reasons"]
+
+    @pytest.mark.asyncio
+    async def test_pending_review_counts_unactioned_candidates(self, client):
+        cookies, headers = _auth()
+        runs = [
+            # Reviewable: completed, has a config, nobody applied or dismissed it.
+            _run(uuid="a", kb_uuid="kb-1"),
+            # Tied with baseline — nothing to promote.
+            _run(uuid="b", kb_uuid="kb-1", tied_with_baseline=True),
+            # Already applied and live.
+            _run(uuid="c", kb_uuid="kb-1", applied_at=_NOW),
+            # Dismissed by its owner.
+            _run(uuid="d", kb_uuid="kb-1", dismissed_at=_NOW),
+        ]
+        with _AdminHarness(kb=runs):
+            resp = await client.get(
+                "/api/admin/optimizer/activity", cookies=cookies, headers=headers,
+            )
+
+        summary = resp.json()["summary"]
+        assert summary["total"] == 4
+        assert summary["pending_review"] == 1
+        assert summary["applied"] == 1
+        assert summary["dismissed"] == 1
+
+    @pytest.mark.asyncio
+    async def test_rows_carry_owner_and_item_name(self, client):
+        cookies, headers = _auth()
+        run = _run(uuid="wf-a", workflow_id=_WF_ID,
+                   options={"shadow_trigger": "quality_alert"})
+        with _AdminHarness(workflow=[run]):
+            resp = await client.get(
+                "/api/admin/optimizer/activity", cookies=cookies, headers=headers,
+            )
+
+        row = resp.json()["runs"][0]
+        assert row["item_name"] == "Proposal intake"
+        assert row["item_deleted"] is False
+        assert row["user_email"] == "user1@example.com"
+        assert row["trigger"] == "quality_alert"
+        assert resp.json()["summary"]["auto_triggered"] == 1
+        assert resp.json()["summary"]["user_launched"] == 0
+
+    @pytest.mark.asyncio
+    async def test_deleted_item_is_flagged_not_dropped(self, client):
+        cookies, headers = _auth()
+        run = _run(uuid="kb-a", kb_uuid="kb-gone")
+        with _AdminHarness(kb=[run], kbs=[]):
+            resp = await client.get(
+                "/api/admin/optimizer/activity", cookies=cookies, headers=headers,
+            )
+
+        row = resp.json()["runs"][0]
+        assert row["item_deleted"] is True
+        assert row["item_name"] is None
+
+    @pytest.mark.asyncio
+    async def test_surface_filter_skips_other_collections(self, client):
+        cookies, headers = _auth()
+        with _AdminHarness() as h:
+            resp = await client.get(
+                "/api/admin/optimizer/activity?surface=kb", cookies=cookies, headers=headers,
+            )
+        assert resp.status_code == 200
+        h.MockKB.find.assert_called_once()
+        h.MockEx.find.assert_not_called()
+        h.MockWf.find.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_bogus_surface_is_rejected(self, client):
+        cookies, headers = _auth()
+        with _AdminHarness():
+            resp = await client.get(
+                "/api/admin/optimizer/activity?surface=nope", cookies=cookies, headers=headers,
+            )
+        assert resp.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_trigger_filter_shapes_the_query(self, client):
+        cookies, headers = _auth()
+        with _AdminHarness() as h:
+            await client.get(
+                "/api/admin/optimizer/activity?trigger=auto", cookies=cookies, headers=headers,
+            )
+            auto_query = h.MockKB.find.call_args.args[0]
+        assert auto_query["options.shadow_trigger"] == {"$exists": True}
+
+        with _AdminHarness() as h:
+            await client.get(
+                "/api/admin/optimizer/activity?trigger=user", cookies=cookies, headers=headers,
+            )
+            user_query = h.MockKB.find.call_args.args[0]
+        assert user_query["options.shadow_trigger"] == {"$exists": False}
+
+    @pytest.mark.asyncio
+    async def test_status_filter_is_passed_through(self, client):
+        cookies, headers = _auth()
+        with _AdminHarness() as h:
+            await client.get(
+                "/api/admin/optimizer/activity?status=failed", cookies=cookies, headers=headers,
+            )
+            query = h.MockKB.find.call_args.args[0]
+        assert query["status"] == "failed"

--- a/backend/tests/test_optimizer_inbox.py
+++ b/backend/tests/test_optimizer_inbox.py
@@ -1,0 +1,414 @@
+"""Tests for the optimizer inbox — the triage surface for auto-generated
+tuning suggestions and failed tuning runs.
+
+Covers GET /inbox (access scoping, categorization, item names, failure
+surfacing, dismissed filtering), GET /inbox/count, and the dismiss/restore
+endpoints including the manage-rights gate.
+"""
+
+import datetime
+import secrets
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.config import Settings
+from app.utils.security import create_access_token
+
+
+_TEST_SETTINGS = Settings(jwt_secret_key="test-secret-key", environment="development")
+
+_NOW = datetime.datetime(2026, 7, 20, 12, 0, tzinfo=datetime.timezone.utc)
+
+
+def _make_user(user_id="user1"):
+    user = MagicMock()
+    user.id = "fake-id"
+    user.user_id = user_id
+    user.email = f"{user_id}@example.com"
+    user.name = "Test User"
+    user.is_admin = False
+    user.is_staff = False
+    user.is_examiner = False
+    user.current_team = None
+    user.is_demo_user = False
+    user.token_version = 0
+    user.demo_status = None
+    user.api_token_hash = None
+    user.api_token_created_at = None
+    user.api_token_expires_at = None
+    return user
+
+
+def _auth(user_id="user1"):
+    token = create_access_token(user_id, _TEST_SETTINGS)
+    csrf = secrets.token_urlsafe(32)
+    return {"access_token": token, "csrf_token": csrf}, {"X-CSRF-Token": csrf}
+
+
+@pytest.fixture
+async def client():
+    with patch("app.main.init_db", new_callable=AsyncMock):
+        from app.main import app
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        ) as ac:
+            yield ac
+
+
+def _run(**overrides):
+    """A run document stand-in.
+
+    ``SimpleNamespace`` rather than ``MagicMock`` on purpose: the router makes
+    boolean decisions on these fields, and every MagicMock attribute is truthy.
+    """
+    base = dict(
+        uuid="run-1",
+        status="completed",
+        started_at=_NOW,
+        completed_at=_NOW,
+        optimized_score=0.82,
+        baseline_default_score=0.70,
+        options={"shadow_trigger": "quality_alert", "shadow_trigger_detail": {"severity": "high"}},
+        tied_with_baseline=False,
+        best_config={"step_overrides": {"s1": {"model": "m"}}},
+        apply_preview={"total": 4, "will_change": 2, "regressions": 0, "items": []},
+        suggestions=[],
+        dismissed_at=None,
+        dismissed_by=None,
+        applied_at=None,
+        reverted_at=None,
+        previous_override=None,
+        error_message=None,
+        error_code=None,
+        error_context=None,
+        stopped_reason=None,
+        phase="done",
+        progress_message="",
+        judge_model="judge-1",
+        overfitting_warning=False,
+        tokens_used=1000,
+        token_budget=200000,
+    )
+    base.update(overrides)
+    ns = SimpleNamespace(**base)
+    ns.save = AsyncMock()
+    return ns
+
+
+def _find_chain(items):
+    chain = MagicMock()
+    chain.sort.return_value = chain
+    chain.limit.return_value = chain
+    chain.to_list = AsyncMock(return_value=items)
+    return chain
+
+
+class _InboxHarness:
+    """Context manager stacking every patch the inbox endpoints need."""
+
+    def __init__(self, *, kb=(), extraction=(), workflow=(), authorized=True, can_manage=True,
+                 kb_doc=None, ss_doc=None, wf_doc=None):
+        self.kb, self.extraction, self.workflow = list(kb), list(extraction), list(workflow)
+        self.authorized = authorized
+        self.can_manage = can_manage
+        self.kb_doc = kb_doc or SimpleNamespace(title="Compliance KB", uuid="kb-1")
+        self.ss_doc = ss_doc or SimpleNamespace(
+            title="Budget fields", uuid="ss-1",
+            extraction_config_override=None, extraction_config_override_set_at=None,
+        )
+        self.wf_doc = wf_doc or SimpleNamespace(
+            name="Proposal intake", config_override=None, config_override_set_at=None,
+        )
+        self._stack = []
+
+    def _authorized(self, doc):
+        async def _impl(*_args, manage=False, **_kwargs):
+            if not self.authorized:
+                return None
+            if manage and not self.can_manage:
+                return None
+            return doc
+        return _impl
+
+    def __enter__(self):
+        user = _make_user("user1")
+        patches = [
+            patch("app.dependencies.decode_token", return_value={"sub": "user1", "type": "access"}),
+            patch("app.dependencies.User"),
+            patch("app.routers.optimizer_inbox.KBOptimizationRun"),
+            patch("app.routers.optimizer_inbox.ExtractionOptimizationRun"),
+            patch("app.routers.optimizer_inbox.WorkflowOptimizationRun"),
+            patch("app.routers.optimizer_inbox.access_control.get_team_access_context",
+                  new_callable=AsyncMock, return_value=MagicMock()),
+            patch("app.routers.optimizer_inbox.organization_service.get_user_org_ancestry",
+                  new_callable=AsyncMock, return_value=[]),
+            patch("app.routers.optimizer_inbox.access_control.get_authorized_knowledge_base",
+                  new=self._authorized(self.kb_doc)),
+            patch("app.routers.optimizer_inbox.access_control.get_authorized_search_set",
+                  new=self._authorized(self.ss_doc)),
+            patch("app.routers.optimizer_inbox.access_control.get_authorized_workflow",
+                  new=self._authorized(self.wf_doc)),
+        ]
+        entered = [p.__enter__() for p in patches]
+        self._stack = patches
+        entered[1].find_one = AsyncMock(return_value=user)
+        self.MockKB, self.MockEx, self.MockWf = entered[2], entered[3], entered[4]
+        self.MockKB.find = MagicMock(return_value=_find_chain(self.kb))
+        self.MockEx.find = MagicMock(return_value=_find_chain(self.extraction))
+        self.MockWf.find = MagicMock(return_value=_find_chain(self.workflow))
+        self.MockKB.find_one = AsyncMock(return_value=self.kb[0] if self.kb else None)
+        self.MockEx.find_one = AsyncMock(return_value=self.extraction[0] if self.extraction else None)
+        self.MockWf.find_one = AsyncMock(return_value=self.workflow[0] if self.workflow else None)
+        return self
+
+    def __exit__(self, *exc):
+        for p in reversed(self._stack):
+            p.__exit__(*exc)
+        return False
+
+
+# ---------------------------------------------------------------------------
+# GET /inbox
+# ---------------------------------------------------------------------------
+
+
+class TestListInbox:
+    @pytest.mark.asyncio
+    async def test_completed_shadow_run_is_a_reviewable_candidate(self, client):
+        cookies, headers = _auth()
+        run = _run(uuid="wf-run", workflow_id="507f1f77bcf86cd799439011")
+        with _InboxHarness(workflow=[run]):
+            resp = await client.get("/api/optimizer/inbox", cookies=cookies, headers=headers)
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert len(body["items"]) == 1
+        item = body["items"][0]
+        assert item["surface"] == "workflow"
+        assert item["category"] == "needs_review"
+        # The name is the point — an item_id alone is unreadable in a UI.
+        assert item["item_name"] == "Proposal intake"
+        assert item["trigger"] == "quality_alert"
+        assert item["can_manage"] is True
+        assert item["link"] == "/?workflow=507f1f77bcf86cd799439011"
+        assert body["counts"]["needs_review"] == 1
+        # Legacy alias preserved for the original client contract.
+        assert body["counts"]["pending_review"] == 1
+
+    @pytest.mark.asyncio
+    async def test_runs_for_inaccessible_items_are_hidden(self, client):
+        cookies, headers = _auth()
+        run = _run(uuid="wf-run", workflow_id="507f1f77bcf86cd799439011")
+        with _InboxHarness(workflow=[run], authorized=False):
+            resp = await client.get("/api/optimizer/inbox", cookies=cookies, headers=headers)
+
+        assert resp.status_code == 200
+        assert resp.json()["items"] == []
+
+    @pytest.mark.asyncio
+    async def test_view_only_access_shows_row_without_manage_rights(self, client):
+        cookies, headers = _auth()
+        run = _run(uuid="wf-run", workflow_id="507f1f77bcf86cd799439011")
+        with _InboxHarness(workflow=[run], can_manage=False):
+            resp = await client.get("/api/optimizer/inbox", cookies=cookies, headers=headers)
+
+        item = resp.json()["items"][0]
+        assert item["can_manage"] is False
+
+    @pytest.mark.asyncio
+    async def test_failed_run_surfaces_its_error(self, client):
+        cookies, headers = _auth()
+        run = _run(
+            uuid="kb-run", kb_uuid="kb-1", status="failed",
+            error_message="Judge model unavailable", error_code="judge_unavailable",
+            optimized_score=None, best_config=None, options={},
+        )
+        with _InboxHarness(kb=[run]):
+            resp = await client.get("/api/optimizer/inbox", cookies=cookies, headers=headers)
+
+        item = resp.json()["items"][0]
+        assert item["category"] == "failed"
+        assert item["error_message"] == "Judge model unavailable"
+        assert item["error_code"] == "judge_unavailable"
+        assert resp.json()["counts"]["failed"] == 1
+
+    @pytest.mark.asyncio
+    async def test_tied_run_is_no_change_not_a_candidate(self, client):
+        cookies, headers = _auth()
+        run = _run(uuid="kb-run", kb_uuid="kb-1", tied_with_baseline=True)
+        with _InboxHarness(kb=[run]):
+            resp = await client.get("/api/optimizer/inbox", cookies=cookies, headers=headers)
+
+        body = resp.json()
+        assert body["items"][0]["category"] == "no_change"
+        assert body["counts"]["needs_review"] == 0
+
+    @pytest.mark.asyncio
+    async def test_applied_kb_run_is_categorized_live(self, client):
+        cookies, headers = _auth()
+        run = _run(uuid="kb-run", kb_uuid="kb-1", applied_at=_NOW)
+        with _InboxHarness(kb=[run]):
+            resp = await client.get("/api/optimizer/inbox", cookies=cookies, headers=headers)
+
+        item = resp.json()["items"][0]
+        assert item["category"] == "applied"
+        assert item["is_live"] is True
+
+    @pytest.mark.asyncio
+    async def test_reverted_kb_run_is_reviewable_again(self, client):
+        cookies, headers = _auth()
+        run = _run(uuid="kb-run", kb_uuid="kb-1", applied_at=_NOW, reverted_at=_NOW)
+        with _InboxHarness(kb=[run]):
+            resp = await client.get("/api/optimizer/inbox", cookies=cookies, headers=headers)
+
+        assert resp.json()["items"][0]["category"] == "needs_review"
+
+    @pytest.mark.asyncio
+    async def test_extraction_run_is_live_only_when_override_matches(self, client):
+        cookies, headers = _auth()
+        run = _run(uuid="ex-run", search_set_uuid="ss-1", best_config={"model": "m2"})
+        live_set = SimpleNamespace(
+            title="Budget fields", uuid="ss-1",
+            extraction_config_override={"model": "m2"},
+            extraction_config_override_set_at=_NOW,
+        )
+        with _InboxHarness(extraction=[run], ss_doc=live_set):
+            resp = await client.get("/api/optimizer/inbox", cookies=cookies, headers=headers)
+        assert resp.json()["items"][0]["category"] == "applied"
+
+        stale_set = SimpleNamespace(
+            title="Budget fields", uuid="ss-1",
+            extraction_config_override={"model": "something-else"},
+            extraction_config_override_set_at=_NOW,
+        )
+        with _InboxHarness(extraction=[run], ss_doc=stale_set):
+            resp = await client.get("/api/optimizer/inbox", cookies=cookies, headers=headers)
+        assert resp.json()["items"][0]["category"] == "needs_review"
+
+    @pytest.mark.asyncio
+    async def test_dismissed_runs_are_hidden_unless_requested(self, client):
+        cookies, headers = _auth()
+        run = _run(uuid="kb-run", kb_uuid="kb-1", dismissed_at=_NOW, dismissed_by="user1")
+
+        with _InboxHarness(kb=[run]):
+            resp = await client.get("/api/optimizer/inbox", cookies=cookies, headers=headers)
+        assert resp.json()["items"] == []
+
+        with _InboxHarness(kb=[run]):
+            resp = await client.get(
+                "/api/optimizer/inbox?include_dismissed=true", cookies=cookies, headers=headers,
+            )
+        items = resp.json()["items"]
+        assert len(items) == 1 and items[0]["category"] == "dismissed"
+
+    @pytest.mark.asyncio
+    async def test_query_window_covers_shadow_runs_and_failures(self, client):
+        cookies, headers = _auth()
+        with _InboxHarness() as h:
+            await client.get("/api/optimizer/inbox?days=7", cookies=cookies, headers=headers)
+            query = h.MockKB.find.call_args.args[0]
+
+        assert "$or" in query
+        assert {"options.shadow_trigger": {"$exists": True}} in query["$or"]
+        assert {"status": "failed"} in query["$or"]
+        assert "started_at" in query
+
+    @pytest.mark.asyncio
+    async def test_rejects_out_of_range_window(self, client):
+        cookies, headers = _auth()
+        with _InboxHarness():
+            resp = await client.get("/api/optimizer/inbox?days=500", cookies=cookies, headers=headers)
+        assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_requires_auth(self, client):
+        resp = await client.get("/api/optimizer/inbox")
+        assert resp.status_code in (401, 403)
+
+
+class TestInboxCount:
+    @pytest.mark.asyncio
+    async def test_count_matches_categories(self, client):
+        cookies, headers = _auth()
+        candidate = _run(uuid="kb-a", kb_uuid="kb-1")
+        failure = _run(
+            uuid="kb-b", kb_uuid="kb-1", status="failed",
+            error_message="boom", best_config=None, options={},
+        )
+        with _InboxHarness(kb=[candidate, failure]):
+            resp = await client.get("/api/optimizer/inbox/count", cookies=cookies, headers=headers)
+
+        body = resp.json()
+        assert body["needs_review"] == 1
+        assert body["failed"] == 1
+        assert body["total"] == 2
+
+
+# ---------------------------------------------------------------------------
+# Dismiss / restore
+# ---------------------------------------------------------------------------
+
+
+class TestDismiss:
+    @pytest.mark.asyncio
+    async def test_dismiss_stamps_who_and_when(self, client):
+        cookies, headers = _auth()
+        run = _run(uuid="kb-run", kb_uuid="kb-1")
+        with _InboxHarness(kb=[run]):
+            resp = await client.post(
+                "/api/optimizer/inbox/kb/kb-run/dismiss", cookies=cookies, headers=headers,
+            )
+
+        assert resp.status_code == 200
+        assert run.dismissed_at is not None
+        assert run.dismissed_by == "user1"
+        run.save.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_restore_clears_dismissal(self, client):
+        cookies, headers = _auth()
+        run = _run(uuid="wf-run", workflow_id="507f1f77bcf86cd799439011",
+                   dismissed_at=_NOW, dismissed_by="user1")
+        with _InboxHarness(workflow=[run]):
+            resp = await client.post(
+                "/api/optimizer/inbox/workflow/wf-run/restore", cookies=cookies, headers=headers,
+            )
+
+        assert resp.status_code == 200
+        assert run.dismissed_at is None
+        assert run.dismissed_by is None
+
+    @pytest.mark.asyncio
+    async def test_view_only_user_cannot_dismiss(self, client):
+        cookies, headers = _auth()
+        run = _run(uuid="kb-run", kb_uuid="kb-1")
+        with _InboxHarness(kb=[run], can_manage=False):
+            resp = await client.post(
+                "/api/optimizer/inbox/kb/kb-run/dismiss", cookies=cookies, headers=headers,
+            )
+
+        assert resp.status_code == 404
+        assert run.dismissed_at is None
+
+    @pytest.mark.asyncio
+    async def test_unknown_surface_is_rejected(self, client):
+        cookies, headers = _auth()
+        with _InboxHarness():
+            resp = await client.post(
+                "/api/optimizer/inbox/bogus/run-1/dismiss", cookies=cookies, headers=headers,
+            )
+        assert resp.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_missing_run_is_404(self, client):
+        cookies, headers = _auth()
+        with _InboxHarness():
+            resp = await client.post(
+                "/api/optimizer/inbox/kb/nope/dismiss", cookies=cookies, headers=headers,
+            )
+        assert resp.status_code == 404

--- a/frontend/src/api/admin.ts
+++ b/frontend/src/api/admin.ts
@@ -958,3 +958,76 @@ export function getAdminKnowledgeBases(params?: { search?: string; limit?: numbe
   const q = qs.toString()
   return apiFetch<AdminKBListResponse>(`/api/admin/knowledge-bases${q ? `?${q}` : ''}`)
 }
+
+// ──────────────────────────────────────────
+// Optimizer activity (read-only operator view over all three optimizers)
+// ──────────────────────────────────────────
+
+export interface OptimizerActivityRun {
+  surface: 'kb' | 'extraction' | 'workflow'
+  run_uuid: string
+  item_id: string
+  /** Null when the tuned item has since been deleted. */
+  item_name: string | null
+  item_deleted: boolean
+  user_id: string | null
+  user_email: string | null
+  status: string
+  /** Null for user-launched runs; a signal name for auto-triggered ones. */
+  trigger: string | null
+  trigger_detail: Record<string, unknown>
+  started_at: string | null
+  completed_at: string | null
+  baseline_score: number | null
+  optimized_score: number | null
+  tied_with_baseline: boolean
+  tokens_used: number
+  token_budget: number
+  actual_cost_usd: number | null
+  stopped_reason: string | null
+  error_message: string | null
+  error_code: string | null
+  phase: string | null
+  progress_message: string | null
+  is_live: boolean
+  dismissed_at: string | null
+}
+
+export interface OptimizerActivitySummary {
+  window_days: number
+  total: number
+  by_status: Record<string, number>
+  by_surface: Record<string, number>
+  auto_triggered: number
+  user_launched: number
+  failed: number
+  applied: number
+  dismissed: number
+  pending_review: number
+  tokens_used: number
+  failure_reasons: { reason: string; count: number }[]
+  /** True when a per-surface fetch hit the limit, so counts are a floor. */
+  truncated: boolean
+}
+
+export interface OptimizerActivityResponse {
+  runs: OptimizerActivityRun[]
+  summary: OptimizerActivitySummary
+}
+
+export function getOptimizerActivity(params?: {
+  days?: number
+  surface?: string
+  status?: string
+  trigger?: 'auto' | 'user'
+  limit?: number
+}) {
+  const qs = new URLSearchParams()
+  if (params?.days) qs.set('days', String(params.days))
+  if (params?.surface) qs.set('surface', params.surface)
+  if (params?.status) qs.set('status', params.status)
+  if (params?.trigger) qs.set('trigger', params.trigger)
+  if (params?.limit) qs.set('limit', String(params.limit))
+  const q = qs.toString()
+  return apiFetch<OptimizerActivityResponse>(`/api/admin/optimizer/activity${q ? `?${q}` : ''}`)
+}

--- a/frontend/src/api/optimizerInbox.ts
+++ b/frontend/src/api/optimizerInbox.ts
@@ -1,16 +1,33 @@
 import { apiFetch } from './client'
 import type { ApplyPreview } from './knowledge'
 
+export type OptimizerSurface = 'kb' | 'extraction' | 'workflow'
+
+/** Row categories the backend computes so the UI groups without re-deriving. */
+export type OptimizerInboxCategory =
+  | 'needs_review'
+  | 'no_change'
+  | 'applied'
+  | 'failed'
+  | 'in_flight'
+  | 'cancelled'
+  | 'dismissed'
+
 /** Per-surface inbox entry returned by ``/api/optimizer/inbox``.
  *  Same shape across KB/extraction/workflow so the inbox UI is one table. */
 export interface OptimizerInboxItem {
-  surface: 'kb' | 'extraction' | 'workflow'
+  surface: OptimizerSurface
   run_uuid: string
   item_id: string
+  /** Display name of the tuned KB / extraction set / workflow. */
+  item_name: string
   status: 'queued' | 'running' | 'completed' | 'failed' | 'cancelled'
+  category: OptimizerInboxCategory
+  started_at: string | null
   completed_at: string | null
   score: number | null
   baseline_score: number | null
+  /** Null for runs the user launched themselves. */
   trigger:
     | 'cross_field_failure'
     | 'chat_feedback_threshold'
@@ -19,23 +36,68 @@ export interface OptimizerInboxItem {
   trigger_detail: Record<string, unknown>
   tied_with_baseline: boolean
   apply_preview: ApplyPreview | null
+  suggestion_count: number
   applied_at: string | null
   reverted_at: string | null
+  /** True when this run's winning config is the item's live config. */
+  is_live: boolean
+  /** False for view-only access — Apply and Dismiss are hidden. */
+  can_manage: boolean
+  dismissed_at: string | null
+  error_message: string | null
+  error_code: string | null
+  error_context: Record<string, unknown> | null
+  stopped_reason: string | null
+  phase: string | null
+  progress_message: string | null
+  judge_model: string | null
+  overfitting_warning: boolean
+  /** Deep link to the tuned item in the workspace. */
   link: string
+}
+
+export interface OptimizerInboxCounts {
+  total: number
+  needs_review: number
+  failed: number
+  in_flight: number
+  applied: number
+  no_change: number
+  dismissed: number
+  /** Alias of needs_review, kept for the original client contract. */
+  pending_review: number
 }
 
 export interface OptimizerInboxResponse {
   items: OptimizerInboxItem[]
-  counts: {
-    total: number
-    pending_review: number
-    in_flight: number
-    applied: number
-  }
+  counts: OptimizerInboxCounts
   lookback_days: number
 }
 
-/** Phase 6: unified inbox of shadow optimizer candidates across all surfaces. */
-export function getOptimizerInbox() {
-  return apiFetch<OptimizerInboxResponse>('/api/optimizer/inbox')
+/** Unified inbox of tuning suggestions (and tuning failures) across surfaces. */
+export function getOptimizerInbox(opts?: { includeDismissed?: boolean; days?: number }) {
+  const params = new URLSearchParams()
+  if (opts?.includeDismissed) params.set('include_dismissed', 'true')
+  if (opts?.days) params.set('days', String(opts.days))
+  const qs = params.toString()
+  return apiFetch<OptimizerInboxResponse>(`/api/optimizer/inbox${qs ? `?${qs}` : ''}`)
+}
+
+/** Badge counts only — cheap enough to fetch from always-mounted chrome. */
+export function getOptimizerInboxCount() {
+  return apiFetch<OptimizerInboxCounts>('/api/optimizer/inbox/count')
+}
+
+export function dismissOptimizerCandidate(surface: OptimizerSurface, runUuid: string) {
+  return apiFetch<{ ok: boolean; dismissed_at: string | null }>(
+    `/api/optimizer/inbox/${surface}/${runUuid}/dismiss`,
+    { method: 'POST' },
+  )
+}
+
+export function restoreOptimizerCandidate(surface: OptimizerSurface, runUuid: string) {
+  return apiFetch<{ ok: boolean }>(
+    `/api/optimizer/inbox/${surface}/${runUuid}/restore`,
+    { method: 'POST' },
+  )
 }

--- a/frontend/src/components/admin/OptimizerTab.tsx
+++ b/frontend/src/components/admin/OptimizerTab.tsx
@@ -1,0 +1,273 @@
+import { useCallback, useEffect, useState } from 'react'
+import {
+  AlertTriangle, CheckCircle2, Eye, Play, RefreshCw, Sparkles, XCircle,
+} from 'lucide-react'
+import {
+  getOptimizerActivity,
+  type OptimizerActivityResponse,
+  type OptimizerActivityRun,
+} from '../../api/admin'
+import { relativeTime } from '../../utils/time'
+import { KpiCard, StatusBadge } from './shared/primitives'
+
+/**
+ * Optimizer activity — read-only operator view of every tuning run.
+ *
+ * The per-item panels only show one item's history and a user's inbox only
+ * shows their own items, so neither answers "is the optimizer healthy?".
+ * This tab does: run volume, what's waiting on a human, and which failures
+ * are repeating. There are no actions here on purpose — applying a config
+ * belongs to whoever owns the item, from their own inbox.
+ */
+
+const SURFACE_LABEL: Record<string, string> = {
+  kb: 'Knowledge base',
+  extraction: 'Extraction set',
+  workflow: 'Workflow',
+}
+
+const DAY_OPTIONS = [7, 14, 30, 90]
+
+function pct(score: number | null): string {
+  return score == null ? '—' : `${Math.round(score * 100)}`
+}
+
+function triggerLabel(run: OptimizerActivityRun): string {
+  if (!run.trigger) return 'user-launched'
+  return run.trigger.replace(/_/g, ' ')
+}
+
+export function OptimizerTab() {
+  const [data, setData] = useState<OptimizerActivityResponse | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [days, setDays] = useState(14)
+  const [surface, setSurface] = useState('')
+  const [status, setStatus] = useState('')
+  const [trigger, setTrigger] = useState<'' | 'auto' | 'user'>('')
+
+  const load = useCallback(() => {
+    setLoading(true)
+    setError(null)
+    getOptimizerActivity({
+      days,
+      surface: surface || undefined,
+      status: status || undefined,
+      trigger: trigger || undefined,
+      limit: 200,
+    })
+      .then(setData)
+      .catch(e => setError(e instanceof Error ? e.message : 'Failed to load optimizer activity'))
+      .finally(() => setLoading(false))
+  }, [days, surface, status, trigger])
+
+  useEffect(() => { load() }, [load])
+
+  const summary = data?.summary
+
+  return (
+    <div>
+      <div style={{
+        display: 'flex', alignItems: 'center', gap: 12,
+        flexWrap: 'wrap', marginBottom: 16,
+      }}>
+        <div>
+          <h2 style={{ fontSize: 18, fontWeight: 700, color: '#111827', margin: 0 }}>
+            Optimizer activity
+          </h2>
+          <p style={{ fontSize: 12, color: '#6b7280', margin: '4px 0 0' }}>
+            Every tuning run across workflows, extraction sets, and knowledge bases.
+            Read-only — owners act on their own suggestions from Tuning suggestions.
+          </p>
+        </div>
+        <div style={{ marginLeft: 'auto', display: 'flex', alignItems: 'center', gap: 8 }}>
+          <select value={days} onChange={e => setDays(Number(e.target.value))} style={selectStyle} aria-label="Time window">
+            {DAY_OPTIONS.map(d => <option key={d} value={d}>Last {d} days</option>)}
+          </select>
+          <select value={surface} onChange={e => setSurface(e.target.value)} style={selectStyle} aria-label="Surface">
+            <option value="">All surfaces</option>
+            <option value="workflow">Workflows</option>
+            <option value="extraction">Extraction sets</option>
+            <option value="kb">Knowledge bases</option>
+          </select>
+          <select value={status} onChange={e => setStatus(e.target.value)} style={selectStyle} aria-label="Status">
+            <option value="">All statuses</option>
+            <option value="completed">Completed</option>
+            <option value="failed">Failed</option>
+            <option value="running">Running</option>
+            <option value="queued">Queued</option>
+            <option value="cancelled">Cancelled</option>
+          </select>
+          <select
+            value={trigger}
+            onChange={e => setTrigger(e.target.value as '' | 'auto' | 'user')}
+            style={selectStyle}
+            aria-label="Trigger"
+          >
+            <option value="">Any trigger</option>
+            <option value="auto">Auto-triggered</option>
+            <option value="user">User-launched</option>
+          </select>
+          <button onClick={load} disabled={loading} style={buttonStyle}>
+            <RefreshCw size={12} style={{ animation: loading ? 'spin 1s linear infinite' : undefined }} />
+            Refresh
+          </button>
+        </div>
+      </div>
+
+      {error && (
+        <div style={{
+          display: 'flex', alignItems: 'center', gap: 8, padding: 12, marginBottom: 16,
+          background: '#fef2f2', border: '1px solid #fecaca', borderRadius: 8,
+          color: '#991b1b', fontSize: 13,
+        }}>
+          <AlertTriangle size={14} />
+          {error}
+        </div>
+      )}
+
+      {summary && (
+        <>
+          <div style={{
+            display: 'grid', gap: 12, marginBottom: 16,
+            gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))',
+          }}>
+            <KpiCard label="Runs" value={summary.total} icon={Play} color="#0050d7" />
+            <KpiCard label="Waiting on review" value={summary.pending_review} icon={Eye} color="#b45309" />
+            <KpiCard label="Failed" value={summary.failed} icon={XCircle} color="#b3261e" />
+            <KpiCard label="Applied" value={summary.applied} icon={CheckCircle2} color="#1a7f37" />
+            <KpiCard label="Auto-triggered" value={summary.auto_triggered} icon={Sparkles} color="#7c3aed" />
+          </div>
+
+          {summary.truncated && (
+            <p style={{ fontSize: 11, color: '#9a3412', margin: '0 0 12px' }}>
+              A surface hit the 200-run fetch cap — totals below are a floor, not the
+              exact fleet count. Narrow the window or filter by surface for exact numbers.
+            </p>
+          )}
+
+          {summary.failure_reasons.length > 0 && (
+            <section style={{
+              background: '#fff', border: '1px solid #e5e7eb', borderRadius: 12,
+              padding: 16, marginBottom: 16,
+            }}>
+              <h3 style={{ fontSize: 13, fontWeight: 700, color: '#111827', margin: '0 0 8px' }}>
+                Why runs failed
+              </h3>
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+                {summary.failure_reasons.map(f => (
+                  <div
+                    key={f.reason}
+                    style={{ display: 'flex', alignItems: 'center', gap: 10, fontSize: 12 }}
+                  >
+                    <span style={{
+                      minWidth: 28, textAlign: 'right', fontWeight: 700,
+                      color: '#991b1b', fontVariantNumeric: 'tabular-nums',
+                    }}>
+                      {f.count}
+                    </span>
+                    <span style={{ color: '#374151', wordBreak: 'break-word' }}>
+                      {f.reason.replace(/_/g, ' ')}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </section>
+          )}
+        </>
+      )}
+
+      <div style={{
+        background: '#fff', border: '1px solid #e5e7eb', borderRadius: 12,
+        overflow: 'hidden',
+      }}>
+        <div style={{ overflowX: 'auto' }}>
+          <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 12 }}>
+            <thead>
+              <tr style={{ background: '#f9fafb', textAlign: 'left' }}>
+                {['Item', 'Surface', 'Status', 'Trigger', 'Score', 'Owner', 'Started', 'Detail'].map(h => (
+                  <th key={h} style={thStyle}>{h}</th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {(data?.runs || []).map(run => (
+                <tr key={`${run.surface}:${run.run_uuid}`} style={{ borderTop: '1px solid #f3f4f6' }}>
+                  <td style={tdStyle}>
+                    <span style={{ fontWeight: 600, color: '#111827' }}>
+                      {run.item_name || '(deleted)'}
+                    </span>
+                    {run.is_live && (
+                      <span style={{ marginLeft: 6, fontSize: 10, color: '#1a7f37', fontWeight: 700 }}>
+                        LIVE
+                      </span>
+                    )}
+                    {run.dismissed_at && (
+                      <span style={{ marginLeft: 6, fontSize: 10, color: '#6b7280', fontWeight: 700 }}>
+                        DISMISSED
+                      </span>
+                    )}
+                  </td>
+                  <td style={tdStyle}>{SURFACE_LABEL[run.surface] || run.surface}</td>
+                  <td style={tdStyle}><StatusBadge status={run.status} /></td>
+                  <td style={{ ...tdStyle, color: run.trigger ? '#7c3aed' : '#6b7280' }}>
+                    {triggerLabel(run)}
+                  </td>
+                  <td style={{ ...tdStyle, fontVariantNumeric: 'tabular-nums' }}>
+                    {pct(run.baseline_score)} → {pct(run.optimized_score)}
+                    {run.tied_with_baseline && (
+                      <span style={{ marginLeft: 6, fontSize: 10, color: '#92400e' }}>tied</span>
+                    )}
+                  </td>
+                  <td style={{ ...tdStyle, color: '#6b7280' }}>{run.user_email || run.user_id || '—'}</td>
+                  <td style={{ ...tdStyle, color: '#6b7280', whiteSpace: 'nowrap' }}>
+                    {run.started_at ? relativeTime(run.started_at) : '—'}
+                  </td>
+                  <td style={{ ...tdStyle, maxWidth: 320 }}>
+                    {run.status === 'failed' ? (
+                      <span style={{ color: '#991b1b', wordBreak: 'break-word' }}>
+                        {run.error_code ? `${run.error_code.replace(/_/g, ' ')}: ` : ''}
+                        {run.error_message || 'no error recorded'}
+                      </span>
+                    ) : run.status === 'running' || run.status === 'queued' ? (
+                      <span style={{ color: '#0050d7' }}>{run.progress_message || run.phase || '—'}</span>
+                    ) : (
+                      <span style={{ color: '#6b7280' }}>{run.stopped_reason?.replace(/_/g, ' ') || '—'}</span>
+                    )}
+                  </td>
+                </tr>
+              ))}
+              {!loading && (data?.runs.length || 0) === 0 && (
+                <tr>
+                  <td colSpan={8} style={{ ...tdStyle, textAlign: 'center', color: '#6b7280', padding: 24 }}>
+                    No optimizer runs in this window.
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+const selectStyle: React.CSSProperties = {
+  padding: '5px 8px', fontSize: 12, borderRadius: 6,
+  border: '1px solid #d1d5db', background: '#fff', color: '#374151',
+}
+
+const buttonStyle: React.CSSProperties = {
+  display: 'inline-flex', alignItems: 'center', gap: 5,
+  padding: '5px 10px', fontSize: 12, fontWeight: 600, borderRadius: 6,
+  border: '1px solid #d1d5db', background: '#fff', color: '#374151', cursor: 'pointer',
+}
+
+const thStyle: React.CSSProperties = {
+  padding: '8px 12px', fontSize: 11, fontWeight: 700, color: '#6b7280',
+  textTransform: 'uppercase', letterSpacing: 0.4, whiteSpace: 'nowrap',
+}
+
+const tdStyle: React.CSSProperties = {
+  padding: '8px 12px', verticalAlign: 'top', color: '#374151',
+}

--- a/frontend/src/components/layout/TeamsDropdown.tsx
+++ b/frontend/src/components/layout/TeamsDropdown.tsx
@@ -1,16 +1,18 @@
 import { useState, useRef, useEffect } from 'react'
 import type { KeyboardEvent } from 'react'
-import { Award, User, Users, Settings, LogOut, IdCard, Shield, ClipboardCheck, ChevronDown, MessageSquare, KeyRound } from 'lucide-react'
+import { Award, User, Users, Settings, LogOut, IdCard, Shield, ClipboardCheck, ChevronDown, MessageSquare, KeyRound, Sparkles } from 'lucide-react'
 import { Link } from '@tanstack/react-router'
 import { useTeams } from '../../hooks/useTeams'
 import { useAuth } from '../../hooks/useAuth'
 import { useCertificationPanel } from '../../contexts/CertificationPanelContext'
+import { useOptimizerInboxCount } from '../../hooks/useOptimizerInboxCount'
 import { VersionMenuFooter } from './VersionMenuFooter'
 
 export function TeamsDropdown() {
   const { teams, currentTeam, switchTeam } = useTeams()
   const { user, logout } = useAuth()
   const certPanel = useCertificationPanel()
+  const { actionable: tuningActionable } = useOptimizerInboxCount()
   const [open, setOpen] = useState(false)
   const ref = useRef<HTMLDivElement>(null)
   const triggerRef = useRef<HTMLButtonElement>(null)
@@ -175,6 +177,28 @@ export function TeamsDropdown() {
           >
             <KeyRound className="h-4 w-4 shrink-0" style={{ width: 18 }} />
             <span>Credentials</span>
+          </Link>
+
+          {/* Tuning suggestions — always listed (even at zero) so the surface
+              is discoverable; the rail badge is what draws attention when
+              something is actually waiting. */}
+          <Link
+            to="/tuning"
+            role="menuitem"
+            tabIndex={-1}
+            onClick={() => closeMenu()}
+            className="flex items-center gap-2.5 rounded-md px-3.5 py-2.5 text-sm text-[#111] hover:bg-black/[.04] transition-colors"
+          >
+            <Sparkles className="h-4 w-4 shrink-0" style={{ width: 18 }} />
+            <span>Tuning suggestions</span>
+            {tuningActionable > 0 && (
+              <span
+                className="ml-auto rounded-full px-1.5 text-[10px] font-semibold text-[#111]"
+                style={{ backgroundColor: 'var(--highlight-color, #eab308)' }}
+              >
+                {tuningActionable}
+              </span>
+            )}
           </Link>
 
           {/* Certification */}

--- a/frontend/src/components/shared/OptimizerInbox.test.tsx
+++ b/frontend/src/components/shared/OptimizerInbox.test.tsx
@@ -1,0 +1,168 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { OptimizerInbox } from './OptimizerInbox'
+import {
+  getOptimizerInbox,
+  dismissOptimizerCandidate,
+  type OptimizerInboxItem,
+  type OptimizerInboxResponse,
+} from '../../api/optimizerInbox'
+import { applyWorkflowOptimization } from '../../api/workflows'
+
+vi.mock('../../api/optimizerInbox', () => ({
+  getOptimizerInbox: vi.fn(),
+  dismissOptimizerCandidate: vi.fn(),
+  restoreOptimizerCandidate: vi.fn(),
+}))
+vi.mock('../../api/workflows', () => ({ applyWorkflowOptimization: vi.fn() }))
+vi.mock('../../api/knowledge', () => ({ applyKBOptimization: vi.fn() }))
+vi.mock('../../api/extractions', () => ({ applyExtractionOptimization: vi.fn() }))
+
+const mockToast = vi.fn()
+vi.mock('../../contexts/ToastContext', () => ({ useToast: () => ({ toast: mockToast }) }))
+vi.mock('./useConfirm', () => ({ useConfirm: () => () => Promise.resolve(true) }))
+
+const mockGet = vi.mocked(getOptimizerInbox)
+const mockDismiss = vi.mocked(dismissOptimizerCandidate)
+const mockApplyWorkflow = vi.mocked(applyWorkflowOptimization)
+
+function makeItem(overrides: Partial<OptimizerInboxItem> = {}): OptimizerInboxItem {
+  return {
+    surface: 'workflow',
+    run_uuid: 'run-1',
+    item_id: 'wf-1',
+    item_name: 'Proposal intake',
+    status: 'completed',
+    category: 'needs_review',
+    started_at: '2026-07-20T12:00:00Z',
+    completed_at: '2026-07-20T12:30:00Z',
+    score: 0.85,
+    baseline_score: 0.7,
+    trigger: 'quality_alert',
+    trigger_detail: {},
+    tied_with_baseline: false,
+    apply_preview: null,
+    suggestion_count: 0,
+    applied_at: null,
+    reverted_at: null,
+    is_live: false,
+    can_manage: true,
+    dismissed_at: null,
+    error_message: null,
+    error_code: null,
+    error_context: null,
+    stopped_reason: null,
+    phase: null,
+    progress_message: null,
+    judge_model: 'judge-1',
+    overfitting_warning: false,
+    link: '/?workflow=wf-1',
+    ...overrides,
+  }
+}
+
+function makeResponse(items: OptimizerInboxItem[]): OptimizerInboxResponse {
+  const count = (category: string) => items.filter(i => i.category === category).length
+  return {
+    items,
+    counts: {
+      total: items.length,
+      needs_review: count('needs_review'),
+      failed: count('failed'),
+      in_flight: count('in_flight'),
+      applied: count('applied'),
+      no_change: count('no_change'),
+      dismissed: count('dismissed'),
+      pending_review: count('needs_review'),
+    },
+    lookback_days: 14,
+  }
+}
+
+beforeEach(() => {
+  mockGet.mockReset()
+  mockDismiss.mockReset()
+  mockApplyWorkflow.mockReset()
+  mockToast.mockReset()
+})
+
+describe('OptimizerInbox', () => {
+  it('shows a reviewable candidate with its item name and lift', async () => {
+    mockGet.mockResolvedValue(makeResponse([makeItem()]))
+    render(<OptimizerInbox />)
+
+    expect(await screen.findByText('Proposal intake')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: /Ready to review/ })).toBeInTheDocument()
+    expect(screen.getByText(/\+15\.0 pts/)).toBeInTheDocument()
+    expect(screen.getByText(/Auto-tuned because a quality regression alert fired/)).toBeInTheDocument()
+  })
+
+  it('explains the empty state instead of rendering nothing', async () => {
+    mockGet.mockResolvedValue(makeResponse([]))
+    render(<OptimizerInbox />)
+
+    expect(await screen.findByText('Nothing waiting for review')).toBeInTheDocument()
+  })
+
+  it('surfaces the error message of a failed tuning run', async () => {
+    mockGet.mockResolvedValue(makeResponse([
+      makeItem({
+        category: 'failed', status: 'failed',
+        error_code: 'judge_unavailable', error_message: 'Judge model unavailable',
+        score: null,
+      }),
+    ]))
+    render(<OptimizerInbox />)
+
+    expect(await screen.findByText('Tuning failed')).toBeInTheDocument()
+    expect(screen.getByText('Judge model unavailable')).toBeInTheDocument()
+    expect(screen.getByText('judge unavailable')).toBeInTheDocument()
+  })
+
+  it('applies through the surface-specific endpoint and reloads', async () => {
+    mockGet.mockResolvedValue(makeResponse([makeItem()]))
+    mockApplyWorkflow.mockResolvedValue({
+      ok: true,
+      applied_config: { step_overrides: {} },
+      applied_step_ids: [],
+      partial: false,
+    })
+    render(<OptimizerInbox />)
+
+    fireEvent.click(await screen.findByRole('button', { name: /Review & apply/i }))
+
+    await waitFor(() => expect(mockApplyWorkflow).toHaveBeenCalledWith('wf-1', 'run-1'))
+    expect(mockToast).toHaveBeenCalledWith('Applied to Proposal intake', 'success')
+    // Refetched so the row moves out of "Ready to review".
+    await waitFor(() => expect(mockGet).toHaveBeenCalledTimes(2))
+  })
+
+  it('dismisses a candidate', async () => {
+    mockGet.mockResolvedValue(makeResponse([makeItem()]))
+    mockDismiss.mockResolvedValue({ ok: true, dismissed_at: '2026-07-21T00:00:00Z' })
+    render(<OptimizerInbox />)
+
+    fireEvent.click(await screen.findByRole('button', { name: /Dismiss/i }))
+
+    await waitFor(() => expect(mockDismiss).toHaveBeenCalledWith('workflow', 'run-1'))
+  })
+
+  it('hides Apply and Dismiss without manage rights', async () => {
+    mockGet.mockResolvedValue(makeResponse([makeItem({ can_manage: false })]))
+    render(<OptimizerInbox />)
+
+    expect(await screen.findByText('Proposal intake')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Review & apply/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Dismiss/i })).not.toBeInTheDocument()
+  })
+
+  it('offers nothing to apply on a tied candidate', async () => {
+    mockGet.mockResolvedValue(makeResponse([
+      makeItem({ category: 'no_change', tied_with_baseline: true }),
+    ]))
+    render(<OptimizerInbox />)
+
+    expect(await screen.findByText('No change recommended')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Review & apply/i })).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/shared/OptimizerInbox.tsx
+++ b/frontend/src/components/shared/OptimizerInbox.tsx
@@ -1,145 +1,524 @@
-import { useEffect, useState } from 'react'
-import { Loader2, Inbox, Sparkles, ArrowRight, CheckCircle2 } from 'lucide-react'
-import { getOptimizerInbox, type OptimizerInboxItem, type OptimizerInboxResponse } from '../../api/optimizerInbox'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import {
+  AlertTriangle,
+  BookOpen,
+  CheckCircle2,
+  ExternalLink,
+  Inbox,
+  Loader2,
+  MinusCircle,
+  RotateCcw,
+  Sparkles,
+  Undo2,
+  Workflow as WorkflowIcon,
+  ListChecks,
+  X,
+} from 'lucide-react'
+import {
+  dismissOptimizerCandidate,
+  getOptimizerInbox,
+  restoreOptimizerCandidate,
+  type OptimizerInboxCategory,
+  type OptimizerInboxItem,
+  type OptimizerInboxResponse,
+  type OptimizerSurface,
+} from '../../api/optimizerInbox'
+import { applyKBOptimization } from '../../api/knowledge'
+import { applyExtractionOptimization } from '../../api/extractions'
+import { applyWorkflowOptimization } from '../../api/workflows'
+import { ApplyPreviewModal } from './ApplyPreviewModal'
+import { useToast } from '../../contexts/ToastContext'
+import { useConfirm } from './useConfirm'
+import { relativeTime } from '../../utils/time'
 
 /**
- * Optimizer Inbox  - Phase 6 unified candidate review surface.
+ * Optimizer Inbox — the review surface for automatically generated tuning
+ * suggestions, plus the tuning runs that failed.
  *
- * Shows shadow optimizer runs across KB/extraction/workflow that the
- * system enqueued in response to quality alerts (Phase 6) or report-only
- * signals (Phase 5). Each row links to the surface's autovalidate panel
- * where the user can preview deltas, apply, or dismiss.
+ * Auto-triggered ("shadow") optimizer runs finish with a winning config that
+ * nothing ever asked a human to look at. This lists them per item the caller
+ * can see, shows the expected impact, and offers Apply / Dismiss.
  *
- * The component is intentionally self-contained — embed it anywhere
- * (sidebar, admin dashboard, modal). No props required.
+ * Apply deliberately calls the per-surface apply endpoint each panel uses, so
+ * the same governance gates (tied-with-baseline, cross-field thresholds,
+ * revert snapshots, quality-timeline recording) apply here too.
  */
+
+const SURFACE_META: Record<OptimizerSurface, {
+  label: string
+  color: string
+  icon: typeof BookOpen
+  itemNoun: string
+  itemNounPlural: string
+  openLabel: string
+}> = {
+  kb: {
+    label: 'Knowledge base', color: '#7c3aed', icon: BookOpen,
+    itemNoun: 'query', itemNounPlural: 'queries', openLabel: 'Open knowledge base',
+  },
+  extraction: {
+    label: 'Extraction set', color: '#166534', icon: ListChecks,
+    itemNoun: 'field', itemNounPlural: 'fields', openLabel: 'Open extraction set',
+  },
+  workflow: {
+    label: 'Workflow', color: '#0050d7', icon: WorkflowIcon,
+    itemNoun: 'step', itemNounPlural: 'steps', openLabel: 'Open workflow',
+  },
+}
+
+const TRIGGER_LABEL: Record<string, string> = {
+  cross_field_failure: 'cross-field checks were failing',
+  chat_feedback_threshold: 'chat answers were getting thumbs-down',
+  quality_alert: 'a quality regression alert fired',
+}
+
+const CATEGORY_ORDER: OptimizerInboxCategory[] = [
+  'needs_review', 'failed', 'in_flight', 'applied', 'no_change', 'cancelled', 'dismissed',
+]
+
+const CATEGORY_META: Record<OptimizerInboxCategory, { title: string; blurb: string }> = {
+  needs_review: {
+    title: 'Ready to review',
+    blurb: 'A tuning run found a better configuration. Nothing changes until you apply it.',
+  },
+  failed: {
+    title: 'Tuning failed',
+    blurb: 'These runs stopped before producing a suggestion.',
+  },
+  in_flight: { title: 'Tuning now', blurb: 'Runs still in progress.' },
+  applied: { title: 'Applied', blurb: 'These configurations are live on the item.' },
+  no_change: {
+    title: 'No change recommended',
+    blurb: 'The best configuration found was no better than the current one.',
+  },
+  cancelled: { title: 'Cancelled', blurb: 'Runs cancelled before finishing.' },
+  dismissed: { title: 'Dismissed', blurb: 'Suggestions you decided against.' },
+}
+
+function pct(score: number | null): string {
+  return score == null ? '—' : `${Math.round(score * 100)}`
+}
+
+function triggerSentence(item: OptimizerInboxItem): string {
+  if (!item.trigger) return 'Tuned on request'
+  const reason = TRIGGER_LABEL[item.trigger] || 'the system flagged a quality signal'
+  return `Auto-tuned because ${reason}`
+}
+
 export function OptimizerInbox() {
+  const { toast } = useToast()
+  const confirm = useConfirm()
   const [data, setData] = useState<OptimizerInboxResponse | null>(null)
   const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [showDismissed, setShowDismissed] = useState(false)
+  const [busyRun, setBusyRun] = useState<string | null>(null)
+  const [previewFor, setPreviewFor] = useState<OptimizerInboxItem | null>(null)
 
-  useEffect(() => {
+  const load = useCallback(async (includeDismissed: boolean) => {
     setLoading(true)
-    getOptimizerInbox()
-      .then(setData)
-      .catch(e => console.error('getOptimizerInbox failed', e))
-      .finally(() => setLoading(false))
+    setError(null)
+    try {
+      setData(await getOptimizerInbox({ includeDismissed }))
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to load tuning suggestions')
+    } finally {
+      setLoading(false)
+    }
   }, [])
 
-  if (loading) {
+  useEffect(() => { void load(showDismissed) }, [load, showDismissed])
+
+  const applyItem = useCallback(async (item: OptimizerInboxItem) => {
+    setBusyRun(item.run_uuid)
+    try {
+      if (item.surface === 'kb') {
+        await applyKBOptimization(item.item_id, item.run_uuid)
+      } else if (item.surface === 'extraction') {
+        await applyExtractionOptimization(item.item_id, item.run_uuid)
+      } else {
+        await applyWorkflowOptimization(item.item_id, item.run_uuid)
+      }
+      toast(`Applied to ${item.item_name}`, 'success')
+      setPreviewFor(null)
+      await load(showDismissed)
+    } catch (e) {
+      toast(e instanceof Error ? e.message : 'Apply failed', 'error')
+    } finally {
+      setBusyRun(null)
+    }
+  }, [toast, load, showDismissed])
+
+  const handleApplyClick = useCallback(async (item: OptimizerInboxItem) => {
+    // Runs from before apply-preview existed have nothing to show in the
+    // preview modal, so fall back to a plain confirmation.
+    if (item.apply_preview && item.apply_preview.items.length > 0) {
+      setPreviewFor(item)
+      return
+    }
+    const ok = await confirm({
+      title: 'Apply this configuration?',
+      message: `This replaces the current configuration of "${item.item_name}". You can revert it afterwards from the item's Validate & improve tab.`,
+      confirmLabel: 'Apply',
+    })
+    if (ok) await applyItem(item)
+  }, [confirm, applyItem])
+
+  const handleDismiss = useCallback(async (item: OptimizerInboxItem) => {
+    setBusyRun(item.run_uuid)
+    try {
+      await dismissOptimizerCandidate(item.surface, item.run_uuid)
+      await load(showDismissed)
+    } catch (e) {
+      toast(e instanceof Error ? e.message : 'Dismiss failed', 'error')
+    } finally {
+      setBusyRun(null)
+    }
+  }, [toast, load, showDismissed])
+
+  const handleRestore = useCallback(async (item: OptimizerInboxItem) => {
+    setBusyRun(item.run_uuid)
+    try {
+      await restoreOptimizerCandidate(item.surface, item.run_uuid)
+      await load(showDismissed)
+    } catch (e) {
+      toast(e instanceof Error ? e.message : 'Restore failed', 'error')
+    } finally {
+      setBusyRun(null)
+    }
+  }, [toast, load, showDismissed])
+
+  const grouped = useMemo(() => {
+    const groups = new Map<OptimizerInboxCategory, OptimizerInboxItem[]>()
+    for (const item of data?.items || []) {
+      const list = groups.get(item.category) || []
+      list.push(item)
+      groups.set(item.category, list)
+    }
+    return groups
+  }, [data])
+
+  if (loading && !data) {
     return (
-      <div style={{ padding: 24, textAlign: 'center', color: '#888' }}>
-        <Loader2 size={18} style={{ animation: 'spin 1s linear infinite' }} />
+      <div style={{ padding: 32, textAlign: 'center', color: '#6b7280' }}>
+        <Loader2 className="animate-spin" style={{ width: 18, height: 18, margin: '0 auto' }} />
       </div>
     )
   }
-  if (!data) return null
 
-  const { items, counts } = data
-
-  if (items.length === 0) {
+  if (error) {
     return (
       <div style={{
-        padding: 20, background: '#1a1a1a',
-        border: '1px solid #2e2e2e', borderRadius: 8,
+        display: 'flex', alignItems: 'center', gap: 10, padding: 16,
+        background: '#fef2f2', border: '1px solid #fecaca', borderRadius: 8,
+        color: '#991b1b', fontSize: 13,
       }}>
-        <div style={{ display: 'flex', alignItems: 'center', gap: 8, color: '#bbb', fontSize: 13 }}>
-          <Inbox size={14} />
-          No quality candidates waiting for review.
-        </div>
-        <div style={{ marginTop: 4, fontSize: 11, color: '#666' }}>
-          When the system detects a drop or elevated thumbs-down rate it'll
-          auto-tune the affected item and surface a candidate fix here.
-        </div>
+        <AlertTriangle style={{ width: 16, height: 16, flexShrink: 0 }} />
+        <span style={{ flex: 1 }}>{error}</span>
+        <button onClick={() => void load(showDismissed)} style={secondaryButton}>Retry</button>
       </div>
     )
   }
+
+  const counts = data?.counts
+  const hasRows = (data?.items.length || 0) > 0
 
   return (
     <div>
-      <header style={{
-        display: 'flex', alignItems: 'baseline', gap: 12, marginBottom: 10,
+      <div style={{
+        display: 'flex', alignItems: 'center', gap: 12,
+        flexWrap: 'wrap', marginBottom: 16,
       }}>
-        <h3 style={{ margin: 0, fontSize: 13, fontWeight: 600, color: '#fff' }}>
-          Quality candidates
-        </h3>
-        <span style={{ fontSize: 11, color: '#888' }}>
-          {counts.pending_review} ready · {counts.in_flight} in flight · {counts.applied} applied
-        </span>
-      </header>
-
-      <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
-        {items.map(it => <Row key={`${it.surface}:${it.run_uuid}`} item={it} />)}
+        <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+          <Stat label="Ready to review" value={counts?.needs_review ?? 0} tone="action" />
+          <Stat label="Failed" value={counts?.failed ?? 0} tone={counts?.failed ? 'bad' : 'neutral'} />
+          <Stat label="Tuning now" value={counts?.in_flight ?? 0} tone="neutral" />
+          <Stat label="Applied" value={counts?.applied ?? 0} tone="good" />
+        </div>
+        <div style={{ marginLeft: 'auto', display: 'flex', alignItems: 'center', gap: 12 }}>
+          <label style={{
+            display: 'inline-flex', alignItems: 'center', gap: 6,
+            fontSize: 12, color: '#4b5563', cursor: 'pointer',
+          }}>
+            <input
+              type="checkbox"
+              checked={showDismissed}
+              onChange={e => setShowDismissed(e.target.checked)}
+            />
+            Show dismissed
+          </label>
+          <button onClick={() => void load(showDismissed)} style={secondaryButton} disabled={loading}>
+            <RotateCcw style={{ width: 12, height: 12 }} />
+            Refresh
+          </button>
+        </div>
       </div>
+
+      {!hasRows ? (
+        <div style={{
+          padding: 24, background: '#fff', border: '1px solid #e5e7eb',
+          borderRadius: 8, textAlign: 'center',
+        }}>
+          <Inbox style={{ width: 20, height: 20, color: '#9ca3af', margin: '0 auto 8px' }} />
+          <div style={{ fontSize: 14, color: '#374151', fontWeight: 600 }}>
+            Nothing waiting for review
+          </div>
+          <div style={{ marginTop: 4, fontSize: 12, color: '#6b7280', maxWidth: 460, margin: '4px auto 0' }}>
+            When quality slips on a workflow, extraction set, or knowledge base, the
+            system tunes it in the background and the candidate fix shows up here.
+            Failed tuning runs show up here too.
+          </div>
+        </div>
+      ) : (
+        CATEGORY_ORDER.map(category => {
+          const items = grouped.get(category)
+          if (!items?.length) return null
+          const meta = CATEGORY_META[category]
+          return (
+            <section key={category} style={{ marginBottom: 24 }}>
+              <h2 style={{
+                fontSize: 13, fontWeight: 700, color: '#111827',
+                margin: '0 0 2px', display: 'flex', alignItems: 'center', gap: 6,
+              }}>
+                {meta.title}
+                <span style={{ fontWeight: 500, color: '#6b7280' }}>({items.length})</span>
+              </h2>
+              <p style={{ fontSize: 12, color: '#6b7280', margin: '0 0 8px' }}>{meta.blurb}</p>
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+                {items.map(item => (
+                  <Row
+                    key={`${item.surface}:${item.run_uuid}`}
+                    item={item}
+                    busy={busyRun === item.run_uuid}
+                    onApply={() => void handleApplyClick(item)}
+                    onDismiss={() => void handleDismiss(item)}
+                    onRestore={() => void handleRestore(item)}
+                  />
+                ))}
+              </div>
+            </section>
+          )
+        })
+      )}
+
+      {data && (
+        <p style={{ fontSize: 11, color: '#9ca3af', marginTop: 4 }}>
+          Showing the last {data.lookback_days} days. Older runs stay in each item's
+          Validate &amp; improve history.
+        </p>
+      )}
+
+      {previewFor?.apply_preview && (
+        <ApplyPreviewModal
+          open
+          preview={previewFor.apply_preview}
+          itemNoun={SURFACE_META[previewFor.surface].itemNoun}
+          itemNounPlural={SURFACE_META[previewFor.surface].itemNounPlural}
+          applying={busyRun === previewFor.run_uuid}
+          onConfirm={() => void applyItem(previewFor)}
+          onCancel={() => setPreviewFor(null)}
+        />
+      )}
     </div>
   )
 }
 
-function Row({ item }: { item: OptimizerInboxItem }) {
-  const score = item.score != null ? `${Math.round(item.score * 100)}` : '—'
-  const baseline = item.baseline_score != null ? `${Math.round(item.baseline_score * 100)}` : '—'
+function Row({ item, busy, onApply, onDismiss, onRestore }: {
+  item: OptimizerInboxItem
+  busy: boolean
+  onApply: () => void
+  onDismiss: () => void
+  onRestore: () => void
+}) {
+  const meta = SURFACE_META[item.surface]
+  const Icon = meta.icon
   const lift = (item.score != null && item.baseline_score != null)
     ? (item.score - item.baseline_score) * 100
     : null
-
-  const surfaceColor = item.surface === 'kb' ? '#a78bfa'
-    : item.surface === 'extraction' ? '#22c55e'
-    : '#3b82f6'
-
-  const triggerLabel = item.trigger === 'cross_field_failure' ? 'workflow check fails'
-    : item.trigger === 'chat_feedback_threshold' ? 'chat thumbs-down rate'
-    : item.trigger === 'quality_alert' ? 'quality regression alert'
-    : 'auto-trigger'
-
-  const isApplied = !!item.applied_at && !item.reverted_at
-  const isStale = item.tied_with_baseline
+  const when = item.completed_at || item.started_at
+  const preview = item.apply_preview
+  const isFailed = item.category === 'failed'
+  const isDismissed = item.category === 'dismissed'
+  const canAct = item.can_manage && !busy
 
   return (
-    <a
-      href={item.link}
-      style={{
-        display: 'flex', alignItems: 'center', gap: 12,
-        padding: '10px 12px', backgroundColor: '#1f1f1f',
-        border: '1px solid #2e2e2e', borderRadius: 6,
-        textDecoration: 'none', color: 'inherit',
-        opacity: isApplied || isStale ? 0.65 : 1,
-      }}
-    >
-      <span style={{
-        padding: '2px 6px', fontSize: 10, fontWeight: 600,
-        color: surfaceColor, background: surfaceColor + '14',
-        borderRadius: 4, textTransform: 'uppercase', letterSpacing: 0.5,
-      }}>
-        {item.surface}
-      </span>
-      <div style={{ flex: 1, minWidth: 0 }}>
-        <div style={{ fontSize: 12, color: '#e5e5e5', display: 'flex', alignItems: 'center', gap: 6 }}>
-          {isApplied
-            ? <CheckCircle2 size={11} style={{ color: '#22c55e' }} />
-            : <Sparkles size={11} style={{ color: '#a78bfa' }} />}
-          {isApplied
-            ? `Applied · ${score} (was ${baseline})`
-            : isStale
-              ? `No measurable improvement vs current`
-              : `Candidate · ${score} (was ${baseline})`}
-          {lift != null && !isStale && (
-            <span style={{ color: lift >= 0 ? '#22c55e' : '#ef4444', fontWeight: 600, fontVariantNumeric: 'tabular-nums' }}>
-              {lift >= 0 ? '+' : ''}{lift.toFixed(1)} pts
+    <article style={{
+      background: '#fff',
+      border: `1px solid ${isFailed ? '#fecaca' : '#e5e7eb'}`,
+      borderRadius: 8, padding: '12px 14px',
+      opacity: isDismissed ? 0.7 : 1,
+    }}>
+      <div style={{ display: 'flex', alignItems: 'flex-start', gap: 10 }}>
+        <span
+          title={meta.label}
+          style={{
+            display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+            width: 26, height: 26, borderRadius: 6, flexShrink: 0,
+            background: `${meta.color}14`, color: meta.color,
+          }}
+        >
+          <Icon style={{ width: 14, height: 14 }} />
+        </span>
+
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div style={{ display: 'flex', alignItems: 'baseline', gap: 8, flexWrap: 'wrap' }}>
+            <span style={{ fontSize: 13, fontWeight: 600, color: '#111827' }}>
+              {item.item_name}
             </span>
+            <span style={{ fontSize: 11, color: '#6b7280' }}>{meta.label}</span>
+            {when && (
+              <span style={{ fontSize: 11, color: '#9ca3af' }}>· {relativeTime(when)}</span>
+            )}
+          </div>
+
+          <div style={{ fontSize: 12, color: '#4b5563', marginTop: 3 }}>
+            {triggerSentence(item)}
+          </div>
+
+          {isFailed ? (
+            <div style={{
+              marginTop: 8, padding: '8px 10px', background: '#fef2f2',
+              borderRadius: 6, fontSize: 12, color: '#991b1b',
+            }}>
+              <strong style={{ fontWeight: 600 }}>
+                {item.error_code ? item.error_code.replace(/_/g, ' ') : 'Run failed'}
+              </strong>
+              {item.error_message && (
+                <div style={{ marginTop: 2, color: '#7f1d1d', wordBreak: 'break-word' }}>
+                  {item.error_message}
+                </div>
+              )}
+            </div>
+          ) : item.category === 'in_flight' ? (
+            <div style={{ marginTop: 6, fontSize: 12, color: '#0050d7', display: 'flex', alignItems: 'center', gap: 6 }}>
+              <Loader2 className="animate-spin" style={{ width: 12, height: 12 }} />
+              {item.progress_message || item.phase || 'Running'}
+            </div>
+          ) : (
+            <div style={{ marginTop: 6, display: 'flex', alignItems: 'center', gap: 10, flexWrap: 'wrap' }}>
+              <span style={{
+                fontSize: 12, color: '#374151', fontVariantNumeric: 'tabular-nums',
+              }}>
+                Score {pct(item.baseline_score)} → <strong>{pct(item.score)}</strong>
+              </span>
+              {lift != null && (
+                <span style={{
+                  fontSize: 12, fontWeight: 600,
+                  color: lift > 0 ? '#166534' : lift < 0 ? '#b3261e' : '#6b7280',
+                  fontVariantNumeric: 'tabular-nums',
+                }}>
+                  {lift > 0 ? '+' : ''}{lift.toFixed(1)} pts
+                </span>
+              )}
+              {preview && (
+                <span style={{ fontSize: 12, color: '#4b5563' }}>
+                  {preview.will_change} of {preview.total} {meta.itemNounPlural} change
+                  {preview.regressions > 0 && (
+                    <span style={{ color: '#9a3412' }}>
+                      {' '}· {preview.regressions} regress
+                      {preview.significant_regressions > 0 && ' (some beyond noise)'}
+                    </span>
+                  )}
+                </span>
+              )}
+              {item.overfitting_warning && (
+                <span
+                  title="Too few test items to hold any back, so the score is measured on the same data the tuner optimized against."
+                  style={{ fontSize: 11, color: '#9a3412', display: 'inline-flex', alignItems: 'center', gap: 4 }}
+                >
+                  <AlertTriangle style={{ width: 11, height: 11 }} />
+                  in-sample score
+                </span>
+              )}
+            </div>
+          )}
+
+          {item.category === 'applied' && (
+            <div style={{ marginTop: 6, fontSize: 12, color: '#166534', display: 'inline-flex', alignItems: 'center', gap: 5 }}>
+              <CheckCircle2 style={{ width: 12, height: 12 }} />
+              Live on this item{item.applied_at ? ` since ${relativeTime(item.applied_at)}` : ''}
+            </div>
+          )}
+
+          {item.category === 'no_change' && (
+            <div style={{ marginTop: 6, fontSize: 12, color: '#6b7280', display: 'inline-flex', alignItems: 'center', gap: 5 }}>
+              <MinusCircle style={{ width: 12, height: 12 }} />
+              Statistically tied with the current settings — nothing to apply.
+            </div>
           )}
         </div>
-        <div style={{ fontSize: 10, color: '#888', marginTop: 2 }}>
-          Triggered by {triggerLabel}
-          {item.completed_at && ` · ${new Date(item.completed_at).toLocaleString()}`}
-          {item.apply_preview && (
-            <> · {item.apply_preview.will_change}/{item.apply_preview.total} items
-              {item.apply_preview.regressions > 0 && (
-                <span style={{ color: '#f97316' }}> · {item.apply_preview.regressions} regress</span>
-              )}
-            </>
+
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 6, alignItems: 'stretch' }}>
+          {item.category === 'needs_review' && item.can_manage && (
+            <button onClick={onApply} disabled={!canAct} style={primaryButton}>
+              {busy ? <Loader2 className="animate-spin" style={{ width: 12, height: 12 }} /> : <Sparkles style={{ width: 12, height: 12 }} />}
+              Review &amp; apply
+            </button>
           )}
+          {item.category === 'needs_review' && item.can_manage && (
+            <button onClick={onDismiss} disabled={!canAct} style={secondaryButton}>
+              <X style={{ width: 12, height: 12 }} />
+              Dismiss
+            </button>
+          )}
+          {isFailed && item.can_manage && (
+            <button onClick={onDismiss} disabled={!canAct} style={secondaryButton}>
+              <X style={{ width: 12, height: 12 }} />
+              Dismiss
+            </button>
+          )}
+          {isDismissed && item.can_manage && (
+            <button onClick={onRestore} disabled={!canAct} style={secondaryButton}>
+              <Undo2 style={{ width: 12, height: 12 }} />
+              Restore
+            </button>
+          )}
+          <a href={item.link} style={{ ...secondaryButton, textDecoration: 'none' }}>
+            <ExternalLink style={{ width: 12, height: 12 }} />
+            Open
+          </a>
         </div>
       </div>
-      <ArrowRight size={14} style={{ color: '#666' }} />
-    </a>
+    </article>
   )
+}
+
+function Stat({ label, value, tone }: {
+  label: string
+  value: number
+  tone: 'action' | 'good' | 'bad' | 'neutral'
+}) {
+  const colors: Record<string, { bg: string; fg: string }> = {
+    action: { bg: '#fef3c7', fg: '#92400e' },
+    good: { bg: '#dcfce7', fg: '#166534' },
+    bad: { bg: '#fee2e2', fg: '#991b1b' },
+    neutral: { bg: '#f3f4f6', fg: '#374151' },
+  }
+  const c = colors[tone]
+  return (
+    <span style={{
+      display: 'inline-flex', alignItems: 'center', gap: 6,
+      padding: '4px 10px', borderRadius: 999,
+      background: c.bg, color: c.fg, fontSize: 12, fontWeight: 600,
+    }}>
+      <span style={{ fontVariantNumeric: 'tabular-nums' }}>{value}</span>
+      <span style={{ fontWeight: 500 }}>{label}</span>
+    </span>
+  )
+}
+
+const baseButton: React.CSSProperties = {
+  display: 'inline-flex', alignItems: 'center', justifyContent: 'center', gap: 5,
+  padding: '5px 10px', borderRadius: 6, fontSize: 12, fontWeight: 600,
+  cursor: 'pointer', whiteSpace: 'nowrap',
+}
+
+const primaryButton: React.CSSProperties = {
+  ...baseButton,
+  background: '#111827', color: '#fff', border: '1px solid #111827',
+}
+
+const secondaryButton: React.CSSProperties = {
+  ...baseButton,
+  background: '#fff', color: '#374151', border: '1px solid #d1d5db',
 }

--- a/frontend/src/components/support/SupportChatPanel.tsx
+++ b/frontend/src/components/support/SupportChatPanel.tsx
@@ -725,12 +725,14 @@ function ChatView({
     el.style.height = `${Math.min(el.scrollHeight, 160)}px`
   }, [message])
 
-  const loadTicket = useCallback(async () => {
+  // Error toasts persist until dismissed, so the 15s refresh stays silent on
+  // failure — only the initial load reports.
+  const loadTicket = useCallback(async (isPoll = false) => {
     try {
       const data = await supportApi.getTicket(ticketUuid)
       setTicket(data)
     } catch {
-      toast('Failed to load ticket', 'error')
+      if (!isPoll) toast('Failed to load ticket', 'error')
     } finally {
       setLoading(false)
     }
@@ -743,7 +745,7 @@ function ChatView({
     import('../../api/notifications').then(({ markReadForItem }) => {
       markReadForItem('support_ticket', ticketUuid).catch(() => {})
     }).catch(() => {})
-    const interval = setInterval(loadTicket, 15000)
+    const interval = setInterval(() => loadTicket(true), 15000)
     return () => clearInterval(interval)
   }, [loadTicket, ticketUuid])
 

--- a/frontend/src/components/workspace/ActivityRail.tsx
+++ b/frontend/src/components/workspace/ActivityRail.tsx
@@ -1,6 +1,8 @@
 import { useCallback } from 'react'
+import { useNavigate } from '@tanstack/react-router'
 import {
   Award,
+  Sparkles,
   MessageSquare,
   Workflow,
   ListChecks,
@@ -16,6 +18,7 @@ import {
   SquarePen,
 } from 'lucide-react'
 import { useActivities } from '../../hooks/useActivities'
+import { useOptimizerInboxCount } from '../../hooks/useOptimizerInboxCount'
 import { deleteActivity } from '../../api/activity'
 import { useWorkspace } from '../../contexts/WorkspaceContext'
 import { useToast } from '../../contexts/ToastContext'
@@ -80,6 +83,8 @@ function isStale(activity: ActivityEvent, thresholdMinutes: number): boolean {
 export function ActivityRail() {
   const { railDocked, toggleRailDocked, setActiveRightTab, setLoadConversationId, triggerNewChat, openWorkflow, openExtraction, closeWorkflow, closeExtraction, closeAutomation, activitySignal, currentConversationUuid } = useWorkspace()
   const { activities, refresh, freshTitleIds, markTitleShimmered, staleThresholdMinutes } = useActivities(activitySignal)
+  const { counts: tuningCounts, actionable: tuningActionable } = useOptimizerInboxCount()
+  const navigate = useNavigate()
   const { toast } = useToast()
   const { togglePanel, progress } = useCertificationPanel()
   const confirm = useConfirm()
@@ -197,6 +202,47 @@ export function ActivityRail() {
               <div className="text-[11px] leading-[1.4] text-[#111]">New chat</div>
             )}
           </div>
+
+          {/* Tuning suggestions — only when something is actually waiting, so
+              the rail stays quiet on a healthy account. The always-present
+              entry point is the account menu. */}
+          {tuningActionable > 0 && (
+            <div
+              onClick={() => navigate({ to: '/tuning' })}
+              title={`${tuningCounts?.needs_review || 0} tuning suggestion(s) to review${
+                tuningCounts?.failed ? `, ${tuningCounts.failed} failed run(s)` : ''
+              }`}
+              className={cn(
+                'flex items-center gap-2 rounded-lg cursor-pointer p-2',
+                'hover:bg-[#f0f2f5] hover:shadow-[0_1px_3px_rgb(15_23_42/0.12)]',
+                'transition-[background-color,box-shadow] duration-200',
+                railDocked ? 'justify-center' : '',
+              )}
+            >
+              <div className="relative shrink-0 w-4 text-center text-[#806600]">
+                <Sparkles className="h-4 w-4" />
+                {railDocked && (
+                  <span
+                    className="absolute -right-1 -top-1 h-[7px] w-[7px] rounded-full"
+                    style={{ backgroundColor: 'var(--highlight-color, #eab308)' }}
+                  />
+                )}
+              </div>
+              {!railDocked && (
+                <>
+                  <div className="min-w-0 flex-1 text-[11px] leading-[1.4] text-[#111]">
+                    Tuning suggestions
+                  </div>
+                  <span
+                    className="shrink-0 rounded-full px-1.5 text-[10px] font-semibold text-[#111]"
+                    style={{ backgroundColor: 'var(--highlight-color, #eab308)' }}
+                  >
+                    {tuningActionable}
+                  </span>
+                </>
+              )}
+            </div>
+          )}
           <div className="h-[5px]" />
 
           {activities.map((activity) => {

--- a/frontend/src/contexts/ToastContext.test.tsx
+++ b/frontend/src/contexts/ToastContext.test.tsx
@@ -1,0 +1,86 @@
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { render, screen, act, fireEvent } from '@testing-library/react'
+import { ToastProvider, useToast, type ToastType } from './ToastContext'
+
+function Trigger({ message, type }: { message: string; type: ToastType }) {
+  const { toast } = useToast()
+  return <button onClick={() => toast(message, type)}>fire</button>
+}
+
+function setup(message: string, type: ToastType) {
+  render(
+    <ToastProvider>
+      <Trigger message={message} type={type} />
+    </ToastProvider>,
+  )
+  fireEvent.click(screen.getByText('fire'))
+}
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('ToastContext auto-dismiss', () => {
+  it('keeps an error toast on screen past the auto-dismiss window', () => {
+    vi.useFakeTimers()
+    setup('Website blocked: https://example.com - not on the allowlist', 'error')
+    expect(screen.getByRole('alert')).toBeTruthy()
+
+    act(() => {
+      vi.advanceTimersByTime(60_000)
+    })
+    expect(screen.queryByRole('alert')).toBeTruthy()
+  })
+
+  it('does not dismiss an error when its body is clicked', () => {
+    setup('Something went wrong', 'error')
+
+    fireEvent.click(screen.getByText('Something went wrong'))
+
+    expect(screen.queryByRole('alert')).toBeTruthy()
+  })
+
+  it('dismisses an error via the close button', () => {
+    setup('Something went wrong', 'error')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss error' }))
+
+    expect(screen.queryByRole('alert')).toBeNull()
+  })
+
+  it.each<ToastType>(['success', 'info'])('auto-dismisses a %s toast after 4s', type => {
+    vi.useFakeTimers()
+    setup('All good', type)
+    expect(screen.getByRole('status')).toBeTruthy()
+
+    act(() => {
+      vi.advanceTimersByTime(4000)
+    })
+    expect(screen.queryByRole('status')).toBeNull()
+  })
+
+  it('caps stacked toasts, keeping the newest', () => {
+    function Many() {
+      const { toast } = useToast()
+      return (
+        <button onClick={() => { for (let i = 1; i <= 8; i++) toast(`err ${i}`, 'error') }}>
+          fire
+        </button>
+      )
+    }
+    render(<ToastProvider><Many /></ToastProvider>)
+    fireEvent.click(screen.getByText('fire'))
+
+    expect(screen.getAllByRole('alert')).toHaveLength(5)
+    expect(screen.queryByText('err 3')).toBeNull()
+    expect(screen.getByText('err 8')).toBeTruthy()
+  })
+
+  it('dismisses a success toast when clicked', () => {
+    setup('All good', 'success')
+
+    fireEvent.click(screen.getByText('All good'))
+
+    expect(screen.queryByRole('status')).toBeNull()
+  })
+})

--- a/frontend/src/contexts/ToastContext.tsx
+++ b/frontend/src/contexts/ToastContext.tsx
@@ -24,6 +24,10 @@ const ToastContext = createContext<ToastContextValue | null>(null)
 
 let nextId = 1
 
+// Errors no longer auto-dismiss, so a repeatedly-failing background job could
+// otherwise pile toasts past the bottom of the viewport. Keep the newest few.
+const MAX_TOASTS = 5
+
 export function ToastProvider({ children }: { children: ReactNode }) {
   const [toasts, setToasts] = useState<Toast[]>([])
 
@@ -33,8 +37,12 @@ export function ToastProvider({ children }: { children: ReactNode }) {
 
   const toast = useCallback((message: string, type: ToastType = 'info', action?: ToastAction) => {
     const id = nextId++
-    setToasts(prev => [...prev, { id, type, message, action }])
-    setTimeout(() => dismiss(id), action ? 8000 : 4000)
+    setToasts(prev => [...prev, { id, type, message, action }].slice(-MAX_TOASTS))
+    // Errors are the longest messages and often need to be read carefully or
+    // copied into a support ticket, so they stay until the user closes them.
+    if (type !== 'error') {
+      setTimeout(() => dismiss(id), action ? 8000 : 4000)
+    }
   }, [dismiss])
 
   return (
@@ -50,28 +58,33 @@ export function ToastProvider({ children }: { children: ReactNode }) {
             display: 'flex', flexDirection: 'column', gap: 8, maxWidth: 380,
           }}
         >
-          {toasts.map(t => (
+          {toasts.map(t => {
+            // Errors persist until dismissed, so clicking the body must not close
+            // them \u2014 the user needs to select and copy the text.
+            const isError = t.type === 'error'
+            return (
             <div
               key={t.id}
               // Error toasts interrupt (assertive); success/info wait (polite).
-              role={t.type === 'error' ? 'alert' : 'status'}
-              aria-live={t.type === 'error' ? 'assertive' : 'polite'}
-              onClick={() => dismiss(t.id)}
+              role={isError ? 'alert' : 'status'}
+              aria-live={isError ? 'assertive' : 'polite'}
+              onClick={isError ? undefined : () => dismiss(t.id)}
               style={{
                 padding: '12px 16px', borderRadius: 'var(--ui-radius, 12px)',
                 boxShadow: '0 4px 16px rgba(0,0,0,0.15)',
-                cursor: 'pointer', fontSize: 14, fontWeight: 500,
-                display: 'flex', alignItems: 'center', gap: 10,
+                cursor: isError ? 'default' : 'pointer', fontSize: 14, fontWeight: 500,
+                userSelect: isError ? 'text' : undefined,
+                display: 'flex', alignItems: isError ? 'flex-start' : 'center', gap: 10,
                 animation: 'toast-slide-in 0.2s ease-out',
                 ...(t.type === 'success' ? { background: '#f0fdf4', border: '1px solid #bbf7d0', color: '#166534' } :
-                   t.type === 'error' ? { background: '#fef2f2', border: '1px solid #fecaca', color: '#991b1b' } :
+                   isError ? { background: '#fef2f2', border: '1px solid #fecaca', color: '#991b1b' } :
                    { background: '#fff', border: '1px solid #e5e7eb', color: '#374151' }),
               }}
             >
               <span style={{ fontSize: 16 }}>
-                {t.type === 'success' ? '\u2713' : t.type === 'error' ? '\u2717' : '\u2139'}
+                {t.type === 'success' ? '\u2713' : isError ? '\u2717' : '\u2139'}
               </span>
-              <span style={{ flex: 1 }}>
+              <span style={{ flex: 1, wordBreak: 'break-word' }}>
                 {t.message}
                 {t.action && (
                   <button
@@ -87,8 +100,25 @@ export function ToastProvider({ children }: { children: ReactNode }) {
                   </button>
                 )}
               </span>
+              {isError && (
+                <button
+                  type="button"
+                  aria-label="Dismiss error"
+                  title="Dismiss"
+                  onClick={(e) => { e.stopPropagation(); dismiss(t.id) }}
+                  style={{
+                    flexShrink: 0, marginLeft: 4, marginTop: -2,
+                    background: 'none', border: 'none', padding: '0 2px',
+                    fontSize: 16, lineHeight: 1, color: 'inherit',
+                    opacity: 0.7, cursor: 'pointer',
+                  }}
+                >
+                  {'\u2715'}
+                </button>
+              )}
             </div>
-          ))}
+            )
+          })}
         </div>
       )}
       <style>{`

--- a/frontend/src/hooks/useOptimizerInboxCount.ts
+++ b/frontend/src/hooks/useOptimizerInboxCount.ts
@@ -1,0 +1,55 @@
+import { useEffect, useState } from 'react'
+import { getOptimizerInboxCount, type OptimizerInboxCounts } from '../api/optimizerInbox'
+
+/**
+ * Badge counts for the tuning-suggestions inbox.
+ *
+ * Polled slowly on purpose: auto-tuning is rate-limited by a multi-hour
+ * per-item cooldown, so a candidate appearing between polls is minutes-stale
+ * at worst — and the endpoint access-checks every row it counts.
+ *
+ * State lives at module scope with one shared timer, because both the account
+ * menu and the activity rail badge want the same number and neither should
+ * cost a second poll.
+ */
+const POLL_MS = 5 * 60 * 1000
+
+let cached: OptimizerInboxCounts | null = null
+let timer: ReturnType<typeof setInterval> | null = null
+let inFlight: Promise<void> | null = null
+const subscribers = new Set<(counts: OptimizerInboxCounts | null) => void>()
+
+function refresh(): Promise<void> {
+  if (inFlight) return inFlight
+  inFlight = getOptimizerInboxCount()
+    .then(data => {
+      cached = data
+      subscribers.forEach(fn => fn(data))
+    })
+    .catch(() => {
+      // Silent: a nav badge must never surface an error state.
+    })
+    .finally(() => { inFlight = null })
+  return inFlight
+}
+
+export function useOptimizerInboxCount() {
+  const [counts, setCounts] = useState<OptimizerInboxCounts | null>(cached)
+
+  useEffect(() => {
+    subscribers.add(setCounts)
+    void refresh()
+    if (!timer) timer = setInterval(() => void refresh(), POLL_MS)
+    return () => {
+      subscribers.delete(setCounts)
+      if (subscribers.size === 0 && timer) {
+        clearInterval(timer)
+        timer = null
+      }
+    }
+  }, [])
+
+  // Rows the user can actually act on — candidates plus failures.
+  const actionable = (counts?.needs_review ?? 0) + (counts?.failed ?? 0)
+  return { counts, actionable, refresh }
+}

--- a/frontend/src/pages/Admin.tsx
+++ b/frontend/src/pages/Admin.tsx
@@ -4,7 +4,7 @@ import {
   Lock, Globe, Zap,
   FileText, FolderTree,
   Mail, Award, KeyRound, PackageOpen,
-  BookOpen,
+  BookOpen, Sparkles,
 } from 'lucide-react'
 import { PageLayout } from '../components/layout/PageLayout'
 import { useAuth } from '../hooks/useAuth'
@@ -23,6 +23,7 @@ import { UsageTab } from '../components/admin/UsageTab'
 import { WorkflowsTab } from '../components/admin/WorkflowsTab'
 import { OrganizationsTab } from '../components/admin/OrganizationsTab'
 import { QualityTab } from '../components/admin/QualityTab'
+import { OptimizerTab } from '../components/admin/OptimizerTab'
 import { CertificationsTab } from '../components/admin/CertificationsTab'
 import { EmailAnalyticsTab } from '../components/admin/EmailAnalyticsTab'
 import { DemoTab } from '../components/admin/DemoTab'
@@ -31,7 +32,7 @@ import { TelemetryOptInBanner } from '../components/admin/TelemetryOptInBanner'
 import { ConfigTab } from '../components/admin/ConfigTab'
 import { getFeatureFlags } from '../api/config'
 
-type Tab = 'usage' | 'users' | 'teams' | 'organizations' | 'workflows' | 'quality' | 'knowledgebases' | 'compliance' | 'audit' | 'demo' | 'email' | 'certifications' | 'apikeys' | 'catalog' | 'telemetry' | 'config'
+type Tab = 'usage' | 'users' | 'teams' | 'organizations' | 'workflows' | 'quality' | 'optimizer' | 'knowledgebases' | 'compliance' | 'audit' | 'demo' | 'email' | 'certifications' | 'apikeys' | 'catalog' | 'telemetry' | 'config'
 
 const TABS: { key: Tab; label: string; icon: typeof BarChart3 }[] = [
   { key: 'usage', label: 'Usage', icon: BarChart3 },
@@ -40,6 +41,7 @@ const TABS: { key: Tab; label: string; icon: typeof BarChart3 }[] = [
   { key: 'organizations', label: 'Organizations', icon: FolderTree },
   { key: 'workflows', label: 'Workflows', icon: Workflow },
   { key: 'quality', label: 'Quality', icon: ShieldCheck },
+  { key: 'optimizer', label: 'Optimizer', icon: Sparkles },
   { key: 'knowledgebases', label: 'Knowledge Bases', icon: BookOpen },
   { key: 'compliance', label: 'Compliance', icon: Lock },
   { key: 'audit', label: 'Audit Log', icon: FileText },
@@ -89,7 +91,7 @@ export default function Admin() {
   // endpoints accept a team scope. Tabs whose backends require admin/staff (email,
   // plus everything in hiddenForNonAdmin) stay hidden so we never render a tab that
   // can only 403.
-  const hiddenForNonAdmin = ['config', 'catalog', 'quality', 'knowledgebases', 'compliance', 'demo', 'organizations', 'approvals', 'audit', 'certifications', 'apikeys', 'email', 'teams', 'telemetry']
+  const hiddenForNonAdmin = ['config', 'catalog', 'quality', 'optimizer', 'knowledgebases', 'compliance', 'demo', 'organizations', 'approvals', 'audit', 'certifications', 'apikeys', 'email', 'teams', 'telemetry']
   let visibleTabs = isGlobalAdmin
     ? TABS
     : isStaff
@@ -176,6 +178,7 @@ export default function Admin() {
           {activeTab === 'organizations' && (isGlobalAdmin || isStaff) && <OrganizationsTab />}
           {activeTab === 'workflows' && <WorkflowsTab />}
           {activeTab === 'quality' && <QualityTab />}
+          {activeTab === 'optimizer' && (isGlobalAdmin || isStaff) && <OptimizerTab />}
           {activeTab === 'knowledgebases' && (isGlobalAdmin || isStaff) && <KnowledgeBasesTab canEdit={isGlobalAdmin} />}
           {activeTab === 'compliance' && (isGlobalAdmin || isStaff) && <ComplianceTab />}
           {activeTab === 'audit' && (isGlobalAdmin || isStaff) && <AuditTab />}

--- a/frontend/src/pages/SupportCenter.tsx
+++ b/frontend/src/pages/SupportCenter.tsx
@@ -945,12 +945,14 @@ function ChatView({
     el.style.height = `${Math.min(el.scrollHeight, 200)}px`
   }, [reply])
 
-  const loadTicket = useCallback(async () => {
+  // Error toasts persist until dismissed, so the 15s refresh stays silent on
+  // failure — only the initial load reports.
+  const loadTicket = useCallback(async (isPoll = false) => {
     try {
       const data = await supportApi.getTicket(ticketUuid)
       setTicket(data)
     } catch {
-      toast('Failed to load ticket', 'error')
+      if (!isPoll) toast('Failed to load ticket', 'error')
     } finally {
       setLoading(false)
     }
@@ -959,7 +961,7 @@ function ChatView({
   useEffect(() => {
     loadTicket()
     supportApi.markTicketRead(ticketUuid).catch(() => {})
-    const interval = setInterval(loadTicket, 15000)
+    const interval = setInterval(() => loadTicket(true), 15000)
     return () => clearInterval(interval)
   }, [loadTicket, ticketUuid])
 

--- a/frontend/src/pages/TuningSuggestions.tsx
+++ b/frontend/src/pages/TuningSuggestions.tsx
@@ -1,0 +1,30 @@
+import { PageLayout } from '../components/layout/PageLayout'
+import { OptimizerInbox } from '../components/shared/OptimizerInbox'
+
+/**
+ * Tuning suggestions — the user-facing home for automatically generated
+ * optimizer candidates and failed tuning runs.
+ *
+ * The per-item "Validate & improve" tabs stay the place you *launch* tuning
+ * from; this page answers the question those tabs can't: "did anything the
+ * system tuned on its own need me?"
+ */
+export default function TuningSuggestions() {
+  return (
+    <PageLayout>
+      <div style={{ maxWidth: 980, margin: '0 auto' }}>
+        <header style={{ marginBottom: 20 }}>
+          <h1 style={{ fontSize: 24, fontWeight: 700, color: '#111827', margin: 0 }}>
+            Tuning suggestions
+          </h1>
+          <p style={{ fontSize: 13, color: '#4b5563', margin: '6px 0 0', maxWidth: 640 }}>
+            When quality slips on one of your workflows, extraction sets, or knowledge
+            bases, the system re-tunes it in the background and proposes a better
+            configuration. Nothing is changed until you apply it here.
+          </p>
+        </header>
+        <OptimizerInbox />
+      </div>
+    </PageLayout>
+  )
+}

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -33,6 +33,7 @@ const JoinProjectAccept = lazy(() => import('./pages/JoinProjectAccept'))
 const Organizations = lazy(() => import('./pages/Organizations'))
 const Credentials = lazy(() => import('./pages/Credentials'))
 const Reviews = lazy(() => import('./pages/Reviews'))
+const TuningSuggestions = lazy(() => import('./pages/TuningSuggestions'))
 const ReviewDetail = lazy(() => import('./pages/ReviewDetail'))
 const Login = lazy(() => import('./pages/Login'))
 const ResetPassword = lazy(() => import('./pages/ResetPassword'))
@@ -74,6 +75,7 @@ const ROUTE_TITLES: Array<[string, string]> = [
   ['/teams', 'Teams'],
   ['/organizations', 'Organizations'],
   ['/verification', 'Verification'],
+  ['/tuning', 'Tuning suggestions'],
   ['/support', 'Support'],
   ['/automation', 'Automations'],
   ['/docs', 'Docs'],
@@ -400,6 +402,16 @@ const reviewsRoute = createRoute({
   ),
 })
 
+const tuningRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/tuning',
+  component: () => (
+    <ProtectedRoute>
+      <TuningSuggestions />
+    </ProtectedRoute>
+  ),
+})
+
 const reviewDetailRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/reviews/$uuid',
@@ -478,6 +490,7 @@ const routeTree = rootRoute.addChildren([
   reviewsRoute,
   reviewDetailRoute,
   approvalsRoute,
+  tuningRoute,
 ])
 
 export const router = createRouter({ routeTree })


### PR DESCRIPTION
## The problem

Support ticket: *"Optimizer generates tuning suggestions that no one can see or act on."* On prod ~50 suggestions had been generated and never applied; on dev ~50 tuning runs had failed over ten days with no indication anywhere in the app.

The root cause wasn't missing backend work — the inbox was **dead code**:

- `GET /api/optimizer/inbox` already existed and was registered in `main.py`
- `components/shared/OptimizerInbox.tsx` already existed and **nothing imported it**

The endpoint also couldn't have backed a real screen: no access scoping (its docstring claimed owner filtering the query didn't do), raw `item_id`s with no names, no dismiss concept, failures excluded, and deep links pointing at `mode=workspace` / `mode=extractions` — modes the router rejects.

## Users — `/tuning` "Tuning suggestions"

Rows grouped by what they need: **ready to review**, **tuning failed**, **tuning now**, **applied**, **no change recommended**, **dismissed**. Each candidate shows the item's name, why it auto-tuned in plain language ("Auto-tuned because chat answers were getting thumbs-down"), baseline → optimized score with lift, and the apply-preview rollup ("2 of 4 steps change · 1 regresses"). Failed runs show their error code and message.

Apply reuses the existing `ApplyPreviewModal` and calls the **per-surface** apply endpoints, so the tied-with-baseline gate, cross-field threshold, revert snapshot and quality-timeline recording all still apply — deliberately no second, weaker apply path in the inbox router.

Discoverability: always-present account-menu entry, plus an ActivityRail badge that appears only when something is actionable. Both consumers share one module-level poller, so the badge costs one request.

## Admins — read-only Optimizer tab

Every run across all three surfaces with surface/status/trigger/window filters, KPI tiles (runs, waiting on review, failed, applied, auto-triggered), and a **"Why runs failed"** rollup grouped by `error_code` — the thing that turns "50 silent failures" into a one-line answer. No actions on purpose: applying someone else's config is theirs to do from their own inbox.

## Design rules encoded in the code

- **Inbox membership**: shadow-triggered runs of any status, plus any failed run. Completed *user-launched* runs stay out — the item's own Validate & improve tab already restores those, and folding them in turns triage into a firehose.
- **Dismissal soft-hides** (`dismissed_at` / `dismissed_by` on all three run models). Runs stay in item history and in the admin view, so a dismissal is a triage decision, not a cover-up.
- **The inbox triages; the per-item "Validate & improve" tab owns the tuning flow.** This is a triage list that deep-links into existing panels, not a parallel tuning UI.
- Rows are access-filtered against the parent KB / search set / workflow and carry `can_manage`, so the UI only offers Apply where it would succeed, and dismiss-without-manage returns 404 rather than confirming the run exists.

## Testing

- **28 new backend tests** (18 inbox, 10 admin), all passing — access scoping, view-only vs. manage, failure surfacing, tied → `no_change`, the extraction override-equality liveness check, dismissed filtering, query shape, and the 404-not-403 dismiss gate.
- **7 new frontend tests**; full suite 297/297; coverage 8.19% lines (gate 6%); production build passes.
- `make backend-static` clean; new backend files clean under mypy.

Two pre-existing issues, unrelated to this branch: `tests/test_url_validation.py` fails 2 DNS-dependent tests in a sandboxed environment, and the frontend suite needs `--testTimeout=25000` on a contended machine (a different untouched file times out each run at the 5s default; each passes in isolation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
