### PR TITLE
fix(support): declare queue filters once so partial search updates typecheck

### DIFF
--- a/frontend/src/pages/SupportCenter.tsx
+++ b/frontend/src/pages/SupportCenter.tsx
@@ -15,12 +15,10 @@ import {
 } from '../api/feedback'
 import type {
   SupportTicket, SupportTicketSummary, SupportAttachment,
+  StatusFilter, PriorityFilter, ClassificationFilter, SupportSearch,
 } from '../types/support'
 
 type View = 'list' | 'new' | 'chat' | 'whats_working'
-type StatusFilter = 'all' | 'open' | 'in_progress' | 'closed'
-type PriorityFilter = 'all' | 'low' | 'normal' | 'high'
-type ClassificationFilter = 'all' | 'bug' | 'enhancement' | 'feature_request'
 
 const MAX_BYTES = 10 * 1024 * 1024
 
@@ -63,14 +61,6 @@ const statCardStyle = (color: string): React.CSSProperties => ({
   border: '1px solid #e5e7eb', borderLeft: `4px solid ${color}`,
 })
 
-type SupportSearch = {
-  ticket?: string
-  status?: StatusFilter
-  priority?: PriorityFilter
-  classification?: ClassificationFilter
-  tag?: string
-  q?: string
-}
 
 export default function SupportCenter() {
   const { user } = useAuth()

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -11,6 +11,7 @@ import {
 import { useBranding } from './contexts/BrandingContext'
 import { ProtectedRoute } from './components/auth/ProtectedRoute'
 import { useCertificationPanel } from './contexts/CertificationPanelContext'
+import type { SupportSearch } from './types/support'
 import { Workspace } from './pages/Workspace'
 import { TeamSettings } from './pages/TeamSettings'
 
@@ -289,7 +290,11 @@ const supportRoute = createRoute({
   path: '/support',
   // Queue filters live in the URL so they survive a refresh (and can be shared
   // or bookmarked). Anything unrecognized falls back to the default.
-  validateSearch: (search: Record<string, unknown>) => {
+  // Annotated rather than inferred: without it every key is inferred as
+  // required-but-possibly-undefined, so a partial update like
+  // `search={{ ticket: undefined }}` fails to typecheck for missing the other
+  // five keys — even though all five would be undefined. See types/support.
+  validateSearch: (search: Record<string, unknown>): SupportSearch => {
     const oneOf = <T extends string>(v: unknown, allowed: readonly T[]): T | undefined =>
       typeof v === 'string' && (allowed as readonly string[]).includes(v) ? (v as T) : undefined
     return {

--- a/frontend/src/types/support.ts
+++ b/frontend/src/types/support.ts
@@ -88,3 +88,32 @@ export interface SupportContact {
   email: string
   name: string
 }
+
+// ---------------------------------------------------------------------------
+// Queue filters, as they live in the URL
+// ---------------------------------------------------------------------------
+
+/**
+ * Declared here so the route that validates these and the page that updates
+ * them agree on one shape. They were previously declared in both places: the
+ * route's `validateSearch` returned every key, which TypeScript infers as
+ * required-but-possibly-undefined, while the page declared them optional. Any
+ * partial update — `search={{ ticket: undefined }}`, or a reducer spreading
+ * `prev` — then failed to typecheck against the route.
+ *
+ * Optional is the honest shape: `validateSearch` returns `undefined` for every
+ * absent or unrecognized value, so a missing key and a key set to `undefined`
+ * mean the same thing, and a caller should be free to pass either.
+ */
+export type StatusFilter = 'all' | 'open' | 'in_progress' | 'closed'
+export type PriorityFilter = 'all' | 'low' | 'normal' | 'high'
+export type ClassificationFilter = 'all' | 'bug' | 'enhancement' | 'feature_request'
+
+export type SupportSearch = {
+  ticket?: string
+  status?: StatusFilter
+  priority?: PriorityFilter
+  classification?: ClassificationFilter
+  tag?: string
+  q?: string
+}


### PR DESCRIPTION
## What's broken

`main` fails `make frontend-ci` at the typecheck step with four `TS2322` errors. That blocks CI on every branch cut from it, so no PR can show a green frontend check right now.

```
src/components/layout/TeamsDropdown.tsx(225,17): error TS2322
src/pages/SupportCenter.tsx(107,7):  error TS2322
src/pages/SupportCenter.tsx(231,32): error TS2322
src/pages/SupportCenter.tsx(237,32): error TS2322
```

## Why

The Support Center's URL filters are declared in two places:

- `router.tsx` — `validateSearch` returns all six keys, which TypeScript infers as **required**-but-possibly-undefined
- `SupportCenter.tsx` — the same shape with **optional** keys

Neither is wrong alone, but no caller can satisfy both. Every partial update fails:

```tsx
<Link to="/support" search={{ ticket: undefined }} />
navigate({ search: (prev) => ({ ...(prev as SupportSearch), ticket: uuid }) })
```

TypeScript reads `{ ticket: undefined }` as *missing* `status`, `priority`, `classification`, `tag` and `q` — even though all five would be `undefined`.

## The change

Moved the filter types next to the other Support types in `types/support.ts` and annotated `validateSearch` with the shared type, so the route and the page agree by construction instead of by hand.

Optional is the honest shape: `validateSearch` already returns `undefined` for every absent or unrecognized value, so an omitted key and a key set to `undefined` mean the same thing, and a caller should be free to pass either.

**Types only — no behaviour change.** No runtime code was touched.

## Verification

| Check | Result |
|---|---|
| `tsc -b` on unmodified `main` | **4 errors** |
| `tsc -b` with this change | **0 errors** |
| `eslint` on all changed files | clean |
| `vitest run` | 495 passed, 64 files |

Found while investigating a CI failure on an unrelated PR — the failing files aren't touched by that branch.