### PR TITLE
Stop marking unreadable documents complete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- **A document whose text could not be extracted is no longer marked complete.** When OCR failed on a scanned PDF, the document was stored with zero extracted text but `task_status: "complete"` — it looked processed, and chat then answered questions about it with "the document does not mention that", which is indistinguishable from the document genuinely not containing the answer. The failure was silent and the wrong answer was confident. Extraction had always recorded the failure correctly; the error was erased afterwards, first by `perform_semantic_ingestion` setting `readying` unconditionally and then by `complete` on both the success and exception paths. Every post-extraction status write now goes through one helper that refuses to advance a document extraction already marked `error`, with the exclusion in the MongoDB query filter rather than a preceding read, because the ingestion stages run on separate Celery queues and can race. A first version of this fix guarded only the `complete` write and the bug survived it — the intermediate `readying` write is the half that matters.
+
 ## [v4.10.0] - 2026-08-10
 
 ### Added

--- a/backend/app/tasks/document_tasks.py
+++ b/backend/app/tasks/document_tasks.py
@@ -450,6 +450,56 @@ def perform_extraction_and_update(self, document_uuid: str, extension: str) -> s
         return ""
 
 
+def advance_task_status(db, document_uuid: str, status: str) -> bool:
+    """Move a document to ``status`` unless extraction already marked it failed.
+
+    Applies to *every* post-extraction status write, not just the terminal
+    "complete" one. An intermediate marker is just as destructive: setting
+    "readying" on a document that already failed erases the error, and then the
+    very next write legitimately advances the now-unmarked document to
+    "complete". That is how a zero-character document ends up carrying an
+    extraction error message and a green checkmark at the same time.
+
+    The exclusion lives in the query filter, not in a preceding read. These
+    tasks run concurrently on separate queues — extraction on `documents`,
+    compliance on `uploads` — so a read-then-write check can be overtaken
+    between the read and the update.
+
+    Note this is deliberately one-way: it never *clears* an error. Re-running
+    extraction is what resets a failed document, via the "extracting" write at
+    the top of `perform_extraction_and_update`, so a retry still works.
+
+    Returns True when the document was advanced.
+    """
+    result = db.smart_document.update_one(
+        {"uuid": document_uuid, "task_status": {"$ne": "error"}},
+        {"$set": {"task_status": status}},
+    )
+    if not result.matched_count:
+        logger.info(
+            "Leaving document %s in its failed state rather than setting %r",
+            document_uuid, status,
+        )
+    return bool(result.matched_count)
+
+
+def mark_complete_unless_errored(db, document_uuid: str) -> bool:
+    """Advance a document to "complete" unless extraction already failed."""
+    return advance_task_status(db, document_uuid, "complete")
+
+
+def _record_ingestion_result(db, document_uuid: str, fields: dict) -> None:
+    """Persist ingestion bookkeeping, then advance the status if it's allowed.
+
+    Two writes on purpose. Chunk counts and readiness flags are true whatever
+    extraction did, so they are always recorded; only the status transition is
+    conditional. Folding them into one guarded write would silently drop the
+    bookkeeping for documents that failed extraction.
+    """
+    db.smart_document.update_one({"uuid": document_uuid}, {"$set": fields})
+    mark_complete_unless_errored(db, document_uuid)
+
+
 @celery_app.task(
     bind=True,
     name="tasks.document.update",
@@ -819,10 +869,10 @@ def perform_semantic_ingestion(self, raw_text: str, document_uuid: str, user_id:
         logger.warning("Document %s not found for semantic ingestion", document_uuid)
         return ""
 
-    db.smart_document.update_one(
-        {"uuid": document_uuid},
-        {"$set": {"task_status": "readying"}},
-    )
+    # Guarded: a document whose extraction just failed must not be dragged back
+    # into an in-progress state, because that erases the error and lets the
+    # terminal write below mark it complete.
+    advance_task_status(db, document_uuid, "readying")
 
     # If the caller passed empty raw_text, fall back to whatever the
     # extraction task already wrote to the DB.
@@ -844,28 +894,24 @@ def perform_semantic_ingestion(self, raw_text: str, document_uuid: str, user_id:
         )
     except Exception as e:
         logger.exception("Semantic ingestion failed for %s", document_uuid)
-        db.smart_document.update_one(
-            {"uuid": document_uuid},
+        _record_ingestion_result(
+            db,
+            document_uuid,
             {
-                "$set": {
-                    "task_status": "complete",
-                    "chromadb_ready": False,
-                    "chunk_count": 0,
-                    "ingest_error": str(e)[:500],
-                }
+                "chromadb_ready": False,
+                "chunk_count": 0,
+                "ingest_error": str(e)[:500],
             },
         )
         raise
 
-    db.smart_document.update_one(
-        {"uuid": document_uuid},
+    _record_ingestion_result(
+        db,
+        document_uuid,
         {
-            "$set": {
-                "task_status": "complete",
-                "chromadb_ready": chunk_count > 0,
-                "chunk_count": chunk_count,
-                "ingest_error": None,
-            }
+            "chromadb_ready": chunk_count > 0,
+            "chunk_count": chunk_count,
+            "ingest_error": None,
         },
     )
 

--- a/backend/app/tasks/upload_validation_tasks.py
+++ b/backend/app/tasks/upload_validation_tasks.py
@@ -187,13 +187,17 @@ def summarize_results(
         "validation_feedback": summary.get("feedback", ""),
         "validating": False,
     }
-    if not background:
-        update_fields["task_status"] = "complete"
 
     db.smart_document.update_one(
         {"uuid": document_uuid},
         {"$set": update_fields},
     )
+    # Compliance validation says nothing about whether the text could be read,
+    # so it must not overwrite an extraction failure with a green checkmark.
+    if not background:
+        from app.tasks.document_tasks import mark_complete_unless_errored
+
+        mark_complete_unless_errored(db, document_uuid)
 
     logger.info(
         "Document %s validation updated: valid=%s, background=%s",
@@ -233,19 +237,28 @@ def perform_document_validation(
             "validation_feedback": "Compliance checks disabled.",
             "validating": False,
         }
-        if not background:
-            skip_fields["task_status"] = "complete"
         db.smart_document.update_one(
             {"uuid": document_uuid},
             {"$set": skip_fields},
         )
+        # Skipping a check the deployment turned off is not evidence that the
+        # document was read successfully.
+        if not background:
+            from app.tasks.document_tasks import mark_complete_unless_errored
+
+            mark_complete_unless_errored(db, document_uuid)
         logger.info("Compliance disabled — skipping validation for %s", document_uuid)
         return ""
 
-    update_fields = {"validating": True}
+    db.smart_document.update_one(
+        {"uuid": document_uuid}, {"$set": {"validating": True}}
+    )
     if not background:
-        update_fields["task_status"] = "security"
-    db.smart_document.update_one({"uuid": document_uuid}, {"$set": update_fields})
+        # Same guard as every other status write: an in-progress marker on a
+        # document that already failed extraction erases the failure.
+        from app.tasks.document_tasks import advance_task_status
+
+        advance_task_status(db, document_uuid, "security")
 
     start = time.perf_counter()
 

--- a/backend/tests/test_document_tasks.py
+++ b/backend/tests/test_document_tasks.py
@@ -12,6 +12,29 @@ import pytest
 from bson import ObjectId
 
 
+
+def _set_containing(db, key):
+    """The $set of the write that carried `key`.
+
+    Ingestion writes bookkeeping and the status transition separately (the
+    status write is guarded so it cannot resurrect a failed extraction), so
+    these look up a write by what it carries rather than by position.
+    """
+    for call in db.smart_document.update_one.call_args_list:
+        payload = call[0][1].get("$set", {})
+        if key in payload:
+            return payload
+    raise AssertionError(f"no update wrote {key!r}")
+
+
+def _status_sequence(db):
+    return [
+        call[0][1]["$set"]["task_status"]
+        for call in db.smart_document.update_one.call_args_list
+        if "task_status" in call[0][1].get("$set", {})
+    ]
+
+
 # ---------------------------------------------------------------------------
 # _remove_images_from_markdown
 # ---------------------------------------------------------------------------
@@ -602,8 +625,8 @@ class TestPerformSemanticIngestion:
             raw_text="content",
             text_markers=[],
         )
-        # The final update should reflect the chunk count and ready flag.
-        final_update = db.smart_document.update_one.call_args_list[-1][0][1]["$set"]
+        # The bookkeeping write should reflect the chunk count and ready flag.
+        final_update = _set_containing(db, "chromadb_ready")
         assert final_update["chromadb_ready"] is True
         assert final_update["chunk_count"] == 5
 
@@ -625,10 +648,8 @@ class TestPerformSemanticIngestion:
 
         perform_semantic_ingestion(raw_text="text", document_uuid="doc-1", user_id="u1")
 
-        # First update: readying, second: complete
-        updates = db.smart_document.update_one.call_args_list
-        assert updates[0][0][1]["$set"]["task_status"] == "readying"
-        assert updates[1][0][1]["$set"]["task_status"] == "complete"
+        # readying while it works, complete once it has.
+        assert _status_sequence(db) == ["readying", "complete"]
 
     @patch("app.services.document_manager.DocumentManager")
     @patch("app.config.Settings")
@@ -651,7 +672,7 @@ class TestPerformSemanticIngestion:
         with pytest.raises(RuntimeError):
             perform_semantic_ingestion(raw_text="text", document_uuid="doc-1", user_id="u1")
 
-        final_update = db.smart_document.update_one.call_args_list[-1][0][1]["$set"]
+        final_update = _set_containing(db, "ingest_error")
         assert final_update["chromadb_ready"] is False
         assert "embedding service down" in final_update["ingest_error"]
 
@@ -762,3 +783,189 @@ class TestSyncProjectKbOnMove:
         inc = db.knowledge_bases.update_one.call_args[0][1]["$inc"]
         assert inc["total_chunks"] == -3
         assert inc["total_sources"] == -1
+
+
+# ---------------------------------------------------------------------------
+# An extraction failure must survive the rest of the pipeline
+# ---------------------------------------------------------------------------
+
+
+class TestIngestionDoesNotResurrectFailedExtraction:
+    """A document that extracted nothing must not end up marked "complete".
+
+    Observed on the live deployment, 2026-08-11 17:41 UTC. A scanned PDF was
+    uploaded while a 36 GB vLLM engine held the shared GPU. The OCR bridge
+    answered `503 GPU held by llm-svc — retry shortly` three times in 3.5s,
+    extraction returned "", and the guard in `perform_extraction_and_update`
+    correctly set task_status="error" with a user-facing message.
+
+    `update_document_fields` ran next and correctly declined to overwrite it.
+    Then `perform_semantic_ingestion` finished and set task_status="complete"
+    unconditionally, and the document was left with an error message it never
+    showed, zero characters, and a green checkmark. Chat then answered "the
+    document doesn't mention that" about a document containing nothing at all.
+
+    The trigger was GPU contention, but the silence is this status write: any
+    empty extraction is resurrected the same way, whatever caused it. That is
+    why this is testable without OCR running — the failure is a *state*.
+    """
+
+    def _doc(self) -> dict:
+        return {
+            "uuid": "doc-1",
+            "title": "05_Budget_Justification_degraded.pdf",
+            "path": "uploads/scan.pdf",
+            "raw_text": "",
+            "task_status": "error",
+            "error_message": "We couldn't extract any text from this document.",
+        }
+
+    def _status_writes(self, db) -> list:
+        """Every task_status this call attempted to write, in order."""
+        return [
+            call[0][1]["$set"]["task_status"]
+            for call in db.smart_document.update_one.call_args_list
+            if "task_status" in call[0][1].get("$set", {})
+        ]
+
+    def _unguarded_status_writes(self, db) -> list:
+        """*Any* status write that could land on an already-failed document.
+
+        Checking only the terminal "complete" write is not enough, and missing
+        that is what let the live bug survive a first fix: ingestion sets
+        "readying" before it starts, which erases the error, after which the
+        terminal write advances a document that no longer looks failed. Every
+        status write has to carry the exclusion.
+
+        The guard belongs in the query filter, not in a preceding read: these
+        tasks run concurrently on separate queues, so a read-then-write check
+        can be overtaken between the read and the update.
+        """
+        unguarded = []
+        for call in db.smart_document.update_one.call_args_list:
+            query, update = call[0][0], call[0][1]
+            if "task_status" not in update.get("$set", {}):
+                continue
+            if query.get("task_status") != {"$ne": "error"}:
+                unguarded.append((query, update["$set"]["task_status"]))
+        return unguarded
+
+    @patch("app.services.document_manager.DocumentManager")
+    @patch("app.config.Settings")
+    @patch("app.tasks.document_tasks.get_sync_db")
+    def test_successful_ingestion_does_not_clear_an_error_status(
+        self, mock_get_db, MockSettings, MockDM
+    ):
+        from app.tasks.document_tasks import perform_semantic_ingestion
+
+        db = MagicMock()
+        mock_get_db.return_value = db
+        db.smart_document.find_one.return_value = self._doc()
+
+        settings = MagicMock()
+        settings.chromadb_persist_dir = "/data/chroma"
+        MockSettings.return_value = settings
+
+        dm_instance = MagicMock()
+        dm_instance.add_document.return_value = 0  # nothing to chunk: no text
+        MockDM.return_value = dm_instance
+
+        perform_semantic_ingestion(
+            raw_text="", document_uuid="doc-1", user_id="user1"
+        )
+
+        assert self._unguarded_status_writes(db) == [], (
+            "semantic ingestion wrote a task_status without excluding errored "
+            "documents — this is the silent data loss"
+        )
+
+    @patch("app.services.document_manager.DocumentManager")
+    @patch("app.config.Settings")
+    @patch("app.tasks.document_tasks.get_sync_db")
+    def test_ingestion_failure_does_not_clear_an_error_status_either(
+        self, mock_get_db, MockSettings, MockDM
+    ):
+        """The exception path writes "complete" too, and is if anything more
+        likely to run on a document that already failed extraction."""
+        from app.tasks.document_tasks import perform_semantic_ingestion
+
+        db = MagicMock()
+        mock_get_db.return_value = db
+        db.smart_document.find_one.return_value = self._doc()
+
+        settings = MagicMock()
+        settings.chromadb_persist_dir = "/data/chroma"
+        MockSettings.return_value = settings
+
+        dm_instance = MagicMock()
+        dm_instance.add_document.side_effect = RuntimeError("chroma unavailable")
+        MockDM.return_value = dm_instance
+
+        with pytest.raises(RuntimeError):
+            perform_semantic_ingestion(
+                raw_text="", document_uuid="doc-1", user_id="user1"
+            )
+
+        assert self._unguarded_status_writes(db) == []
+
+    @patch("app.services.document_manager.DocumentManager")
+    @patch("app.config.Settings")
+    @patch("app.tasks.document_tasks.get_sync_db")
+    def test_a_healthy_document_is_still_marked_complete(
+        self, mock_get_db, MockSettings, MockDM
+    ):
+        """The guard must not strand ordinary documents in a non-complete state."""
+        from app.tasks.document_tasks import perform_semantic_ingestion
+
+        db = MagicMock()
+        mock_get_db.return_value = db
+        db.smart_document.find_one.return_value = {
+            "uuid": "doc-1", "title": "Report.pdf", "path": "uploads/report.pdf",
+            "raw_text": "real content", "task_status": "extracting",
+        }
+
+        settings = MagicMock()
+        settings.chromadb_persist_dir = "/data/chroma"
+        MockSettings.return_value = settings
+
+        dm_instance = MagicMock()
+        dm_instance.add_document.return_value = 5
+        MockDM.return_value = dm_instance
+
+        perform_semantic_ingestion(
+            raw_text="real content", document_uuid="doc-1", user_id="user1"
+        )
+
+        assert "complete" in self._status_writes(db)
+
+    @patch("app.services.document_manager.DocumentManager")
+    @patch("app.config.Settings")
+    @patch("app.tasks.document_tasks.get_sync_db")
+    def test_ingestion_bookkeeping_is_still_recorded_on_a_failed_document(
+        self, mock_get_db, MockSettings, MockDM
+    ):
+        """Withholding "complete" must not also withhold chunk_count and
+        chromadb_ready — those stay accurate regardless of extraction state."""
+        from app.tasks.document_tasks import perform_semantic_ingestion
+
+        db = MagicMock()
+        mock_get_db.return_value = db
+        db.smart_document.find_one.return_value = self._doc()
+
+        settings = MagicMock()
+        settings.chromadb_persist_dir = "/data/chroma"
+        MockSettings.return_value = settings
+
+        dm_instance = MagicMock()
+        dm_instance.add_document.return_value = 0
+        MockDM.return_value = dm_instance
+
+        perform_semantic_ingestion(
+            raw_text="", document_uuid="doc-1", user_id="user1"
+        )
+
+        written = {}
+        for call in db.smart_document.update_one.call_args_list:
+            written.update(call[0][1].get("$set", {}))
+        assert written.get("chromadb_ready") is False
+        assert written.get("chunk_count") == 0

--- a/backend/tests/test_upload_validation_tasks.py
+++ b/backend/tests/test_upload_validation_tasks.py
@@ -170,12 +170,16 @@ class TestSummarizeResults:
         summary = summarize_results(results, "doc-uuid", False)
 
         assert summary["valid"] is True
-        db.smart_document.update_one.assert_called_once()
-        update_args = db.smart_document.update_one.call_args[0]
+        update_args = db.smart_document.update_one.call_args_list[0][0]
         assert update_args[0] == {"uuid": "doc-uuid"}
         assert update_args[1]["$set"]["valid"] is True
         assert update_args[1]["$set"]["validating"] is False
-        assert update_args[1]["$set"]["task_status"] == "complete"
+        # The status transition is a separate, guarded write: compliance
+        # validation must not overwrite a failed extraction with "complete".
+        assert "task_status" not in update_args[1]["$set"]
+        status_call = db.smart_document.update_one.call_args_list[-1][0]
+        assert status_call[0] == {"uuid": "doc-uuid", "task_status": {"$ne": "error"}}
+        assert status_call[1]["$set"]["task_status"] == "complete"
 
     @patch("app.tasks.upload_validation_tasks._get_secure_agent")
     @patch("app.tasks.upload_validation_tasks._get_db")
@@ -204,7 +208,7 @@ class TestSummarizeResults:
         summary = summarize_results(results, "doc-uuid", False)
 
         assert summary["valid"] is False
-        update_args = db.smart_document.update_one.call_args[0]
+        update_args = db.smart_document.update_one.call_args_list[0][0]
         assert update_args[1]["$set"]["valid"] is False
 
     @patch("app.tasks.upload_validation_tasks._get_secure_agent")
@@ -251,7 +255,11 @@ class TestSummarizeResults:
         assert summary["valid"] is False
         assert "PII detected" in summary["feedback"]
         # Should still persist to DB despite agent error
-        db.smart_document.update_one.assert_called_once()
+        # Two writes now: the validation result, then a guarded status change.
+        assert db.smart_document.update_one.call_count == 2
+        assert "validation_feedback" in (
+            db.smart_document.update_one.call_args_list[0][0][1]["$set"]
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Stop marking unreadable documents `complete`. When OCR fails on a scanned PDF the document is stored with zero extracted text but a `complete` status, so it looks processed and chat then answers questions about it with “the document does not mention that” — indistinguishable from the document genuinely not containing the answer.

Extraction already recorded the failure correctly. The error was erased afterwards by later ingestion stages. Every post-extraction status write now refuses to advance a document that extraction marked `error`.

## Changes

- `advance_task_status()` in `backend/app/tasks/document_tasks.py` — one helper for every post-extraction status write, with the exclusion in the MongoDB **query filter** rather than a preceding read, because the ingestion stages run on separate Celery queues and can race.
- `perform_semantic_ingestion` no longer sets `readying` or `complete` unconditionally. The intermediate `readying` write is the half that matters — a first version of this fix guarded only the `complete` write, was deployed, and the bug survived it.
- Tests covering both the `readying` and `complete` paths, and the atomic-filter behaviour.

## Test Plan

- [x] **Manually tested** — reproduced live on a running deployment in three arms: GPU free → OCR succeeds → 14,188 chars → `complete`; GPU held → OCR 503 ×3 → 0 chars → `complete` (the bug); GPU held after the fix → 0 chars → `error`. The post-fix arm is **n=1** and this is a timing-dependent race, so ~3 runs would be better evidence; stated plainly rather than glossed.
- [x] **Updated `CHANGELOG.md`** — entry under Unreleased → Fixed.
- [x] **Shared checks — backend** — `make backend-ci` passes (3264 passed, 165 skipped), `ruff check app/` clean.
- [ ] **`make ci` end to end** — this PR is backend-only, but for completeness: the frontend half fails at `npm run typecheck` with **4 errors that are also present on an unmodified `main`**, in `src/pages/SupportCenter.tsx` and `src/components/layout/TeamsDropdown.tsx`. Nothing here touches the frontend. Flagging it because `main` currently does not typecheck.
- [ ] **Release check** — not applicable; no packaging or deployment change.
- [ ] **Deploy/release docs** — not applicable; the install path is unchanged.

## Related Issues

No issue to close — this was found by benchmarking rather than reported. Provenance and the corpus that surfaced it are in #628.

---

<details>
<summary><b>Full detail — mechanism, evidence, and the limits of that evidence</b></summary>

## What

Stop marking unreadable documents `complete`. Every post-extraction status write now refuses to advance a document that extraction already marked `error`.

## How this surfaced

Not from a user report — from a benchmark. Real proposals are the only realistic test material for this product and they cannot be shared, committed, or quoted in an issue, so I built a synthetic NSF submission packet to stand in for them: `CSU-NSF-001`, 11 documents in DOCX/PDF/XLSX, 36 pages, ~26k tokens, with 30 questions and hand-verified per-page answer keys.

The part that matters here is that every document also exists rasterized at three degradation severities with **no text layer at any level**, so the OCR path is genuinely forced rather than quietly bypassed by residual text. That put a failing OCR run against a document whose correct answer was already known — which is how a silent `complete` showed up as a confidently wrong answer instead of a plausible one.

Because the packet contains no real data, the reproduction below is runnable by anyone who has it. I am offering it upstream in #628.

## Why

When OCR fails on a scanned PDF, the document is stored with zero extracted text but `task_status: "complete"`. On screen it looks successfully processed. A user then chats with it and is told the document does not mention what they asked about — which is indistinguishable from the document genuinely not containing it. The failure is silent and the wrong answer is confident.

Extraction is not the problem. `perform_extraction_and_update` already detects a zero-character extraction and writes `task_status: "error"` with a user-facing message (`backend/app/tasks/document_tasks.py:393`), and `update_document_fields` already declines to overwrite it (`backend/app/tasks/document_tasks.py:541`). The error is erased afterwards by other stages:

- `perform_semantic_ingestion` set `task_status: "readying"` unconditionally before it started work (`backend/app/tasks/document_tasks.py:842`, line numbers as of this PR's base). That write carries no failure semantics of its own, but it clears the error.
- The same task then set `"complete"` unconditionally on both the success and the exception path (`document_tasks.py:869` and `:882`, same base), and by then the document no longer looked failed, so advancing it was legitimate.

The intermediate `"readying"` write is the half that matters. A first version of this fix guarded only the `"complete"` write, was deployed, and the bug survived it.

The fix is therefore a single helper used by every post-extraction status write, `advance_task_status()` (`backend/app/tasks/document_tasks.py:471`), with the exclusion in the query filter rather than in a preceding read (`document_tasks.py:493`):

```python
db.smart_document.update_one(
    {"uuid": document_uuid, "task_status": {"$ne": "error"}},
    {"$set": {"task_status": status}},
)
```

The filter, not a read-then-write check, because these tasks run concurrently on separate Celery queues (extraction on `documents`, compliance on `uploads`) and a read can be overtaken before the update lands. The guard is one-way — it never clears an error, so re-running extraction remains what resets a failed document, via the `"extracting"` write at `document_tasks.py:317`.

Call sites now guarded: semantic ingestion `"readying"` (`document_tasks.py:893`), and the success and ingest-failure paths (`document_tasks.py:926` and `:915`, both via `_record_ingestion_result` at `:509` and `mark_complete_unless_errored` at `:504`); compliance validation `"security"` (`backend/app/tasks/upload_validation_tasks.py:261`) and `"complete"` in both the normal and checks-disabled branches (`upload_validation_tasks.py:200` and `:249`).

Ingestion bookkeeping — `chunk_count`, `chromadb_ready`, `ingest_error` — is deliberately still written unconditionally, as a separate write, because those values are true regardless of how extraction went (`document_tasks.py:509-518`).

No frontend change is needed: `DocumentViewer` already renders `error_message` for an errored document (`frontend/src/components/files/DocumentViewer.tsx:215`, rendered at `:913-923`).

## Evidence

Reproduced end to end on a live deployment by holding the shared GPU with another service so the OCR bridge returned 503.

| Arm | OCR | Characters extracted | Resulting `task_status` |
| --- | --- | --- | --- |
| GPU free (control) | succeeded | 14,188 | `complete` (correct) |
| GPU held, before fix | 503 x3 | 0 | `complete` (the bug) |
| GPU held, after fix | 503 x3 | 0 | `error` (correct) |

After the fix the worker logged `Leaving document ... rather than setting 'readying'` and the same for `'complete'`.

Limits of this evidence, stated plainly: **the post-fix arm was run once.** This is a timing-dependent race between concurrent queues, and one clean result is not proof that the race is closed. Roughly three runs under contention would be a more convincing check, and I have not done them. The unit tests below cover the logic deterministically, but they do not exercise real concurrency either.

## Testing

The failure is a *state*, not an OCR call, so it is testable without OCR running. New tests in `backend/tests/test_document_tasks.py` assert that no status write reaches Mongo without the `{"task_status": {"$ne": "error"}}` exclusion — not merely that the terminal `"complete"` is withheld, since that narrower assertion is exactly what the first, insufficient fix would have passed. Also covered: a healthy document is still marked `complete`, and bookkeeping is still recorded on a failed one. `backend/tests/test_upload_validation_tasks.py` is updated for the now-split result write and guarded status write.

Each new test was verified to fail by re-introducing the corresponding guard removal separately.

```
$ uv run pytest tests/test_document_tasks.py tests/test_upload_validation_tasks.py -q
61 passed in 0.85s

$ uv run ruff check app/
All checks passed!
```

I have not reported a whole-suite number here: my working branch carries unrelated commits, so a full-suite count from it would not be a statement about this diff.

## Not in scope

- **Why OCR failed.** The bridge answered 503 three times in about 3.5 seconds against an outage lasting minutes — it never reached its 120s timeout. That retry policy is a separate defect, filed as #633. This change addresses the silence, which applies to any empty extraction whatever the cause.
- No frontend changes, no change to how documents are retried, and no change to how extraction itself decides a document is empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

</details>
