### PR TITLE
fix(workflows): keep steps after an approval gate on the run's model

### DIFF
--- a/backend/app/models/workflow.py
+++ b/backend/app/models/workflow.py
@@ -109,6 +109,12 @@ class WorkflowResult(Document):
     #          "oversize_documents": [{"uuid": ..., "title": ..., "token_count": ...}]}
     error_payload: Optional[dict] = None
     session_id: str
+    # LLM model this run started on, snapshotted at dispatch. The model is
+    # resolved once per run (user config → system default) and passed to the
+    # execution task; a run that pauses at an approval gate loses that argument,
+    # so the resume task reads it back from here to keep steps after the gate on
+    # the same model. None for runs created before this field existed.
+    model: Optional[str] = None
     # Celery task id of the execution job, captured at enqueue time so a user
     # can cancel an in-flight run (revoke + terminate). None for runs created
     # before this field existed or for runs that never enqueued a task.

--- a/backend/app/services/workflow_service.py
+++ b/backend/app/services/workflow_service.py
@@ -528,6 +528,7 @@ async def run_workflow(
         status="queued",
         num_steps_total=len(wf.steps),
         input_context={"doc_uuids": document_uuids},
+        model=model,
         celery_task_id=celery_task_id,
     )
     await result.insert()
@@ -720,6 +721,7 @@ async def run_workflow_batch(
             num_steps_total=len(wf.steps),
             batch_id=batch_id,
             document_title=doc_title,
+            model=model,
         )
         await result.insert()
 

--- a/backend/app/tasks/workflow_tasks.py
+++ b/backend/app/tasks/workflow_tasks.py
@@ -125,6 +125,25 @@ def _bson_safe(value):
     return str(value)
 
 
+def _default_model_from_config(sys_config: dict) -> str:
+    """Resolve the configured default model from a raw SystemConfig dict.
+
+    The sync mirror of :func:`app.services.config_service.get_default_model_name`
+    for Celery tasks, which hold the config as a pymongo document rather than a
+    Beanie model. Returns "" when no model is configured at all.
+    """
+    models = [m for m in (sys_config.get("available_models") or []) if isinstance(m, dict)]
+
+    configured_default = (sys_config.get("default_model") or "").strip()
+    if configured_default and any(m.get("name") == configured_default for m in models):
+        return configured_default
+
+    for m in models:
+        if m.get("name"):
+            return m["name"]
+    return ""
+
+
 def _pause_for_approval(db, final_output, engine, workflow_id, workflow_result_id,
                         search_from=0):
     """Persist the approval request and flip the run to ``pending_approval``.
@@ -1083,12 +1102,20 @@ def resume_workflow_after_approval(self, approval_uuid):
                 {"$set": set_ops},
             )
 
+    # Steps after an approval gate must run on the model the run started with.
+    # That model is snapshotted on the result at dispatch; runs that predate the
+    # field fall back to the configured default rather than to a hardcoded model
+    # name, which is never a configured model and so reaches the provider with
+    # no API key.
+    model = result_doc.get("model") or _default_model_from_config(sys_config)
+
     engine = build_workflow_engine(
         steps_data=steps_data,
-        model=workflow_doc.get("resource_config", {}).get("model", "gpt-4o-mini"),
+        model=model,
         user_id=user_id,
         system_config_doc=sys_config,
         allow_code_execution=is_admin,
+        config_override=workflow_doc.get("config_override"),
     )
 
     # Resolved before the try so the failure handler below can always reach it.

--- a/backend/tests/test_workflow_tasks.py
+++ b/backend/tests/test_workflow_tasks.py
@@ -627,6 +627,83 @@ class TestResumeWorkflowAfterApproval:
         assert db.approval_request.insert_one.call_args[0][0]["step_index"] == 3
 
     @patch("app.tasks.workflow_tasks._get_db")
+    @patch("app.services.workflow_engine.build_workflow_engine")
+    def test_resume_runs_on_the_model_the_run_started_with(self, mock_build, mock_get_db):
+        """An LLM step after an approval gate must use the run's model. The
+        resume path used to read a `resource_config.model` key nothing writes,
+        so every resumed step silently fell back to a hardcoded model name that
+        is not configured — reaching the provider with no API key (401)."""
+        from app.tasks.workflow_tasks import resume_workflow_after_approval
+
+        wf_id, result_id = _fake_oid(), _fake_oid()
+        result_doc = _make_result_doc(result_id=result_id, workflow_id=wf_id)
+        result_doc["model"] = "azure-gpt-4.1"
+
+        db = _mock_db(
+            workflow_doc=_make_workflow_doc(wf_id=wf_id),
+            result_doc=result_doc,
+            approval_doc={
+                "uuid": "a1", "status": "approved",
+                "workflow_result_id": result_id, "workflow_id": wf_id,
+                "step_index": 1, "data_for_review": {"extracted": "data"},
+            },
+        )
+        mock_get_db.return_value = db
+
+        mock_engine = MagicMock()
+        mock_engine.execute.return_value = ("Resumed output", [])
+        mock_build.return_value = mock_engine
+
+        resume_workflow_after_approval("a1")
+
+        assert mock_build.call_args[1]["model"] == "azure-gpt-4.1"
+
+    @patch("app.tasks.workflow_tasks._get_db")
+    @patch("app.services.workflow_engine.build_workflow_engine")
+    def test_resume_without_stamped_model_uses_configured_default(self, mock_build, mock_get_db):
+        """Runs created before the model was snapshotted must resolve the
+        configured default, never a hardcoded model name."""
+        from app.tasks.workflow_tasks import resume_workflow_after_approval
+
+        wf_id, result_id = _fake_oid(), _fake_oid()
+
+        db = _mock_db(
+            workflow_doc=_make_workflow_doc(wf_id=wf_id),
+            result_doc=_make_result_doc(result_id=result_id, workflow_id=wf_id),
+            sys_config={"available_models": [{"name": "azure-gpt-4.1"}]},
+            approval_doc={
+                "uuid": "a1", "status": "approved",
+                "workflow_result_id": result_id, "workflow_id": wf_id,
+                "step_index": 1, "data_for_review": {"extracted": "data"},
+            },
+        )
+        mock_get_db.return_value = db
+
+        mock_engine = MagicMock()
+        mock_engine.execute.return_value = ("Resumed output", [])
+        mock_build.return_value = mock_engine
+
+        resume_workflow_after_approval("a1")
+
+        assert mock_build.call_args[1]["model"] == "azure-gpt-4.1"
+
+    def test_default_model_resolution(self):
+        from app.tasks.workflow_tasks import _default_model_from_config
+
+        models = [{"name": "azure-gpt-4.1"}, {"name": "claude-sonnet-5"}]
+
+        # An explicit default wins.
+        assert _default_model_from_config(
+            {"available_models": models, "default_model": "claude-sonnet-5"}
+        ) == "claude-sonnet-5"
+        # A stale default that no longer matches a model falls back to the first.
+        assert _default_model_from_config(
+            {"available_models": models, "default_model": "removed-model"}
+        ) == "azure-gpt-4.1"
+        # No models configured at all resolves to empty, not a guessed name.
+        assert _default_model_from_config({}) == ""
+
+    @patch("app.tasks.workflow_tasks._get_db")
     def test_missing_approval_raises(self, mock_get_db):
         from app.tasks.workflow_tasks import resume_workflow_after_approval
 


### PR DESCRIPTION
Fixes a support ticket: a workflow with an LLM step after an approval gate fails with a 401 the moment the first review is approved.

> `status_code: 401, model_name: gpt-4o-mini, body: {'message': 'Incorrect API key provided: no-api-key' ...}`

The reporter confirmed via Export Definition that no step uses `gpt-4o-mini` — the Prompt step is on "Use workflow default". The wrong model only appears after an approval.

## Root cause

`resume_workflow_after_approval` resolved the model from a key nothing ever writes:

```python
model=workflow_doc.get("resource_config", {}).get("model", "gpt-4o-mini")
```

`resource_config` only ever holds `retry` / `budget` / `throttling` — no code path writes `model` into it. So **every** resumed step fell through to the hardcoded literal. That name isn't in System Config's available models, so `llm_service` found no API key for it and passed the literal `"no-api-key"` (`llm_service.py:512`) to OpenAI, which 401'd.

The run's real model is resolved once at dispatch (`get_user_model_name` → user preference → system default) and passed as a Celery kwarg to `execute_workflow_task`. Pausing at an approval gate ends that task, so the argument was simply gone — and nothing had persisted it.

This is why the ticket's two cases differ:

| Workflow | Result |
|---|---|
| Extraction → Approval → Approval | Resumes fine — no LLM step runs after the gate, so the bogus model is never used |
| Extraction → Approval → Prompt → Approval | 401 on the first call after resume; second gate never reached |

## Fix

- `WorkflowResult.model` — new optional field snapshotting the model at dispatch
- `workflow_service.py` — both dispatch sites (single run + batch) persist it
- `workflow_tasks.py` — resume reads `result_doc["model"]`; runs predating the field fall back to `_default_model_from_config(sys_config)`, a sync mirror of `config_service.get_default_model_name`, instead of a hardcoded name

Also passed `config_override=` on the resume path. The initial run passes it, resume didn't — so optimizer per-step model and prompt-variant overrides were silently dropped after every approval. Same bug class, one line.

## Testing

Three tests added to `TestResumeWorkflowAfterApproval`. Both resume tests were verified to fail against the old code (`assert 'gpt-4o' == 'azure-gpt-4.1'`) and pass with the fix.

`95 passed` across `test_workflow_tasks.py` + `test_workflow_service.py`; `ruff check app/` clean. On the full local tree this change also ran green against the wider `-k "workflow or approval"` selection (705 passed, 11 skipped).

### Note for reviewers

The existing test helper `_make_workflow_doc` sets `resource_config: {"model": "gpt-4o"}` — a shape real workflows never have. That's precisely why the resume tests passed while production 401'd. I left it as-is to keep this diff focused, but it's worth deleting in a follow-up.

`passive_tasks.py` is untouched: it resolves its model as `available_models[0]` and never creates approvals, so it can't hit this. If approval support is ever added there, the same gap reopens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)