### PR TITLE
fix(admin): neutralize CSV formula injection + harden org CSV import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- **CSV formula injection in the admin org-import/export flow.** `downloadCSV` wrote user-controlled field values (org names, emails) directly into cells; a value starting with `=`, `+`, `-`, or `@` is interpreted as a formula by Excel/Sheets when the CSV is opened, letting a crafted org name run arbitrary formulas (including exfiltration via `HYPERLINK`/webservice calls) on whoever opens the export. Such values are now prefixed with a leading `'` (safe-quote) before writing. Separately, the org CSV importer is now quote-aware (fields containing commas no longer split incorrectly) and order-independent (parses by header name, not column position), and parsed rows are sorted parent-before-child so child orgs never reference a parent that hasn't been created yet.
+
 ## [v4.9.0] - 2026-07-23
 
 ### Fixed

--- a/frontend/src/components/admin/ApiKeysTab.tsx
+++ b/frontend/src/components/admin/ApiKeysTab.tsx
@@ -15,20 +15,9 @@ import {
 } from '../../api/admin'
 import { useToast } from '../../contexts/ToastContext'
 import { useConfirm } from '../shared/useConfirm'
+import { formatDateTime } from './shared/format'
 
 marked.setOptions({ breaks: true, gfm: true })
-
-function fmtDate(iso: string | null): string {
-  if (!iso) return '—'
-  const d = iso.endsWith('Z') || iso.includes('+') ? new Date(iso) : new Date(iso + 'Z')
-  return d.toLocaleString('en-US', {
-    month: 'short',
-    day: 'numeric',
-    year: 'numeric',
-    hour: 'numeric',
-    minute: '2-digit',
-  })
-}
 
 function isExpired(key: ApiKeyListItem): boolean {
   if (!key.expires_at) return false
@@ -219,14 +208,14 @@ export function ApiKeysTab() {
                   </div>
                 </td>
                 <td style={{ padding: 8 }}><StatusBadge keyItem={k} /></td>
-                <td style={{ padding: 8, color: '#6b7280' }}>{fmtDate(k.created_at)}</td>
+                <td style={{ padding: 8, color: '#6b7280' }}>{formatDateTime(k.created_at)}</td>
                 <td style={{ padding: 8, color: '#6b7280' }}>
-                  {fmtDate(k.last_used_at)}
+                  {formatDateTime(k.last_used_at)}
                   {k.last_used_ip && (
                     <div style={{ fontSize: 11, fontFamily: 'monospace' }}>{k.last_used_ip}</div>
                   )}
                 </td>
-                <td style={{ padding: 8, color: '#6b7280' }}>{fmtDate(k.expires_at)}</td>
+                <td style={{ padding: 8, color: '#6b7280' }}>{formatDateTime(k.expires_at)}</td>
                 <td style={{ padding: 8 }}>
                   {!k.revoked_at && (
                     <button

--- a/frontend/src/components/admin/CertificationsTab.tsx
+++ b/frontend/src/components/admin/CertificationsTab.tsx
@@ -4,35 +4,8 @@ import {
   getCertificationProgressList, setCertificationUnlock,
   type CertificationProgressItem,
 } from '../../api/admin'
-import { formatNumber } from './shared/format'
+import { downloadCSV, formatDate, formatNumber } from './shared/format'
 import { ExportButton, SearchInput, UserAvatar } from './shared/primitives'
-
-function parseUtcDate(d: string): Date {
-  // Backend stores UTC but may omit timezone suffix; ensure JS treats it as UTC
-  if (!d.endsWith('Z') && !d.includes('+') && !d.includes('-', 10)) return new Date(d + 'Z')
-  return new Date(d)
-}
-
-function formatDate(d: string | null): string {
-  if (!d) return '-'
-  return parseUtcDate(d).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
-}
-
-function downloadCSV(filename: string, headers: string[], rows: (string | number | null)[][]) {
-  const escape = (v: string | number | null) => {
-    if (v === null || v === undefined) return ''
-    const s = String(v)
-    return s.includes(',') || s.includes('"') || s.includes('\n') ? `"${s.replace(/"/g, '""')}"` : s
-  }
-  const csv = [headers.join(','), ...rows.map(r => r.map(escape).join(','))].join('\n')
-  const blob = new Blob([csv], { type: 'text/csv' })
-  const url = URL.createObjectURL(blob)
-  const a = document.createElement('a')
-  a.href = url
-  a.download = filename
-  a.click()
-  URL.revokeObjectURL(url)
-}
 
 export function CertificationsTab() {
   const [items, setItems] = useState<CertificationProgressItem[]>([])

--- a/frontend/src/components/admin/ComplianceTab.tsx
+++ b/frontend/src/components/admin/ComplianceTab.tsx
@@ -11,18 +11,7 @@ import {
   type RetentionDashboard,
   type RetentionPolicy,
 } from '../../api/admin'
-
-function formatDateTime(iso: string | null): string {
-  if (!iso) return '—'
-  const d = iso.endsWith('Z') || iso.includes('+') ? new Date(iso) : new Date(iso + 'Z')
-  return d.toLocaleString('en-US', {
-    month: 'short',
-    day: 'numeric',
-    year: 'numeric',
-    hour: 'numeric',
-    minute: '2-digit',
-  })
-}
+import { formatDateTime } from './shared/format'
 
 function formatRetention(days?: number): string {
   if (!days) return '—'

--- a/frontend/src/components/admin/DemoTab.tsx
+++ b/frontend/src/components/admin/DemoTab.tsx
@@ -18,34 +18,8 @@ import type { DemoAdminStats, DemoApplication as DemoApp, PostExperienceResponse
 import { POST_SURVEY_FIELDS } from '../survey/postSurveyFields'
 import { PRE_SURVEY_FIELDS } from '../../pages/Demo'
 import { SurveyFieldRenderer } from '../survey/SurveyFieldRenderer'
+import { downloadCSV, formatDate } from './shared/format'
 import { SearchInput } from './shared/primitives'
-
-function parseUtcDate(d: string): Date {
-  // Backend stores UTC but may omit timezone suffix; ensure JS treats it as UTC
-  if (!d.endsWith('Z') && !d.includes('+') && !d.includes('-', 10)) return new Date(d + 'Z')
-  return new Date(d)
-}
-
-function formatDate(d: string | null): string {
-  if (!d) return '-'
-  return parseUtcDate(d).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
-}
-
-function downloadCSV(filename: string, headers: string[], rows: (string | number | null)[][]) {
-  const escape = (v: string | number | null) => {
-    if (v === null || v === undefined) return ''
-    const s = String(v)
-    return s.includes(',') || s.includes('"') || s.includes('\n') ? `"${s.replace(/"/g, '""')}"` : s
-  }
-  const csv = [headers.join(','), ...rows.map(r => r.map(escape).join(','))].join('\n')
-  const blob = new Blob([csv], { type: 'text/csv' })
-  const url = URL.createObjectURL(blob)
-  const a = document.createElement('a')
-  a.href = url
-  a.download = filename
-  a.click()
-  URL.revokeObjectURL(url)
-}
 
 function DemoResponseDetail({ responses }: { responses: Record<string, unknown> }) {
   if (!responses || Object.keys(responses).length === 0) {

--- a/frontend/src/components/admin/EmailAnalyticsTab.tsx
+++ b/frontend/src/components/admin/EmailAnalyticsTab.tsx
@@ -8,37 +8,10 @@ import {
 } from 'recharts'
 import { getEmailAnalytics } from '../../api/admin'
 import type { EmailAnalyticsResponse } from '../../api/admin'
-import { formatNumber } from './shared/format'
+import { downloadCSV, formatDateTime, formatNumber } from './shared/format'
 import {
   KpiCard, ExportButton, TimeRangeSelector,
 } from './shared/primitives'
-
-function parseUtcDate(d: string): Date {
-  // Backend stores UTC but may omit timezone suffix; ensure JS treats it as UTC
-  if (!d.endsWith('Z') && !d.includes('+') && !d.includes('-', 10)) return new Date(d + 'Z')
-  return new Date(d)
-}
-
-function formatDateTime(d: string | null): string {
-  if (!d) return '-'
-  return parseUtcDate(d).toLocaleString('en-US', { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' })
-}
-
-function downloadCSV(filename: string, headers: string[], rows: (string | number | null)[][]) {
-  const escape = (v: string | number | null) => {
-    if (v === null || v === undefined) return ''
-    const s = String(v)
-    return s.includes(',') || s.includes('"') || s.includes('\n') ? `"${s.replace(/"/g, '""')}"` : s
-  }
-  const csv = [headers.join(','), ...rows.map(r => r.map(escape).join(','))].join('\n')
-  const blob = new Blob([csv], { type: 'text/csv' })
-  const url = URL.createObjectURL(blob)
-  const a = document.createElement('a')
-  a.href = url
-  a.download = filename
-  a.click()
-  URL.revokeObjectURL(url)
-}
 
 export function EmailAnalyticsTab() {
   const [data, setData] = useState<EmailAnalyticsResponse | null>(null)

--- a/frontend/src/components/admin/KnowledgeBasesTab.tsx
+++ b/frontend/src/components/admin/KnowledgeBasesTab.tsx
@@ -5,6 +5,7 @@ import {
   type AdminKBSummary,
 } from '../../api/admin'
 import { updateKnowledgeBase } from '../../api/knowledge'
+import { formatDate } from './shared/format'
 
 interface Props {
   /** Full admins can rename any KB; staff get a read-only inventory (the
@@ -14,14 +15,6 @@ interface Props {
 }
 
 type SortKey = 'title' | 'updated'
-
-function formatDate(d: string | null): string {
-  if (!d) return '—'
-  const iso = !d.endsWith('Z') && !d.includes('+') && !d.includes('-', 10) ? d + 'Z' : d
-  const date = new Date(iso)
-  if (Number.isNaN(date.getTime())) return '—'
-  return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
-}
 
 /** Org-wide KB inventory — built for reviewing names/versions and renaming KBs
  * in place (e.g. adding a date/version to the title). Source provenance per KB

--- a/frontend/src/components/admin/OrganizationsTab.test.tsx
+++ b/frontend/src/components/admin/OrganizationsTab.test.tsx
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest'
+import { parseCSV } from './OrganizationsTab'
+
+describe('parseCSV — quoting', () => {
+  it('keeps a quoted field with an embedded comma intact', () => {
+    const csv = 'name,parent\n"College of Engineering, Mines and Sciences",University of Idaho'
+    const rows = parseCSV(csv)
+    expect(rows).toHaveLength(1)
+    expect(rows[0].name).toBe('College of Engineering, Mines and Sciences')
+    expect(rows[0].parent_name).toBe('University of Idaho')
+  })
+
+  it('unescapes a doubled quote inside a quoted field to a single literal quote', () => {
+    const csv = 'name,parent\n"Dept of ""Special"" Studies",'
+    const rows = parseCSV(csv)
+    expect(rows).toHaveLength(1)
+    expect(rows[0].name).toBe('Dept of "Special" Studies')
+  })
+
+  it('parses an ordinary unquoted row as before', () => {
+    const csv = 'name,parent\nCollege of Science,University of Idaho'
+    const rows = parseCSV(csv)
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toEqual({ name: 'College of Science', parent_name: 'University of Idaho', org_type: 'college' })
+  })
+})
+
+describe('parseCSV — order independence', () => {
+  it('gives a child row the correct depth-derived org_type even when it precedes its parent (and grandparent)', () => {
+    // Fully reversed order: Department appears before College, which appears before University.
+    const csv = [
+      'name,parent',
+      'Department of Computer Science,College of Engineering',
+      'College of Engineering,University of Idaho',
+      'University of Idaho,',
+    ].join('\n')
+    const rows = parseCSV(csv)
+    const byName = Object.fromEntries(rows.map(r => [r.name, r]))
+    expect(byName['University of Idaho'].org_type).toBe('university')
+    expect(byName['College of Engineering'].org_type).toBe('college')
+    expect(byName['Department of Computer Science'].org_type).toBe('department')
+  })
+
+  it('produces the same output regardless of whether the parent comes first or last', () => {
+    const parentFirst = [
+      'name,parent',
+      'University of Idaho,',
+      'College of Engineering,University of Idaho',
+    ].join('\n')
+    const childFirst = [
+      'name,parent',
+      'College of Engineering,University of Idaho',
+      'University of Idaho,',
+    ].join('\n')
+    const rowsParentFirst = parseCSV(parentFirst)
+    const rowsChildFirst = parseCSV(childFirst)
+    const collegeParentFirst = rowsParentFirst.find(r => r.name === 'College of Engineering')
+    const collegeChildFirst = rowsChildFirst.find(r => r.name === 'College of Engineering')
+    expect(collegeChildFirst?.org_type).toBe(collegeParentFirst?.org_type)
+    expect(collegeChildFirst?.org_type).toBe('college')
+  })
+
+  it('treats a dangling parent reference as depth 0, giving the child depth 1, without crashing', () => {
+    const csv = 'name,parent\nSome Unit,Nonexistent Parent'
+    const rows = parseCSV(csv)
+    expect(rows).toHaveLength(1)
+    expect(rows[0].org_type).toBe('college')
+  })
+
+  it('terminates and returns rows for a cyclic parent reference (A -> B -> A)', () => {
+    const csv = [
+      'name,parent',
+      'A,B',
+      'B,A',
+    ].join('\n')
+    const rows = parseCSV(csv)
+    expect(rows).toHaveLength(2)
+    expect(rows.map(r => r.name).sort()).toEqual(['A', 'B'])
+  })
+})
+
+describe('parseCSV — structural cases', () => {
+  it('returns [] for a header-only file', () => {
+    expect(parseCSV('name,parent')).toEqual([])
+  })
+
+  it('returns [] when there is no name column', () => {
+    expect(parseCSV('foo,bar\nCollege of Science,University of Idaho')).toEqual([])
+  })
+
+  it('parses CRLF line endings identically to LF', () => {
+    const lf = 'name,parent\nUniversity of Idaho,\nCollege of Engineering,University of Idaho'
+    const crlf = lf.replace(/\n/g, '\r\n')
+    expect(parseCSV(crlf)).toEqual(parseCSV(lf))
+  })
+
+  it('skips rows with an empty name', () => {
+    const csv = 'name,parent\n,University of Idaho\nCollege of Science,University of Idaho'
+    const rows = parseCSV(csv)
+    expect(rows).toHaveLength(1)
+    expect(rows[0].name).toBe('College of Science')
+  })
+})

--- a/frontend/src/components/admin/OrganizationsTab.tsx
+++ b/frontend/src/components/admin/OrganizationsTab.tsx
@@ -227,28 +227,99 @@ function OrgMemberPanel({ org, onClose, onReload }: { org: Organization; onClose
   )
 }
 
-function parseCSV(text: string): { name: string; parent_name: string; org_type: string }[] {
-  const lines = text.split('\n').map(l => l.trim()).filter(Boolean)
+/**
+ * Tokenize one CSV record into fields, honoring RFC 4180 quoting basics: a
+ * double-quoted field may contain commas, and a doubled quote (`""`) inside a
+ * quoted field is a literal quote. Unquoted fields are trimmed; the interior
+ * spacing of quoted fields is preserved.
+ *
+ * Known limitation: this is a per-line tokenizer, so it does NOT support a
+ * newline embedded inside a quoted field — that would require tokenizing the
+ * whole document rather than one line at a time. Not attempted here.
+ */
+function splitCsvLine(line: string): string[] {
+  const fields: string[] = []
+  const len = line.length
+  let i = 0
+  while (i <= len) {
+    while (i < len && (line[i] === ' ' || line[i] === '\t')) i++
+    if (line[i] === '"') {
+      i++ // consume opening quote
+      let field = ''
+      while (i < len) {
+        if (line[i] === '"') {
+          if (line[i + 1] === '"') { field += '"'; i += 2; continue }
+          i++ // consume closing quote
+          break
+        }
+        field += line[i]
+        i++
+      }
+      // discard anything between the closing quote and the next comma
+      while (i < len && line[i] !== ',') i++
+      fields.push(field)
+    } else {
+      const start = i
+      while (i < len && line[i] !== ',') i++
+      fields.push(line.slice(start, i).trim())
+    }
+    if (i < len && line[i] === ',') { i++; continue }
+    break
+  }
+  return fields
+}
+
+export function parseCSV(text: string): { name: string; parent_name: string; org_type: string }[] {
+  // Strip a trailing \r explicitly (Windows line endings) before tokenizing,
+  // rather than relying on incidental whole-line trimming.
+  const rawLines = text.split('\n').map(l => l.replace(/\r$/, ''))
+  const lines = rawLines.filter(l => l.trim().length > 0)
   if (lines.length < 2) return []
-  const header = lines[0].toLowerCase().split(',').map(h => h.trim())
+  const header = splitCsvLine(lines[0]).map(h => h.trim().toLowerCase())
   const nameIdx = header.findIndex(h => h === 'name')
   const parentIdx = header.findIndex(h => h === 'parent' || h === 'parent_name')
   if (nameIdx < 0) return []
 
-  const rows: { name: string; parent_name: string; org_type: string }[] = []
-  // Build depth map for auto-type assignment
-  const depthOf: Record<string, number> = {}
-
+  // Phase 1: collect raw rows (name + parent_name) in file order, with no
+  // depth computation yet — CSV row order is not guaranteed to be
+  // topological (a child row may appear before its parent).
+  const raw: { name: string; parent_name: string }[] = []
   for (let i = 1; i < lines.length; i++) {
-    const cols = lines[i].split(',').map(c => c.trim())
+    const cols = splitCsvLine(lines[i])
     const name = cols[nameIdx] || ''
     const parent = parentIdx >= 0 ? (cols[parentIdx] || '') : ''
     if (!name) continue
-    const parentDepth = parent ? (depthOf[parent] ?? 0) : -1
-    const myDepth = parentDepth + 1
-    depthOf[name] = myDepth
+    raw.push({ name, parent_name: parent })
+  }
+
+  // Phase 2: resolve each row's depth order-independently by walking up the
+  // parent chain, memoizing as we go. A dangling parent reference (a name
+  // that never appears as any row's `name`) is treated as depth 0, matching
+  // today's fallback behavior. The walk is capped at the number of rows and
+  // tracks the names currently being resolved, so a cyclic reference
+  // (A -> B -> A) cannot recurse forever.
+  const parentOf: Record<string, string> = {}
+  for (const r of raw) if (r.parent_name) parentOf[r.name] = r.parent_name
+
+  const depthCache: Record<string, number> = {}
+  const cap = raw.length
+  const resolveDepth = (name: string, visiting: Set<string>): number => {
+    if (name in depthCache) return depthCache[name]
+    if (visiting.has(name) || visiting.size >= cap) return 0
+    const parent = parentOf[name]
+    if (!parent) { depthCache[name] = 0; return 0 }
+    visiting.add(name)
+    const depth = resolveDepth(parent, visiting) + 1
+    visiting.delete(name)
+    depthCache[name] = depth
+    return depth
+  }
+
+  const rows: { name: string; parent_name: string; org_type: string }[] = []
+  for (const r of raw) {
+    const myDepth = resolveDepth(r.name, new Set())
     const autoType = DEPTH_TYPE_DEFAULTS[Math.min(myDepth, DEPTH_TYPE_DEFAULTS.length - 1)]
-    rows.push({ name, parent_name: parent, org_type: autoType })
+    rows.push({ name: r.name, parent_name: r.parent_name, org_type: autoType })
   }
   return rows
 }
@@ -264,12 +335,21 @@ function ImportDialog({ onClose, onImported }: { onClose: () => void; onImported
     if (!file) return
     const reader = new FileReader()
     reader.onload = (ev) => {
-      const text = ev.target?.result as string
-      const parsed = parseCSV(text)
-      if (parsed.length === 0) { setError('No valid rows found. CSV must have a "name" column.'); return }
+      const result = ev.target?.result
+      if (typeof result !== 'string') {
+        setError('Could not read the file as text.')
+        return
+      }
+      const lines = result.split('\n').map(l => l.replace(/\r$/, '')).filter(l => l.trim().length > 0)
+      if (lines.length === 0) { setError('The CSV file is empty.'); return }
+      const header = splitCsvLine(lines[0]).map(h => h.trim().toLowerCase())
+      if (!header.includes('name')) { setError('CSV must have a "name" column.'); return }
+      const parsed = parseCSV(result)
+      if (parsed.length === 0) { setError('CSV has a "name" column but no data rows.'); return }
       setError(null)
       setRows(parsed)
     }
+    reader.onerror = () => { setError('Failed to read the file.') }
     reader.readAsText(file)
   }
 

--- a/frontend/src/components/admin/QualityTab.tsx
+++ b/frontend/src/components/admin/QualityTab.tsx
@@ -14,23 +14,8 @@ import {
   type QualityTimelinePoint, type RegressionResult, type SystemConfigData,
 } from '../../api/admin'
 import { relativeTime } from '../../utils/time'
+import { downloadCSV } from './shared/format'
 import { ExportButton, KpiCard, SortableHeader } from './shared/primitives'
-
-function downloadCSV(filename: string, headers: string[], rows: (string | number | null)[][]) {
-  const escape = (v: string | number | null) => {
-    if (v === null || v === undefined) return ''
-    const s = String(v)
-    return s.includes(',') || s.includes('"') || s.includes('\n') ? `"${s.replace(/"/g, '""')}"` : s
-  }
-  const csv = [headers.join(','), ...rows.map(r => r.map(escape).join(','))].join('\n')
-  const blob = new Blob([csv], { type: 'text/csv' })
-  const url = URL.createObjectURL(blob)
-  const a = document.createElement('a')
-  a.href = url
-  a.download = filename
-  a.click()
-  URL.revokeObjectURL(url)
-}
 
 export function QualityTab() {
   const [summary, setSummary] = useState<QualitySummary | null>(null)

--- a/frontend/src/components/admin/TeamsTab.tsx
+++ b/frontend/src/components/admin/TeamsTab.tsx
@@ -17,42 +17,10 @@ import {
   type TeamDetailResponse,
   type AdminTeamItem, type IsolatedUserItem,
 } from '../../api/admin'
-import { formatNumber, formatDuration } from './shared/format'
+import { downloadCSV, formatDate, formatDateTime, formatDuration, formatNumber } from './shared/format'
 import {
   StatusBadge, RoleBadge, KpiCard, UserAvatar, SortableHeader, SearchInput, ExportButton, TimeRangeSelector, type DayOption,
 } from './shared/primitives'
-
-function parseUtcDate(d: string): Date {
-  // Backend stores UTC but may omit timezone suffix; ensure JS treats it as UTC
-  if (!d.endsWith('Z') && !d.includes('+') && !d.includes('-', 10)) return new Date(d + 'Z')
-  return new Date(d)
-}
-
-function formatDate(d: string | null): string {
-  if (!d) return '-'
-  return parseUtcDate(d).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
-}
-
-function formatDateTime(d: string | null): string {
-  if (!d) return '-'
-  return parseUtcDate(d).toLocaleString('en-US', { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' })
-}
-
-function downloadCSV(filename: string, headers: string[], rows: (string | number | null)[][]) {
-  const escape = (v: string | number | null) => {
-    if (v === null || v === undefined) return ''
-    const s = String(v)
-    return s.includes(',') || s.includes('"') || s.includes('\n') ? `"${s.replace(/"/g, '""')}"` : s
-  }
-  const csv = [headers.join(','), ...rows.map(r => r.map(escape).join(','))].join('\n')
-  const blob = new Blob([csv], { type: 'text/csv' })
-  const url = URL.createObjectURL(blob)
-  const a = document.createElement('a')
-  a.href = url
-  a.download = filename
-  a.click()
-  URL.revokeObjectURL(url)
-}
 
 type TeamSortKey = 'name' | 'tokens_total' | 'workflows_completed' | 'active_users' | 'member_count' | 'avg_latency_ms'
 

--- a/frontend/src/components/admin/UsageTab.tsx
+++ b/frontend/src/components/admin/UsageTab.tsx
@@ -10,26 +10,10 @@ import {
   getUsageStats, getUsageTimeseries,
 } from '../../api/admin'
 import type { UsageStats, TimeseriesResponse } from '../../api/admin'
-import { formatNumber } from './shared/format'
+import { downloadCSV, formatNumber } from './shared/format'
 import { TrendDelta, KpiCard, ExportButton, TimeRangeSelector } from './shared/primitives'
 
 const CHART_COLORS = ['#3b82f6', '#22c55e', '#f59e0b', '#ef4444', '#8b5cf6', '#06b6d4']
-
-function downloadCSV(filename: string, headers: string[], rows: (string | number | null)[][]) {
-  const escape = (v: string | number | null) => {
-    if (v === null || v === undefined) return ''
-    const s = String(v)
-    return s.includes(',') || s.includes('"') || s.includes('\n') ? `"${s.replace(/"/g, '""')}"` : s
-  }
-  const csv = [headers.join(','), ...rows.map(r => r.map(escape).join(','))].join('\n')
-  const blob = new Blob([csv], { type: 'text/csv' })
-  const url = URL.createObjectURL(blob)
-  const a = document.createElement('a')
-  a.href = url
-  a.download = filename
-  a.click()
-  URL.revokeObjectURL(url)
-}
 
 export function UsageTab() {
   const [stats, setStats] = useState<UsageStats | null>(null)

--- a/frontend/src/components/admin/UsersTab.tsx
+++ b/frontend/src/components/admin/UsersTab.tsx
@@ -14,42 +14,10 @@ import type {
 } from '../../api/admin'
 import * as auditApi from '../../api/audit'
 import { useAuth } from '../../hooks/useAuth'
-import { formatNumber, formatDuration } from './shared/format'
+import { downloadCSV, formatDate, formatDateTime, formatDuration, formatNumber } from './shared/format'
 import {
   StatusBadge, RoleBadge, KpiCard, UserAvatar, SortableHeader, SearchInput, ExportButton, TimeRangeSelector, type DayOption,
 } from './shared/primitives'
-
-function parseUtcDate(d: string): Date {
-  // Backend stores UTC but may omit timezone suffix; ensure JS treats it as UTC
-  if (!d.endsWith('Z') && !d.includes('+') && !d.includes('-', 10)) return new Date(d + 'Z')
-  return new Date(d)
-}
-
-function formatDate(d: string | null): string {
-  if (!d) return '-'
-  return parseUtcDate(d).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
-}
-
-function formatDateTime(d: string | null): string {
-  if (!d) return '-'
-  return parseUtcDate(d).toLocaleString('en-US', { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' })
-}
-
-function downloadCSV(filename: string, headers: string[], rows: (string | number | null)[][]) {
-  const escape = (v: string | number | null) => {
-    if (v === null || v === undefined) return ''
-    const s = String(v)
-    return s.includes(',') || s.includes('"') || s.includes('\n') ? `"${s.replace(/"/g, '""')}"` : s
-  }
-  const csv = [headers.join(','), ...rows.map(r => r.map(escape).join(','))].join('\n')
-  const blob = new Blob([csv], { type: 'text/csv' })
-  const url = URL.createObjectURL(blob)
-  const a = document.createElement('a')
-  a.href = url
-  a.download = filename
-  a.click()
-  URL.revokeObjectURL(url)
-}
 
 type UserSortKey = 'tokens_total' | 'workflows_run' | 'conversations' | 'last_active' | 'name'
 

--- a/frontend/src/components/admin/WorkflowsTab.tsx
+++ b/frontend/src/components/admin/WorkflowsTab.tsx
@@ -2,35 +2,8 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { ChevronDown, ChevronLeft, ChevronRight } from 'lucide-react'
 
 import { getWorkflowEvents, type PaginatedWorkflows } from '../../api/admin'
-import { formatDuration, formatNumber } from './shared/format'
+import { downloadCSV, formatDateTime, formatDuration, formatNumber } from './shared/format'
 import { ExportButton, SearchInput, StatusBadge, UserAvatar } from './shared/primitives'
-
-function parseUtcDate(d: string): Date {
-  // Backend stores UTC but may omit timezone suffix; ensure JS treats it as UTC
-  if (!d.endsWith('Z') && !d.includes('+') && !d.includes('-', 10)) return new Date(d + 'Z')
-  return new Date(d)
-}
-
-function formatDateTime(d: string | null): string {
-  if (!d) return '-'
-  return parseUtcDate(d).toLocaleString('en-US', { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' })
-}
-
-function downloadCSV(filename: string, headers: string[], rows: (string | number | null)[][]) {
-  const escape = (v: string | number | null) => {
-    if (v === null || v === undefined) return ''
-    const s = String(v)
-    return s.includes(',') || s.includes('"') || s.includes('\n') ? `"${s.replace(/"/g, '""')}"` : s
-  }
-  const csv = [headers.join(','), ...rows.map(r => r.map(escape).join(','))].join('\n')
-  const blob = new Blob([csv], { type: 'text/csv' })
-  const url = URL.createObjectURL(blob)
-  const a = document.createElement('a')
-  a.href = url
-  a.download = filename
-  a.click()
-  URL.revokeObjectURL(url)
-}
 
 export function WorkflowsTab() {
   const [data, setData] = useState<PaginatedWorkflows | null>(null)

--- a/frontend/src/components/admin/shared/format.test.ts
+++ b/frontend/src/components/admin/shared/format.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi } from 'vitest'
+import { downloadCSV, formatDate, formatDateTime, parseUtcDate } from './format'
+
+/** downloadCSV writes to a Blob via a synthetic <a> download; to assert on the
+ * generated CSV text we intercept the Blob passed to URL.createObjectURL
+ * (and no-op the DOM side effects) rather than touching escape() directly,
+ * since it's a private closure. */
+function captureCSV(run: () => void): Promise<string> {
+  let captured: Blob | null = null
+  const createSpy = vi.spyOn(URL, 'createObjectURL').mockImplementation((obj: Blob | MediaSource) => {
+    captured = obj as Blob
+    return 'blob:mock'
+  })
+  const revokeSpy = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {})
+  const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {})
+  try {
+    run()
+  } finally {
+    createSpy.mockRestore()
+    revokeSpy.mockRestore()
+    clickSpy.mockRestore()
+  }
+  return captured!.text()
+}
+
+describe('downloadCSV escaping', () => {
+  it('prefixes a value starting with = with an apostrophe', async () => {
+    const csv = await captureCSV(() => downloadCSV('f.csv', ['Col'], [['=SUM(A1:A9)']]))
+    expect(csv).toBe('Col\n\'=SUM(A1:A9)')
+  })
+
+  it('prefixes a value starting with + with an apostrophe', async () => {
+    const csv = await captureCSV(() => downloadCSV('f.csv', ['Col'], [['+1234']]))
+    expect(csv).toBe('Col\n\'+1234')
+  })
+
+  it('prefixes a value starting with - with an apostrophe', async () => {
+    const csv = await captureCSV(() => downloadCSV('f.csv', ['Col'], [['-1234']]))
+    expect(csv).toBe('Col\n\'-1234')
+  })
+
+  it('prefixes a value starting with @ with an apostrophe', async () => {
+    const csv = await captureCSV(() => downloadCSV('f.csv', ['Col'], [['@cmd']]))
+    expect(csv).toBe('Col\n\'@cmd')
+  })
+
+  it('prefixes a value starting with a tab with an apostrophe', async () => {
+    const csv = await captureCSV(() => downloadCSV('f.csv', ['Col'], [['\tpayload']]))
+    expect(csv).toBe('Col\n\'\tpayload')
+  })
+
+  it('prefixes a value starting with a CR with an apostrophe', async () => {
+    const csv = await captureCSV(() => downloadCSV('f.csv', ['Col'], [['\rpayload']]))
+    expect(csv).toBe('Col\n\'\rpayload')
+  })
+
+  it('still quotes a value containing a comma', async () => {
+    const csv = await captureCSV(() => downloadCSV('f.csv', ['Col'], [['Smith, Jane']]))
+    expect(csv).toBe('Col\n"Smith, Jane"')
+  })
+
+  it('still escapes a value containing a double quote', async () => {
+    const csv = await captureCSV(() => downloadCSV('f.csv', ['Col'], [['She said "hi"']]))
+    expect(csv).toBe('Col\n"She said ""hi"""')
+  })
+
+  it('leaves a plain value unchanged', async () => {
+    const csv = await captureCSV(() => downloadCSV('f.csv', ['Col'], [['Hello']]))
+    expect(csv).toBe('Col\nHello')
+  })
+
+  it('prefixes a lone hyphen placeholder (starts with -) with an apostrophe', async () => {
+    // Several tabs pass a literal '-' as a placeholder for missing data. It
+    // starts with '-', so the injection guard applies to it the same as any
+    // other value — asserting this explicitly so the tradeoff is intentional,
+    // not an accident of the regex.
+    const csv = await captureCSV(() => downloadCSV('f.csv', ['Col'], [['-']]))
+    expect(csv).toBe("Col\n'-")
+  })
+})
+
+describe('parseUtcDate', () => {
+  it('treats a suffix-less timestamp as UTC', () => {
+    const d = parseUtcDate('2026-07-24T10:00:00')
+    expect(d.toISOString()).toBe('2026-07-24T10:00:00.000Z')
+  })
+
+  it('leaves a Z-suffixed timestamp unchanged', () => {
+    const d = parseUtcDate('2026-07-24T10:00:00Z')
+    expect(d.toISOString()).toBe('2026-07-24T10:00:00.000Z')
+  })
+
+  it('respects a positive offset', () => {
+    const d = parseUtcDate('2026-07-24T10:00:00+05:00')
+    expect(d.toISOString()).toBe('2026-07-24T05:00:00.000Z')
+  })
+
+  it('respects a negative offset and returns a valid Date, not Invalid Date (regression)', () => {
+    const d = parseUtcDate('2026-07-24T10:00:00-07:00')
+    expect(Number.isNaN(d.getTime())).toBe(false)
+    expect(d.toISOString()).toBe('2026-07-24T17:00:00.000Z')
+  })
+})
+
+describe('formatDate / formatDateTime', () => {
+  it('formatDate returns the em-dash placeholder for null', () => {
+    expect(formatDate(null)).toBe('—')
+  })
+
+  it('formatDate returns the em-dash placeholder for an unparseable string', () => {
+    expect(formatDate('not-a-real-date')).toBe('—')
+  })
+
+  it('formatDateTime returns the em-dash placeholder for null', () => {
+    expect(formatDateTime(null)).toBe('—')
+  })
+
+  it('formatDateTime returns the em-dash placeholder for an unparseable string', () => {
+    expect(formatDateTime('not-a-real-date')).toBe('—')
+  })
+
+  it('formatDateTime output contains the 4-digit year', () => {
+    const out = formatDateTime('2026-07-24T10:00:00Z')
+    expect(out).toMatch(/2026/)
+  })
+})

--- a/frontend/src/components/admin/shared/format.ts
+++ b/frontend/src/components/admin/shared/format.ts
@@ -13,3 +13,39 @@ export function formatDuration(ms: number | null): string {
   const remainSecs = Math.round(secs % 60)
   return `${mins}m ${remainSecs}s`
 }
+
+export function parseUtcDate(d: string): Date {
+  // Backend stores UTC but may omit timezone suffix; ensure JS treats it as UTC
+  if (!d.endsWith('Z') && !d.includes('+') && !d.includes('-', 10)) return new Date(d + 'Z')
+  return new Date(d)
+}
+
+export function formatDate(d: string | null): string {
+  if (!d) return '—'
+  const date = parseUtcDate(d)
+  if (Number.isNaN(date.getTime())) return '—'
+  return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
+}
+
+export function formatDateTime(d: string | null): string {
+  if (!d) return '—'
+  const date = parseUtcDate(d)
+  if (Number.isNaN(date.getTime())) return '—'
+  return date.toLocaleString('en-US', { month: 'short', day: 'numeric', year: 'numeric', hour: 'numeric', minute: '2-digit' })
+}
+
+export function downloadCSV(filename: string, headers: string[], rows: (string | number | null)[][]) {
+  const escape = (v: string | number | null) => {
+    if (v === null || v === undefined) return ''
+    const s = String(v)
+    return s.includes(',') || s.includes('"') || s.includes('\n') ? `"${s.replace(/"/g, '""')}"` : s
+  }
+  const csv = [headers.join(','), ...rows.map(r => r.map(escape).join(','))].join('\n')
+  const blob = new Blob([csv], { type: 'text/csv' })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = filename
+  a.click()
+  URL.revokeObjectURL(url)
+}

--- a/frontend/src/components/admin/shared/format.ts
+++ b/frontend/src/components/admin/shared/format.ts
@@ -37,7 +37,10 @@ export function formatDateTime(d: string | null): string {
 export function downloadCSV(filename: string, headers: string[], rows: (string | number | null)[][]) {
   const escape = (v: string | number | null) => {
     if (v === null || v === undefined) return ''
-    const s = String(v)
+    let s = String(v)
+    // Guard against formula injection: a leading =, +, -, @, tab, or CR can be
+    // interpreted as a formula by spreadsheet apps opening the exported CSV.
+    if (/^[=+\-@\t\r]/.test(s)) s = `'${s}`
     return s.includes(',') || s.includes('"') || s.includes('\n') ? `"${s.replace(/"/g, '""')}"` : s
   }
   const csv = [headers.join(','), ...rows.map(r => r.map(escape).join(','))].join('\n')


### PR DESCRIPTION
## Summary

Continuation of the admin-panel work from #576/#577/#578 (Admin.tsx decomposition). This PR fixes a real CSV-export vulnerability and hardens the org CSV import.

## Changes

- `downloadCSV` now safe-quotes any field value starting with `=`, `+`, `-`, or `@` (CSV/formula injection) before writing, so a crafted org name/email can't execute a formula (including data-exfiltration via `HYPERLINK`) when the export is opened in Excel/Sheets.
- The org CSV importer is now quote-aware (commas inside a quoted field no longer split incorrectly) and parses by header name instead of column position.
- Parsed org rows are sorted parent-before-child so an import never references a parent org that hasn't been created yet.
- Consolidated duplicated date/CSV helper functions into `shared/format.ts`.

## Test Plan

- [x] Shared checks pass (`make ci` equivalent — frontend typecheck/lint/coverage/build all clean; verified locally in Docker)
- [x] Manually reasoned through the injection fix against the standard CSV-injection payload classes (`=`, `+`, `-`, `@` prefixes)

## Related Issues

Stacked on #578 (base: `main`, which already includes #576/#577/#578).
