### PR TITLE
fix(workflows): failed steps fail the run instead of posing as results

### DIFF
--- a/backend/app/services/workflow_engine.py
+++ b/backend/app/services/workflow_engine.py
@@ -422,17 +422,25 @@ class MultiTaskNode(Node):
         task_step_name = self.name
         merged_sources: list[dict] = []
         warnings: list[str] = []
+        errors: list[str] = []
+        request_preview = None
         for result in results:
             if result.get("_approval_pause"):
                 return result
-            # Citations and warnings must survive the wrapper even when a task
-            # produced no output (e.g. a failed KB lookup reports a warning).
+            # Citations, warnings, errors, and the API request preview must
+            # survive the wrapper even when a task produced no output (e.g. a
+            # failed KB lookup reports a warning, a blocked API call an error).
             sources = result.get("retrieved_sources")
             if isinstance(sources, list):
                 merged_sources.extend(sources)
             warning = result.get("warning")
             if isinstance(warning, str) and warning:
                 warnings.append(warning)
+            error = result.get("error")
+            if isinstance(error, str) and error:
+                errors.append(error)
+            if isinstance(result.get("request"), dict):
+                request_preview = result["request"]
             result_output = result.get("output")
             if result_output is None:
                 continue
@@ -452,6 +460,10 @@ class MultiTaskNode(Node):
             out["retrieved_sources"] = merged_sources
         if warnings:
             out["warning"] = " | ".join(warnings)
+        if errors:
+            out["error"] = " | ".join(errors)
+        if request_preview is not None:
+            out["request"] = request_preview
         return out
 
 
@@ -587,16 +599,22 @@ class WebsiteNode(Node):
         from app.services.web_fetcher import fetch_url_sync
 
         self.report_progress(f"Fetching {url}")
+        error = None
         try:
             result = fetch_url_sync(url)
             text = result.text
         except ValueError as e:
-            text = f"Blocked URL: {e}"
+            error = f"Blocked URL: {e}"
+            text = error
         except (httpx.HTTPStatusError, httpx.RequestError) as e:
             from app.utils.fetch_errors import describe_fetch_error
 
-            text = f"Could not fetch {url}: {describe_fetch_error(e)}"
-        return {"output": text, "input": inputs.get("output"), "step_name": self.name}
+            error = f"Could not fetch {url}: {describe_fetch_error(e)}"
+            text = error
+        out = {"output": text, "input": inputs.get("output"), "step_name": self.name}
+        if error:
+            out["error"] = error
+        return out
 
 
 class AddDocumentNode(Node):
@@ -657,6 +675,7 @@ class CodeExecutionNode(Node):
         except (ValueError, SyntaxError) as e:
             return {
                 "output": f"Code rejected: {e}",
+                "error": f"Code rejected: {e}",
                 "input": inputs.get("output"),
                 "step_name": self.name,
             }
@@ -668,8 +687,10 @@ class CodeExecutionNode(Node):
         )
 
         if result.get("timed_out"):
+            timeout_msg = f"Code execution timed out after {self.CODE_TIMEOUT_SECONDS} seconds"
             return {
-                "output": f"Code execution timed out after {self.CODE_TIMEOUT_SECONDS} seconds",
+                "output": timeout_msg,
+                "error": timeout_msg,
                 "input": inputs.get("output"),
                 "step_name": self.name,
             }
@@ -677,6 +698,7 @@ class CodeExecutionNode(Node):
         if "error" in result:
             return {
                 "output": f"Code execution error: {result['error']}",
+                "error": f"Code execution error: {result['error']}",
                 "input": inputs.get("output"),
                 "step_name": self.name,
             }
@@ -705,7 +727,12 @@ class CrawlerNode(Node):
         try:
             validate_outbound_url(start_url)
         except ValueError as e:
-            return {"output": f"Blocked URL: {e}", "input": inputs.get("output"), "step_name": self.name}
+            return {
+                "output": f"Blocked URL: {e}",
+                "error": f"Blocked URL: {e}",
+                "input": inputs.get("output"),
+                "step_name": self.name,
+            }
 
         from app.utils.bot_challenge import looks_like_bot_challenge
         from app.utils.crawl_scope import parse_crawl_scope, url_in_crawl_scope
@@ -896,6 +923,19 @@ class APICallNode(Node):
         super().__init__("APINode")
         self.data = data
 
+    def _error_result(self, message: str, inputs, *, output=None, request=None) -> dict:
+        """A failed-step result: ``error`` carries the concise failure message
+        (becomes the run's error), ``output`` the full diagnostic text."""
+        result = {
+            "output": output if output is not None else message,
+            "error": message,
+            "input": inputs.get("output"),
+            "step_name": self.name,
+        }
+        if request is not None:
+            result["request"] = request
+        return result
+
     def process(self, inputs):
         from app.utils import templating
 
@@ -914,7 +954,7 @@ class APICallNode(Node):
                 self.data.get("headers", ""), inputs, json_encode=False
             )
         except templating.TemplateError as e:
-            return {"output": str(e), "input": inputs.get("output"), "step_name": self.name}
+            return self._error_result(str(e), inputs)
         body_raw = self.data.get("body", "")
         if not url:
             return {"output": "", "input": inputs.get("output"), "step_name": self.name}
@@ -924,7 +964,7 @@ class APICallNode(Node):
         try:
             validate_outbound_url(url)
         except ValueError as e:
-            return {"output": f"Blocked URL: {e}", "input": inputs.get("output"), "step_name": self.name}
+            return self._error_result(f"Blocked URL: {e}", inputs)
 
         self.report_progress(f"{method} {url}")
         headers: dict[str, str] = {}
@@ -932,33 +972,25 @@ class APICallNode(Node):
             try:
                 parsed = json.loads(headers_raw)
             except json.JSONDecodeError as e:
-                return {
-                    "output": (
-                        f"Invalid Headers JSON: {e}. "
-                        "Check for smart quotes or other invisible characters."
-                    ),
-                    "input": inputs.get("output"),
-                    "step_name": self.name,
-                }
+                return self._error_result(
+                    f"Invalid Headers JSON: {e}. "
+                    "Check for smart quotes or other invisible characters.",
+                    inputs,
+                )
             if not isinstance(parsed, dict):
-                return {
-                    "output": (
-                        "Invalid Headers JSON: expected an object like "
-                        '{"x-api-key": "..."}'
-                    ),
-                    "input": inputs.get("output"),
-                    "step_name": self.name,
-                }
+                return self._error_result(
+                    'Invalid Headers JSON: expected an object like {"x-api-key": "..."}',
+                    inputs,
+                )
             headers = {str(k): str(v) for k, v in parsed.items()}
 
         # Apply credential-based auth (overrides any conflicting header).
         if auth_strategy != "none":
             if not credential_id:
-                return {
-                    "output": f"API Node auth_strategy {auth_strategy!r} requires credential_id",
-                    "input": inputs.get("output"),
-                    "step_name": self.name,
-                }
+                return self._error_result(
+                    f"API Node auth_strategy {auth_strategy!r} requires credential_id",
+                    inputs,
+                )
             from app.services import credentials_service
 
             try:
@@ -966,34 +998,19 @@ class APICallNode(Node):
                 cred_doc = credentials_service.fetch_credential_sync(db, credential_id)
             except Exception as e:
                 logger.exception("Credential lookup failed")
-                return {
-                    "output": f"Credential lookup failed: {e}",
-                    "input": inputs.get("output"),
-                    "step_name": self.name,
-                }
+                return self._error_result(f"Credential lookup failed: {e}", inputs)
             if not cred_doc:
-                return {
-                    "output": f"Credential {credential_id!r} not found",
-                    "input": inputs.get("output"),
-                    "step_name": self.name,
-                }
+                return self._error_result(f"Credential {credential_id!r} not found", inputs)
             if cred_doc.get("type") != auth_strategy:
-                return {
-                    "output": (
-                        f"Credential type {cred_doc.get('type')!r} does not match "
-                        f"auth_strategy {auth_strategy!r}"
-                    ),
-                    "input": inputs.get("output"),
-                    "step_name": self.name,
-                }
+                return self._error_result(
+                    f"Credential type {cred_doc.get('type')!r} does not match "
+                    f"auth_strategy {auth_strategy!r}",
+                    inputs,
+                )
             try:
                 credentials_service.apply_auth(credential_doc=cred_doc, headers=headers)
             except credentials_service.CredentialError as e:
-                return {
-                    "output": f"Auth setup failed: {e}",
-                    "input": inputs.get("output"),
-                    "step_name": self.name,
-                }
+                return self._error_result(f"Auth setup failed: {e}", inputs)
 
         body = None
         body_is_json = False
@@ -1005,11 +1022,7 @@ class APICallNode(Node):
                 try:
                     rendered_body = templating.render(body_raw, inputs, json_encode=True)
                 except templating.TemplateError as e:
-                    return {
-                        "output": str(e),
-                        "input": inputs.get("output"),
-                        "step_name": self.name,
-                    }
+                    return self._error_result(str(e), inputs)
                 try:
                     parsed = json.loads(rendered_body)
                 except json.JSONDecodeError:
@@ -1062,25 +1075,21 @@ class APICallNode(Node):
                 resp = client.request(method, url, headers=headers, json=body if isinstance(body, (dict, list)) else None, content=body if isinstance(body, str) else None)
                 resp.raise_for_status()
         except httpx.HTTPStatusError as e:
-            return {
-                "output": (
-                    f"HTTP error: {e.response.status_code} {e.response.text[:500]}\n\n"
-                    f"--- Request sent ---\n{_format_request_preview(request_preview)}"
-                ),
-                "input": inputs.get("output"),
-                "step_name": self.name,
-                "request": request_preview,
-            }
+            message = f"HTTP error: {e.response.status_code} {e.response.text[:500]}"
+            return self._error_result(
+                message,
+                inputs,
+                output=f"{message}\n\n--- Request sent ---\n{_format_request_preview(request_preview)}",
+                request=request_preview,
+            )
         except httpx.RequestError as e:
-            return {
-                "output": (
-                    f"Request error: {e}\n\n"
-                    f"--- Request sent ---\n{_format_request_preview(request_preview)}"
-                ),
-                "input": inputs.get("output"),
-                "step_name": self.name,
-                "request": request_preview,
-            }
+            message = f"Request error: {e}"
+            return self._error_result(
+                message,
+                inputs,
+                output=f"{message}\n\n--- Request sent ---\n{_format_request_preview(request_preview)}",
+                request=request_preview,
+            )
 
         try:
             output = resp.json()
@@ -1469,6 +1478,21 @@ class WorkflowCancelled(Exception):
     ``canceled``), not an error, and must not retry the task."""
 
 
+class WorkflowStepError(Exception):
+    """Raised inside execute() when a step reports a failure via the ``error``
+    key on its result dict (blocked URL, HTTP failure, bad config, ...).
+
+    Callers should mark the run failed with this message and must not retry
+    the task — the failure is deterministic, not transient. The step's full
+    result (including any request preview) is persisted to steps_output
+    before this is raised, so the run record keeps the debugging detail."""
+
+    def __init__(self, step_name: str, message: str) -> None:
+        self.step_name = step_name
+        self.message = message
+        super().__init__(f"{step_name} step failed: {message}")
+
+
 class WorkflowEngine:
     def __init__(self) -> None:
         self.nodes: list[Node] = []
@@ -1564,6 +1588,14 @@ class WorkflowEngine:
                     "num_steps_completed": idx,
                 })
 
+            # A step that reported a failure halts the run. Its error text must
+            # not flow downstream as step input or become the deliverable — the
+            # run fails with the step's message. The full step result (request
+            # preview etc.) was persisted to steps_output just above.
+            step_error = latest_output.get("error") if isinstance(latest_output, dict) else None
+            if isinstance(step_error, str) and step_error:
+                raise WorkflowStepError(node.name, step_error)
+
             entry = {
                 "name": node.name,
                 "output": latest_output.get("output"),
@@ -1637,6 +1669,8 @@ def _output_looks_empty_or_error(output: dict | None) -> bool:
     obviously dead outputs so we don't pay a retry on every borderline run.
     """
     if not output:
+        return True
+    if output.get("error"):
         return True
     val = output.get("output")
     if val is None:

--- a/backend/app/services/workflow_engine.py
+++ b/backend/app/services/workflow_engine.py
@@ -1487,10 +1487,21 @@ class WorkflowStepError(Exception):
     result (including any request preview) is persisted to steps_output
     before this is raised, so the run record keeps the debugging detail."""
 
-    def __init__(self, step_name: str, message: str) -> None:
+    def __init__(self, step_name: str, message: str, step_output: dict | None = None) -> None:
         self.step_name = step_name
         self.message = message
-        super().__init__(f"{step_name} step failed: {message}")
+        # Not part of args: it exists for in-process callers (e.g. Test Step)
+        # that want the full step result — request preview and all — without
+        # it having to survive a result-backend round trip.
+        self.step_output = step_output
+        # args must stay exactly the constructor's required arguments: Celery's
+        # JSON result backend reconstructs exceptions as cls(*args), so a
+        # single pre-formatted string here would make reconstruction fall back
+        # to a mangled generic Exception on every poll of a failed task.
+        super().__init__(step_name, message)
+
+    def __str__(self) -> str:
+        return f"{self.step_name} step failed: {self.message}"
 
 
 class WorkflowEngine:
@@ -1594,7 +1605,7 @@ class WorkflowEngine:
             # preview etc.) was persisted to steps_output just above.
             step_error = latest_output.get("error") if isinstance(latest_output, dict) else None
             if isinstance(step_error, str) and step_error:
-                raise WorkflowStepError(node.name, step_error)
+                raise WorkflowStepError(node.name, step_error, step_output=latest_output)
 
             entry = {
                 "name": node.name,

--- a/backend/app/services/workflow_service.py
+++ b/backend/app/services/workflow_service.py
@@ -829,13 +829,18 @@ async def test_step(task_name: str, task_data: dict, document_uuids: list[str], 
 
 def get_test_status(task_id: str) -> dict:
     """Poll a step test Celery task."""
+    from app.services.workflow_engine import WorkflowStepError
+
     result = AsyncResult(task_id, app=celery_app)
     if not result.ready():
         return {"status": result.state}
     if result.successful():
         return {"status": "completed", "result": result.result}
     payload = result.result
-    if isinstance(payload, BaseException):
+    if isinstance(payload, WorkflowStepError):
+        # Step failures carry a user-facing message already — no class prefix.
+        error_text = str(payload)
+    elif isinstance(payload, BaseException):
         error_text = f"{type(payload).__name__}: {payload}"
     else:
         error_text = str(payload) if payload else "Test failed"

--- a/backend/app/services/workflow_service.py
+++ b/backend/app/services/workflow_service.py
@@ -835,7 +835,16 @@ def get_test_status(task_id: str) -> dict:
     if not result.ready():
         return {"status": result.state}
     if result.successful():
-        return {"status": "completed", "result": result.result}
+        payload = result.result
+        # A deterministic step failure is returned (not raised) by the test
+        # task so it doesn't retry or land in Sentry — surface it as a failure.
+        if isinstance(payload, dict) and payload.get("step_test_failed"):
+            return {
+                "status": "failed",
+                "error": payload.get("error") or "Test failed",
+                "output": payload.get("output"),
+            }
+        return {"status": "completed", "result": payload}
     payload = result.result
     if isinstance(payload, WorkflowStepError):
         # Step failures carry a user-facing message already — no class prefix.

--- a/backend/app/tasks/passive_tasks.py
+++ b/backend/app/tasks/passive_tasks.py
@@ -522,6 +522,8 @@ def execute_workflow_passive(self, trigger_event_id: str) -> dict:
         }
 
     except Exception as e:
+        from app.services.workflow_engine import WorkflowStepError
+
         logger.error("Passive execution failed for event %s: %s", event.get("uuid"), e)
 
         # Mark the run's WorkflowResult failed too (when it got created) so it
@@ -559,12 +561,15 @@ def execute_workflow_passive(self, trigger_event_id: str) -> dict:
             }},
         )
 
-        # Check retry
+        # Check retry. A WorkflowStepError is a deterministic failure (blocked
+        # URL, bad config, HTTP error the step itself reported) — re-running
+        # cannot succeed and each attempt would mint another failed
+        # WorkflowResult, so it skips straight to the failure callback.
         retry_cfg = (workflow.get("resource_config") or {}).get("retry", {})
         max_retries = retry_cfg.get("max_retries", 3)
         attempt = event.get("attempt_number", 1)
 
-        if attempt < max_retries:
+        if not isinstance(e, WorkflowStepError) and attempt < max_retries:
             retry_delay = retry_cfg.get("retry_delay_seconds", 300)
             next_retry = datetime.now(timezone.utc) + timedelta(seconds=retry_delay)
             db.workflow_trigger_event.update_one(

--- a/backend/app/tasks/passive_tasks.py
+++ b/backend/app/tasks/passive_tasks.py
@@ -370,6 +370,7 @@ def execute_workflow_passive(self, trigger_event_id: str) -> dict:
 
     now = datetime.now(timezone.utc)
     sys_config = db.system_config.find_one() or {}
+    result_id = None
 
     try:
         # Mark running
@@ -522,6 +523,14 @@ def execute_workflow_passive(self, trigger_event_id: str) -> dict:
 
     except Exception as e:
         logger.error("Passive execution failed for event %s: %s", event.get("uuid"), e)
+
+        # Mark the run's WorkflowResult failed too (when it got created) so it
+        # doesn't sit in "running" forever in the run history.
+        if result_id is not None:
+            db.workflow_result.update_one(
+                {"_id": result_id},
+                {"$set": {"status": "error", "error": str(e)}},
+            )
 
         completed_at = datetime.now(timezone.utc)
         started_at = event.get("started_at") or now

--- a/backend/app/tasks/workflow_tasks.py
+++ b/backend/app/tasks/workflow_tasks.py
@@ -332,6 +332,7 @@ def execute_workflow_task(self, workflow_result_id, workflow_id, trigger_step_da
 
     from app.services.workflow_engine import (
         WorkflowCancelled,
+        WorkflowStepError,
         build_workflow_engine,
         sanitize_step_name,
     )
@@ -687,6 +688,13 @@ def execute_workflow_task(self, workflow_result_id, workflow_id, trigger_step_da
                 pass
         # Clean terminal stop — do not re-raise (no retry).
         return {"status": "canceled", "result_id": workflow_result_id}
+    except WorkflowStepError as e:
+        # A step failed (blocked URL, HTTP error, bad config, ...). This is a
+        # deterministic, user-facing failure: mark the run failed and stop —
+        # no re-raise, so it neither retries nor lands in Sentry as a crash.
+        logger.warning("Workflow %s failed: %s", workflow_id, e)
+        _mark_workflow_failed(db, workflow_result_id, activity_id, str(e))
+        return {"status": "error", "result_id": workflow_result_id}
     except Exception as e:
         logger.error("Workflow execution failed for %s: %s", workflow_id, e)
         db.workflow_result.update_one(
@@ -939,7 +947,7 @@ def resume_workflow_after_approval(self, approval_uuid):
     """Resume a workflow after an approval request has been approved."""
     from bson import ObjectId
 
-    from app.services.workflow_engine import build_workflow_engine
+    from app.services.workflow_engine import WorkflowStepError, build_workflow_engine
 
     db = _get_db()
 
@@ -1070,6 +1078,14 @@ def resume_workflow_after_approval(self, approval_uuid):
                 start_index=step_index + 1,
                 initial_output=initial_output,
             )
+    except WorkflowStepError as e:
+        # Deterministic step failure — mark the run failed, don't retry.
+        logger.warning("Workflow %s failed after resume: %s", workflow_id, e)
+        db.workflow_result.update_one(
+            {"_id": ObjectId(workflow_result_id)},
+            {"$set": {"status": "error", "error": str(e)}},
+        )
+        return {"status": "error", "result_id": workflow_result_id}
     except Exception as e:
         logger.error("Workflow resume failed for %s: %s", workflow_id, e)
         db.workflow_result.update_one(

--- a/backend/app/tasks/workflow_tasks.py
+++ b/backend/app/tasks/workflow_tasks.py
@@ -857,6 +857,7 @@ def execute_task_step_test(self, task_name, task_data, doc_uuids):
         ResearchNode,
         WebsiteNode,
         WorkflowEngine,
+        WorkflowStepError,
     )
 
     db = _get_db()
@@ -931,7 +932,21 @@ def execute_task_step_test(self, task_name, task_data, doc_uuids):
     for i in range(1, len(nodes)):
         engine.connect(nodes[i - 1], nodes[i])
 
-    final_output, _ = engine.execute()
+    try:
+        final_output, _ = engine.execute()
+    except WorkflowStepError as e:
+        # Deterministic config/user error (blocked URL, HTTP failure, bad
+        # headers…). Return a structured failure instead of raising: the task
+        # then neither retries nor produces a Sentry error event, the poll
+        # endpoint gets the clean message without a result-backend exception
+        # round-trip, and the step's full output (request preview included)
+        # stays available for debugging — Test Step has no
+        # workflow_result_updater to persist it anywhere else.
+        return {
+            "step_test_failed": True,
+            "error": str(e),
+            "output": e.step_output,
+        }
     return final_output
 
 

--- a/backend/tests/test_workflow_engine_core.py
+++ b/backend/tests/test_workflow_engine_core.py
@@ -19,9 +19,26 @@ from app.services.workflow_engine import (
     Node,
     UsageAccumulator,
     WorkflowEngine,
+    WorkflowStepError,
     build_workflow_engine,
     sanitize_step_name,
 )
+
+
+class _FailingNode(Node):
+    """Stub node that reports a step failure via the ``error`` key."""
+
+    def __init__(self, name="FailingNode", message="Blocked URL: nope"):
+        super().__init__(name)
+        self.message = message
+
+    def process(self, inputs):
+        return {
+            "output": self.message,
+            "error": self.message,
+            "input": inputs.get("output"),
+            "step_name": self.name,
+        }
 
 
 # ---------------------------------------------------------------------------
@@ -304,6 +321,63 @@ class TestWorkflowEngineExecute:
 
 
 # ---------------------------------------------------------------------------
+# Step failure semantics
+# ---------------------------------------------------------------------------
+
+class TestWorkflowStepFailure:
+    def _engine_with_failing_middle_step(self):
+        """Document -> failing step -> AddDocument (must never run)."""
+        engine = WorkflowEngine()
+        doc = DocumentNode({"doc_uuids": ["a"]})
+        fail = MultiTaskNode("API")
+        fail.add_task(_FailingNode())
+        downstream = AddDocumentNode({"doc_texts": ["should not run"]})
+        engine.add_node(doc)
+        engine.add_node(fail)
+        engine.add_node(downstream)
+        engine.connect(doc, fail)
+        engine.connect(fail, downstream)
+        return engine
+
+    def test_step_error_raises_and_halts(self):
+        engine = self._engine_with_failing_middle_step()
+        with pytest.raises(WorkflowStepError) as exc_info:
+            engine.execute()
+        assert exc_info.value.step_name == "API"
+        assert "Blocked URL: nope" in str(exc_info.value)
+
+    def test_step_error_does_not_run_downstream_steps(self):
+        engine = self._engine_with_failing_middle_step()
+        updates = []
+        with pytest.raises(WorkflowStepError):
+            engine.execute(workflow_result_updater=lambda u: updates.append(u))
+        started = [u.get("current_step_name") for u in updates if "current_step_name" in u]
+        assert "AddDocument" not in started
+
+    def test_failing_step_output_still_persisted(self):
+        """The failing step's result (with its diagnostics) lands in
+        steps_output before the run is failed."""
+        engine = self._engine_with_failing_middle_step()
+        updates = []
+        with pytest.raises(WorkflowStepError):
+            engine.execute(workflow_result_updater=lambda u: updates.append(u))
+        persisted = {k: v for u in updates for k, v in u.items()
+                     if k.startswith("steps_output.")}
+        assert "steps_output.API" in persisted
+        assert persisted["steps_output.API"]["error"] == "Blocked URL: nope"
+
+    def test_error_free_run_unaffected(self):
+        engine = WorkflowEngine()
+        doc = DocumentNode({"doc_uuids": ["a"]})
+        add = AddDocumentNode({"doc_texts": ["fine"]})
+        engine.add_node(doc)
+        engine.add_node(add)
+        engine.connect(doc, add)
+        final, data = engine.execute()
+        assert final == "fine"
+
+
+# ---------------------------------------------------------------------------
 # MultiTaskNode
 # ---------------------------------------------------------------------------
 
@@ -325,6 +399,32 @@ class TestMultiTaskNode:
         assert result["_approval_pause"] is True
         assert result["_review_instructions"] == "Review this"
         assert result["output"] == "pending review"
+
+    def test_error_propagates_through_wrapper(self):
+        multi = MultiTaskNode("API Step")
+        multi.add_task(_FailingNode(message="HTTP error: 500"))
+        result = multi.process({"output": "prev"})
+        assert result["error"] == "HTTP error: 500"
+
+    def test_request_preview_propagates_through_wrapper(self):
+        class _RequestNode(Node):
+            def process(self, inputs):
+                return {
+                    "output": "ok",
+                    "request": {"method": "GET", "url": "https://x.test"},
+                    "step_name": self.name,
+                }
+
+        multi = MultiTaskNode("API Step")
+        multi.add_task(_RequestNode("APINode"))
+        result = multi.process({"output": "prev"})
+        assert result["request"] == {"method": "GET", "url": "https://x.test"}
+
+    def test_no_error_key_when_tasks_succeed(self):
+        multi = MultiTaskNode("Step")
+        multi.add_task(AddDocumentNode({"doc_texts": ["fine"]}))
+        result = multi.process({"output": "prev"})
+        assert "error" not in result
 
     def test_multiple_tasks_parallel(self):
         """Multiple tasks execute in parallel and outputs are collected."""

--- a/backend/tests/test_workflow_engine_core.py
+++ b/backend/tests/test_workflow_engine_core.py
@@ -366,6 +366,24 @@ class TestWorkflowStepFailure:
         assert "steps_output.API" in persisted
         assert persisted["steps_output.API"]["error"] == "Blocked URL: nope"
 
+    def test_step_error_survives_celery_json_reconstruction(self):
+        """Celery's JSON result backend rebuilds a task's exception as
+        cls(*args). If args were a single pre-formatted string, reconstruction
+        would TypeError and degrade to a mangled generic Exception — exactly
+        what the Test Step poll endpoint would then show the user."""
+        original = WorkflowStepError("APINode", "Blocked URL: nope")
+        rebuilt = WorkflowStepError(*original.args)
+        assert rebuilt.step_name == "APINode"
+        assert rebuilt.message == "Blocked URL: nope"
+        assert str(rebuilt) == "APINode step failed: Blocked URL: nope"
+
+    def test_step_error_carries_step_output_for_in_process_callers(self):
+        engine = self._engine_with_failing_middle_step()
+        with pytest.raises(WorkflowStepError) as exc_info:
+            engine.execute()
+        assert exc_info.value.step_output is not None
+        assert exc_info.value.step_output.get("error") == "Blocked URL: nope"
+
     def test_error_free_run_unaffected(self):
         engine = WorkflowEngine()
         doc = DocumentNode({"doc_uuids": ["a"]})

--- a/backend/tests/test_workflow_nodes.py
+++ b/backend/tests/test_workflow_nodes.py
@@ -399,6 +399,7 @@ class TestWebsiteNode:
         node = WebsiteNode({"url": "http://metadata.google.internal"})
         result = node.process({"output": "prev"})
         assert "Blocked URL" in result["output"]
+        assert "Blocked URL" in result["error"]
 
     @patch("app.services.web_fetcher.fetch_url_sync")
     def test_http_error(self, mock_fetch):
@@ -490,6 +491,7 @@ class TestCodeExecutionNode:
         node = CodeExecutionNode({"code": "import os"})
         result = node.process({"output": "data"})
         assert "Code rejected" in result["output"]
+        assert "Code rejected" in result["error"]
 
     @patch("app.utils.code_sandbox.validate_sandbox_code",
            side_effect=SyntaxError("invalid syntax"))
@@ -804,6 +806,57 @@ class TestAPICallNode:
         node = APICallNode({"url": "http://internal"})
         result = node.process({"output": "prev"})
         assert "Blocked URL" in result["output"]
+        assert "Blocked URL" in result["error"]
+
+    @patch("app.utils.url_validation.validate_outbound_url", return_value="ok")
+    @patch("app.services.workflow_engine.httpx.Client")
+    def test_http_error_sets_error_and_request_preview(self, mock_client_cls, _mock_validate):
+        import httpx
+
+        request = httpx.Request("GET", "https://api.example.com/data")
+        response = httpx.Response(500, request=request, text="server exploded")
+        mock_response = MagicMock()
+        mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "boom", request=request, response=response,
+        )
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.request.return_value = mock_response
+        mock_client_cls.return_value = mock_client
+
+        node = APICallNode({"url": "https://api.example.com/data", "method": "GET"})
+        result = node.process({"output": "prev"})
+        assert result["error"].startswith("HTTP error: 500")
+        # The full output keeps the request preview for debugging.
+        assert "--- Request sent ---" in result["output"]
+        assert result["request"]["url"] == "https://api.example.com/data"
+
+    @patch("app.utils.url_validation.validate_outbound_url", return_value="ok")
+    @patch("app.services.workflow_engine.httpx.Client")
+    def test_request_error_sets_error(self, mock_client_cls, _mock_validate):
+        import httpx
+
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.request.side_effect = httpx.ConnectError("connection refused")
+        mock_client_cls.return_value = mock_client
+
+        node = APICallNode({"url": "https://api.example.com/data", "method": "GET"})
+        result = node.process({"output": "prev"})
+        assert result["error"].startswith("Request error:")
+        assert result["request"]["url"] == "https://api.example.com/data"
+
+    @patch("app.utils.url_validation.validate_outbound_url", return_value="ok")
+    def test_invalid_headers_json_sets_error(self, _mock_validate):
+        node = APICallNode({
+            "url": "https://api.example.com/data",
+            "method": "GET",
+            "headers": "{not json",
+        })
+        result = node.process({"output": "prev"})
+        assert "Invalid Headers JSON" in result["error"]
 
     @patch("app.utils.url_validation.validate_outbound_url")
     @patch("app.services.workflow_engine.httpx.Client")

--- a/backend/tests/test_workflow_service.py
+++ b/backend/tests/test_workflow_service.py
@@ -806,6 +806,28 @@ class TestGetTestStatus:
         status = get_test_status("task-123")
         assert status["status"] == "PENDING"
 
+    @patch("app.services.workflow_service.AsyncResult")
+    def test_step_failure_returned_by_task_reports_failed_with_clean_message(self, mock_async_result_cls):
+        """A deterministic step failure is *returned* (not raised) by the test
+        task; the poll must surface it as failed with the step's message and
+        keep the step output for diagnostics."""
+        from app.services.workflow_service import get_test_status
+
+        mock_result = MagicMock()
+        mock_result.ready.return_value = True
+        mock_result.successful.return_value = True
+        mock_result.result = {
+            "step_test_failed": True,
+            "error": "APINode step failed: Blocked URL: nope",
+            "output": {"error": "Blocked URL: nope", "output": "--- Request sent ---"},
+        }
+        mock_async_result_cls.return_value = mock_result
+
+        status = get_test_status("task-123")
+        assert status["status"] == "failed"
+        assert status["error"] == "APINode step failed: Blocked URL: nope"
+        assert status["output"]["output"] == "--- Request sent ---"
+
 
 # ---------------------------------------------------------------------------
 # save_expected_output

--- a/backend/tests/test_workflow_tasks.py
+++ b/backend/tests/test_workflow_tasks.py
@@ -166,6 +166,47 @@ class TestExecuteWorkflowTask:
 
     @patch("app.tasks.workflow_tasks._get_db")
     @patch("app.services.workflow_engine.build_workflow_engine")
+    def test_step_failure_marks_run_failed_without_retry(self, mock_build, mock_get_db):
+        """A failed step (blocked URL, HTTP error, ...) must fail the run —
+        not surface the error text as a completed deliverable — and must not
+        re-raise (deterministic failure, no Celery retry)."""
+        from app.services.workflow_engine import WorkflowStepError
+        from app.tasks.workflow_tasks import execute_workflow_task
+
+        wf_id, result_id = _fake_oid(), _fake_oid()
+        db = _mock_db(
+            workflow_doc=_make_workflow_doc(wf_id=wf_id),
+            result_doc=_make_result_doc(result_id=result_id, workflow_id=wf_id),
+        )
+        mock_get_db.return_value = db
+
+        mock_engine = MagicMock()
+        mock_engine.execute.side_effect = WorkflowStepError(
+            "API", "Blocked URL: URL resolves to blocked IP range: 127.0.0.1",
+        )
+        mock_build.return_value = mock_engine
+
+        result = execute_workflow_task(
+            workflow_result_id=str(result_id),
+            workflow_id=str(wf_id),
+            trigger_step_data={"doc_uuids": []},
+            model="gpt-4o",
+        )
+
+        assert result["status"] == "error"
+        error_calls = [c for c in db.workflow_result.update_one.call_args_list
+                       if c[0][1].get("$set", {}).get("status") == "error"]
+        assert len(error_calls) == 1
+        error_msg = error_calls[0][0][1]["$set"]["error"]
+        assert "API step failed" in error_msg
+        assert "blocked IP range" in error_msg
+        # Never marked completed, and no final_output written.
+        completed_calls = [c for c in db.workflow_result.update_one.call_args_list
+                           if c[0][1].get("$set", {}).get("status") == "completed"]
+        assert completed_calls == []
+
+    @patch("app.tasks.workflow_tasks._get_db")
+    @patch("app.services.workflow_engine.build_workflow_engine")
     def test_approval_pause(self, mock_build, mock_get_db):
         from app.tasks.workflow_tasks import execute_workflow_task
 


### PR DESCRIPTION
## Summary

Support ticket: a failed workflow step (e.g. an API step hitting a blocked URL) had its error message stored as the step's result. The run was marked **Completed** with a green checkmark, the error text became the downloadable deliverable, and any downstream AI step received the error string as source material and described it as document content.

## Root cause

Every failure path inside the step nodes in `workflow_engine.py` returned error text as the step's normal `output`. Nothing downstream — engine, Celery task, or UI — could tell an error from a result.

## Changes

- **Nodes signal failure explicitly**: API, Website, Crawler, and Code-execution nodes attach an `error` field to their result (Browser automation already did). The full diagnostic text (including the redacted request preview for API steps) stays in `output`.
- **Engine halts on step failure**: `WorkflowEngine.execute()` raises a new `WorkflowStepError` when a step reports an error, after persisting the step's diagnostics to `steps_output` and after the optimizer's fallback-model retry hook gets its chance. Downstream steps never run on error text.
- **Celery tasks mark the run failed**: `execute_workflow_task` and `resume_workflow_after_approval` catch `WorkflowStepError` and set `status: "error"` with a message like `API step failed: Blocked URL: URL resolves to blocked IP range: 127.0.0.1` — logged as a warning, no retry, no re-raise (deterministic failure, keeps Sentry quiet). The existing frontend error panel renders it; Download / Save to folder no longer appear.
- **Passive runs**: the run's `WorkflowResult` is now marked failed on error instead of sitting in `running` forever (only the trigger event was updated before).
- **MultiTaskNode** propagates `error` and the API `request` preview through its wrapper, so the "API request sent" debug panel works on failed runs.
- **Step tests** (Test button) report the failure as a failed test with a clean message.

KB-query steps keep their deliberate warning-not-error semantics (surfaced via the existing warnings panel).

## Testing

- 13 new tests: node-level error fields, engine halt + downstream-step suppression + diagnostics persistence, MultiTaskNode propagation, and task-level run-failure marking for the ticket's exact repro.
- All 379 tests across the workflow engine/node/task/service suites pass; `ruff check app/` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)