### PR TITLE
fix(knowledge): an empty knowledge base could be exported and cloned

### DIFF
--- a/backend/app/routers/knowledge.py
+++ b/backend/app/routers/knowledge.py
@@ -489,7 +489,11 @@ async def export_knowledge_base(uuid: str, user: User = Depends(get_current_user
     Embeddings are not included — they are regenerated when the file is imported.
     """
     kb = await _get_kb_or_404(uuid, user)
-    payload = await svc.export_knowledge_base(kb)
+    try:
+        payload = await svc.export_knowledge_base(kb)
+    except ValueError as e:
+        # Empty KB: a file with "sources": [] is nothing anyone can share.
+        raise HTTPException(status_code=400, detail=str(e))
     safe_title = re.sub(r"[^A-Za-z0-9_.-]+", "_", kb.title or "knowledge_base").strip("_")
     filename = f"{safe_title or 'knowledge_base'}.kb.json"
     return JSONResponse(

--- a/backend/app/services/knowledge_service.py
+++ b/backend/app/services/knowledge_service.py
@@ -234,6 +234,27 @@ async def get_kb_sources(kb_uuid: str) -> list[KnowledgeBaseSource]:
     ).sort(-KnowledgeBaseSource.created_at).to_list()
 
 
+async def kb_has_sources(kb: KnowledgeBase) -> bool:
+    """True when the KB has at least one source row.
+
+    Counted rather than read off ``kb.total_sources``, a denormalized field
+    that only ``recalculate_stats`` refreshes — a guard that lets an empty KB
+    through because its counter is stale is no guard at all.
+    """
+    return await KnowledgeBaseSource.find(
+        KnowledgeBaseSource.knowledge_base_uuid == kb.uuid,
+    ).count() > 0
+
+
+async def require_kb_sources(kb: KnowledgeBase, action: str) -> None:
+    """Raise ValueError unless the KB has a source. ``action`` reads as a verb
+    phrase in the message: "before exporting it"."""
+    if not await kb_has_sources(kb):
+        raise ValueError(
+            f"This knowledge base has no sources yet — add at least one source before {action} it.",
+        )
+
+
 KB_SOURCE_URL_UNIQUE_INDEX = "kb_uuid_url_unique"
 
 
@@ -824,6 +845,8 @@ async def clone_knowledge_base(
     The clone is NOT verified - the user can extend and re-verify.
     The caller is responsible for passing an already-authorized source KB.
     """
+    await require_kb_sources(source_kb, "cloning")
+
     team_id = str(user.current_team) if user.current_team else None
 
     if new_title:
@@ -1236,6 +1259,8 @@ async def export_knowledge_base(kb: KnowledgeBase) -> dict:
     text) so the importer can reconstruct + re-embed without re-fetching. Does
     NOT include ChromaDB vectors — embeddings are regenerated on import.
     """
+    await require_kb_sources(kb, "exporting")
+
     sources = await get_kb_sources(kb.uuid)
     exported_sources: list[dict] = []
     for s in sources:

--- a/backend/tests/test_kb_empty_guard.py
+++ b/backend/tests/test_kb_empty_guard.py
@@ -1,0 +1,292 @@
+"""Tests for the empty-knowledge-base guard on export and clone.
+
+A KB with no sources kept both actions live: Export downloaded a file whose
+``sources`` list was empty — nothing anyone could import or share — and Clone
+produced a second empty KB. Chat and the validation family already refused.
+These tests pin the refusal at the service and at the route. Mocked models —
+no DB.
+"""
+
+import secrets
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.config import Settings
+from app.services.knowledge_service import (
+    clone_knowledge_base,
+    export_knowledge_base,
+    kb_has_sources,
+    require_kb_sources,
+)
+from app.utils.security import create_access_token
+
+_TEST_SETTINGS = Settings(jwt_secret_key="test-secret-key", environment="development")
+
+
+def _make_user(user_id="user1"):
+    user = MagicMock()
+    user.id = "fake-id"
+    user.user_id = user_id
+    user.email = f"{user_id}@example.com"
+    user.name = "Test User"
+    user.is_admin = False
+    user.is_examiner = False
+    user.current_team = None
+    user.is_demo_user = False
+    user.token_version = 0
+    user.demo_status = None
+    user.api_token_hash = None
+    user.api_token_created_at = None
+    user.api_token_expires_at = None
+    return user
+
+
+def _auth(user_id="user1"):
+    token = create_access_token(user_id, _TEST_SETTINGS)
+    csrf = secrets.token_urlsafe(32)
+    return {"access_token": token, "csrf_token": csrf}, {"X-CSRF-Token": csrf}
+
+
+def _make_kb(uuid="kb-1", title="Export Control Regulations"):
+    kb = MagicMock()
+    kb.uuid = uuid
+    kb.title = title
+    kb.description = ""
+    kb.tags = []
+    kb.status = "empty"
+    kb.shared_with_team = False
+    kb.verified = False
+    kb.organization_ids = []
+    kb.total_sources = 0
+    kb.sources_ready = 0
+    kb.sources_failed = 0
+    kb.total_chunks = 0
+    kb.created_at = None
+    kb.updated_at = None
+    kb.user_id = "user1"
+    return kb
+
+
+def _url_source(uuid="src-1"):
+    """A URL source with cached content — the export path that needs no
+    SmartDocument lookup."""
+    src = MagicMock()
+    src.uuid = uuid
+    src.source_type = "url"
+    src.document_uuid = None
+    src.url = "https://example.edu/policy"
+    src.url_title = "Policy"
+    src.custom_name = None
+    src.content = "Export control policy text."
+    src.crawl_enabled = False
+    src.max_crawl_pages = 1
+    src.parent_source_uuid = None
+    src.crawled_urls = None
+    return src
+
+
+def _stub_sources(rows):
+    """Patch the KnowledgeBaseSource queries the guard and export both make."""
+    cls = MagicMock()
+    query = cls.find.return_value
+    query.count = AsyncMock(return_value=len(rows))
+    query.sort.return_value.to_list = AsyncMock(return_value=list(rows))
+    return patch("app.services.knowledge_service.KnowledgeBaseSource", cls)
+
+
+@pytest.fixture
+async def client():
+    with patch("app.main.init_db", new_callable=AsyncMock):
+        from app.main import app
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        ) as ac:
+            yield ac
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_kb_has_sources_counts_rows_rather_than_trusting_the_counter():
+    """``total_sources`` is denormalized; a stale one must not open the gate."""
+    kb = _make_kb()
+    kb.total_sources = 7  # stale counter, no rows behind it
+
+    with _stub_sources([]):
+        assert await kb_has_sources(kb) is False
+
+    with _stub_sources([_url_source()]):
+        assert await kb_has_sources(kb) is True
+
+
+@pytest.mark.asyncio
+async def test_require_kb_sources_names_the_action():
+    kb = _make_kb()
+    with _stub_sources([_url_source()]):
+        await require_kb_sources(kb, "exporting")  # does not raise
+
+    with _stub_sources([]):
+        with pytest.raises(
+            ValueError,
+            match="no sources yet — add at least one source before exporting it",
+        ):
+            await require_kb_sources(kb, "exporting")
+
+
+# ---------------------------------------------------------------------------
+# Export
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_export_rejects_kb_with_no_sources():
+    kb = _make_kb()
+    doc_cls = MagicMock()
+    doc_cls.find_one = AsyncMock()
+
+    with _stub_sources([]), patch("app.services.knowledge_service.SmartDocument", doc_cls):
+        with pytest.raises(ValueError, match="no sources yet"):
+            await export_knowledge_base(kb)
+
+    doc_cls.find_one.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_export_still_serializes_a_kb_with_a_source():
+    kb = _make_kb()
+
+    with _stub_sources([_url_source()]):
+        payload = await export_knowledge_base(kb)
+
+    assert payload["title"] == "Export Control Regulations"
+    assert len(payload["sources"]) == 1
+    assert payload["sources"][0]["url"] == "https://example.edu/policy"
+
+
+@pytest.mark.asyncio
+async def test_export_route_returns_400_for_an_empty_kb(client):
+    user = _make_user()
+    cookies, headers = _auth()
+    kb = _make_kb()
+
+    with (
+        patch("app.dependencies.decode_token", return_value={"sub": "user1", "type": "access"}),
+        patch("app.dependencies.User") as MockUser,
+        patch(
+            "app.routers.knowledge.organization_service.get_user_org_ancestry",
+            new_callable=AsyncMock,
+        ) as mock_org_ancestry,
+        patch("app.routers.knowledge.svc.get_knowledge_base", new_callable=AsyncMock) as mock_get_kb,
+        _stub_sources([]),
+    ):
+        MockUser.find_one = AsyncMock(return_value=user)
+        mock_org_ancestry.return_value = []
+        mock_get_kb.return_value = kb
+
+        resp = await client.get(
+            "/api/knowledge/kb-1/export",
+            cookies=cookies,
+            headers=headers,
+        )
+
+    assert resp.status_code == 400
+    assert "no sources yet" in resp.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_export_route_still_downloads_a_kb_with_a_source(client):
+    user = _make_user()
+    cookies, headers = _auth()
+    kb = _make_kb()
+
+    with (
+        patch("app.dependencies.decode_token", return_value={"sub": "user1", "type": "access"}),
+        patch("app.dependencies.User") as MockUser,
+        patch(
+            "app.routers.knowledge.organization_service.get_user_org_ancestry",
+            new_callable=AsyncMock,
+        ) as mock_org_ancestry,
+        patch("app.routers.knowledge.svc.get_knowledge_base", new_callable=AsyncMock) as mock_get_kb,
+        _stub_sources([_url_source()]),
+    ):
+        MockUser.find_one = AsyncMock(return_value=user)
+        mock_org_ancestry.return_value = []
+        mock_get_kb.return_value = kb
+
+        resp = await client.get(
+            "/api/knowledge/kb-1/export",
+            cookies=cookies,
+            headers=headers,
+        )
+
+    assert resp.status_code == 200
+    assert "attachment" in resp.headers["content-disposition"]
+    assert len(resp.json()["sources"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# Clone
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_clone_rejects_kb_with_no_sources_before_creating_anything():
+    kb = _make_kb()
+    user = _make_user()
+    name_conflicts = MagicMock()
+    name_conflicts.next_available_name = AsyncMock()
+    kb_cls = MagicMock()
+
+    with (
+        _stub_sources([]),
+        patch("app.services.knowledge_service.name_conflicts", name_conflicts),
+        patch("app.services.knowledge_service.KnowledgeBase", kb_cls),
+    ):
+        with pytest.raises(ValueError, match="no sources yet — add at least one source before cloning it"):
+            await clone_knowledge_base(kb, user)
+
+    # No half-made clone left behind: the guard runs before the title check.
+    name_conflicts.next_available_name.assert_not_awaited()
+    kb_cls.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_clone_route_returns_400_for_an_empty_kb(client):
+    user = _make_user()
+    cookies, headers = _auth()
+    kb = _make_kb()
+    name_conflicts = MagicMock()
+    name_conflicts.next_available_name = AsyncMock()
+
+    with (
+        patch("app.dependencies.decode_token", return_value={"sub": "user1", "type": "access"}),
+        patch("app.dependencies.User") as MockUser,
+        patch(
+            "app.routers.knowledge.organization_service.get_user_org_ancestry",
+            new_callable=AsyncMock,
+        ) as mock_org_ancestry,
+        patch("app.routers.knowledge.svc.get_knowledge_base", new_callable=AsyncMock) as mock_get_kb,
+        patch("app.services.knowledge_service.name_conflicts", name_conflicts),
+        _stub_sources([]),
+    ):
+        MockUser.find_one = AsyncMock(return_value=user)
+        mock_org_ancestry.return_value = []
+        mock_get_kb.return_value = kb
+
+        resp = await client.post(
+            "/api/knowledge/kb-1/clone",
+            json={},
+            cookies=cookies,
+            headers=headers,
+        )
+
+    assert resp.status_code == 400
+    assert "no sources yet" in resp.json()["detail"]
+    name_conflicts.next_available_name.assert_not_awaited()

--- a/frontend/src/components/knowledge/KBGridView.test.tsx
+++ b/frontend/src/components/knowledge/KBGridView.test.tsx
@@ -91,4 +91,23 @@ describe('KBGridView clone action', () => {
 
     expect(screen.queryByText('Clone')).not.toBeInTheDocument()
   })
+
+  // Support ticket: cloning a KB with no sources produced a second empty KB.
+  it('disables Clone on a KB with no sources, and says why', () => {
+    kbs.current = [makeKB({
+      status: 'empty',
+      total_sources: 0,
+      sources_ready: 0,
+      total_chunks: 0,
+    })]
+    const onClone = vi.fn()
+    render(<KBGridView {...baseProps} onClone={onClone} />)
+
+    const button = screen.getByText('Clone').closest('button')
+    expect(button).toBeDisabled()
+    expect(button).toHaveAttribute('title', 'This knowledge base has no sources to copy yet')
+
+    fireEvent.click(screen.getByText('Clone'))
+    expect(onClone).not.toHaveBeenCalled()
+  })
 })

--- a/frontend/src/components/knowledge/KBGridView.tsx
+++ b/frontend/src/components/knowledge/KBGridView.tsx
@@ -86,6 +86,9 @@ function KBGridCard({
   // A broken bookmark has no underlying KB to open — the card is inert except
   // for its Remove button.
   const isUnavailable = kb.status === 'unavailable'
+  // Cloning copies source references. A KB with none yields another empty KB,
+  // which the backend now refuses — the card says so instead of offering it.
+  const canClone = !isUnavailable && kb.total_sources > 0
   // The id a project pins is the canonical KB uuid — for a reference card that's
   // the original it points at, matching what onChat uses.
   const canonicalUuid = isReference ? (kb.source_kb_uuid || kb.uuid) : kb.uuid
@@ -295,13 +298,18 @@ function KBGridCard({
         )}
         {onClone && !isUnavailable && (
           <button
-            onClick={(e) => { e.stopPropagation(); onClone(canonicalUuid) }}
-            title="Make an editable copy of this knowledge base"
+            onClick={(e) => { e.stopPropagation(); if (canClone) onClone(canonicalUuid) }}
+            disabled={!canClone}
+            title={canClone
+              ? 'Make an editable copy of this knowledge base'
+              : 'This knowledge base has no sources to copy yet'}
             style={{
               display: 'flex', alignItems: 'center', gap: 4,
               padding: '4px 10px', fontSize: 11, fontWeight: 600, fontFamily: 'inherit',
-              color: '#ccc', backgroundColor: 'transparent',
-              border: `1px solid ${C.border}`, borderRadius: 4, cursor: 'pointer',
+              color: canClone ? '#ccc' : '#777', backgroundColor: 'transparent',
+              border: `1px solid ${C.border}`, borderRadius: 4,
+              cursor: canClone ? 'pointer' : 'default',
+              opacity: canClone ? 1 : 0.5,
             }}
           >
             <Copy size={11} />

--- a/frontend/src/components/knowledge/KBQualityHistoryTab.test.tsx
+++ b/frontend/src/components/knowledge/KBQualityHistoryTab.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { KBQualityHistoryTab } from './KBQualityHistoryTab'
+
+const getKBQuality = vi.fn().mockResolvedValue({ history: [] })
+
+vi.mock('../../api/knowledge', () => ({
+  getKBQuality: (uuid: string) => getKBQuality(uuid),
+  downloadKBValidationRunExport: vi.fn(),
+}))
+
+// Support ticket: on a KB with no sources the History tab rendered the
+// Validate pitch — a big "Validate & improve" button for a run that KB can't
+// do — instead of saying there were no runs.
+describe('KBQualityHistoryTab empty state', () => {
+  it('states the absence, without the Validate pitch, for a KB with no sources', async () => {
+    render(
+      <KBQualityHistoryTab
+        kbUuid="kb-1"
+        kbHasSources={false}
+        onSwitchToAutovalidate={vi.fn()}
+      />,
+    )
+
+    await waitFor(() =>
+      expect(screen.getByText(/No validation runs yet for this KB/)).toBeInTheDocument(),
+    )
+    expect(screen.getByText(/Add at least one source/)).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Validate & improve/ })).not.toBeInTheDocument()
+  })
+
+  it('keeps the Validate & improve pitch for a KB that could be validated', async () => {
+    render(
+      <KBQualityHistoryTab
+        kbUuid="kb-1"
+        kbHasSources
+        onSwitchToAutovalidate={vi.fn()}
+      />,
+    )
+
+    await waitFor(() =>
+      expect(screen.getByText(/No quality history yet for this KB/)).toBeInTheDocument(),
+    )
+    expect(screen.getByRole('button', { name: /Validate & improve/ })).toBeInTheDocument()
+    expect(screen.queryByText(/No validation runs yet for this KB/)).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/knowledge/KBQualityHistoryTab.tsx
+++ b/frontend/src/components/knowledge/KBQualityHistoryTab.tsx
@@ -9,10 +9,13 @@ interface Props {
   refreshKey?: number
   /** True while a validation run is in flight, to poll for the landing row. */
   polling?: boolean
+  /** False for a KB with no sources: it can't be validated, so an empty history
+   *  is a plain statement of fact rather than a prompt to go run one. */
+  kbHasSources?: boolean
 }
 
 /** Thin adapter over the shared QualityTimeline (Phase 4). */
-export function KBQualityHistoryTab({ kbUuid, onSwitchToAutovalidate, refreshKey, polling }: Props) {
+export function KBQualityHistoryTab({ kbUuid, onSwitchToAutovalidate, refreshKey, polling, kbHasSources = true }: Props) {
   const fetchHistory = useCallback(() => getKBQuality(kbUuid), [kbUuid])
   const exportRun = useCallback(
     (runUuid: string, format: QualityRunExportFormat) =>
@@ -29,6 +32,9 @@ export function KBQualityHistoryTab({ kbUuid, onSwitchToAutovalidate, refreshKey
       refreshKey={refreshKey}
       polling={polling}
       onExportRun={exportRun}
+      blockedReason={kbHasSources
+        ? null
+        : 'Add at least one source, then run Validate & improve to record a quality score here.'}
     />
   )
 }

--- a/frontend/src/components/knowledge/KBValidationPanel.tsx
+++ b/frontend/src/components/knowledge/KBValidationPanel.tsx
@@ -21,6 +21,10 @@ interface Props {
   kbUuid: string
   kbReady: boolean
   canManage: boolean
+  /** Whether the KB has any sources at all. ``kbReady`` alone can't tell an
+   *  empty KB from one still indexing, and only the empty case gets the "add a
+   *  source" wording in History. */
+  kbHasSources?: boolean
   /** Called with the new KB's uuid after the user clones a KB they can't
    * manage, so the parent can navigate to their own copy. */
   onCloned?: (newUuid: string) => void
@@ -72,7 +76,7 @@ type LatestQualitySummary = {
   createdAt: string | null
 }
 
-export function KBValidationPanel({ kbUuid, kbReady, canManage, onCloned, collapsed = false, onToggleCollapsed }: Props) {
+export function KBValidationPanel({ kbUuid, kbReady, canManage, kbHasSources = true, onCloned, collapsed = false, onToggleCollapsed }: Props) {
   const [tab, setTab] = useState<Tab>('autovalidate')
   const [queries, setQueries] = useState<KBTestQuery[]>([])
   const [latestRun, setLatestRun] = useState<KBValidationResult | null>(null)
@@ -429,6 +433,7 @@ export function KBValidationPanel({ kbUuid, kbReady, canManage, onCloned, collap
           onSwitchToAutovalidate={() => setTab('autovalidate')}
           refreshKey={historyRefreshKey}
           polling={running}
+          kbHasSources={kbHasSources}
         />
       )}
       </div>

--- a/frontend/src/components/shared/QualityTimeline.tsx
+++ b/frontend/src/components/shared/QualityTimeline.tsx
@@ -56,13 +56,17 @@ interface Props {
    *  that exports the run's per-query results. Optimizer-apply rows carry no
    *  per-query results, so they never show the menu. */
   onExportRun?: (runUuid: string, format: QualityRunExportFormat) => void | Promise<void>
+  /** Why this item can't be validated yet (e.g. a KB with no sources). When
+   *  set and there is no history, the empty state states that plainly rather
+   *  than pitching a Validate & improve run the item can't do. */
+  blockedReason?: string | null
 }
 
 export type QualityRunExportFormat = 'csv' | 'xlsx' | 'json'
 
 export function QualityTimeline({
   fetchHistory, itemKindLabel, itemKindPluralLabel, onSwitchToAutovalidate, sampleNoun = 'items',
-  refreshKey, polling = false, onExportRun,
+  refreshKey, polling = false, onExportRun, blockedReason,
 }: Props) {
   const [items, setItems] = useState<QualityHistoryItem[]>([])
   const [loading, setLoading] = useState(true)
@@ -98,6 +102,17 @@ export function QualityTimeline({
         }}>
           Loading quality history…
         </span>
+      </div>
+    )
+  }
+
+  if (items.length === 0 && blockedReason) {
+    // Nothing to show and nothing the user could run from here: state the
+    // absence, in the register of the "No prior optimization runs" note, and
+    // leave the pitch to the Validate tab.
+    return (
+      <div role="status" aria-live="polite" style={{ fontSize: 12, color: '#888', padding: '12px 8px', lineHeight: 1.6 }}>
+        No validation runs yet for this {itemKindLabel}. {blockedReason}
       </div>
     )
   }

--- a/frontend/src/components/workspace/KnowledgePanel.test.tsx
+++ b/frontend/src/components/workspace/KnowledgePanel.test.tsx
@@ -214,3 +214,48 @@ describe('KnowledgePanel add-source permissions', () => {
     expect(screen.getByText('Share with Team').closest('button')).not.toBeDisabled()
   }, 30000)
 })
+
+// Support ticket: an empty KB disabled Chat and the whole validation family,
+// but Export happily downloaded a file with no sources in it.
+describe('KnowledgePanel export on an empty KB', () => {
+  beforeEach(() => {
+    getKnowledgeBase.mockClear()
+  })
+
+  it('disables Export until the KB has a source, and says why', async () => {
+    detail.current = makeDetail({
+      status: 'empty',
+      total_sources: 0,
+      sources_ready: 0,
+      total_chunks: 0,
+      sources: [],
+    })
+    await openDetail()
+
+    const exportButton = screen.getByText('Export').closest('button')
+    expect(exportButton).toBeDisabled()
+    expect(exportButton).toHaveAttribute(
+      'title',
+      'Add at least one source to this knowledge base first',
+    )
+  }, 30000)
+
+  it('enables Export once a source exists', async () => {
+    detail.current = makeDetail({
+      status: 'ready',
+      total_sources: 1,
+      sources: [{
+        uuid: 'src-1',
+        source_type: 'url',
+        url: 'https://example.gov/rule',
+        url_title: 'A Rule',
+        status: 'ready',
+        chunk_count: 4,
+        created_at: '2026-01-01T00:00:00Z',
+      }],
+    })
+    await openDetail()
+
+    expect(screen.getByText('Export').closest('button')).not.toBeDisabled()
+  }, 30000)
+})

--- a/frontend/src/components/workspace/KnowledgePanel.tsx
+++ b/frontend/src/components/workspace/KnowledgePanel.tsx
@@ -656,6 +656,9 @@ export function KnowledgePanel() {
     // A ready KB with zero indexed chunks has nothing to retrieve — chatting
     // with it only produces a misleading "still indexing" reply.
     const canChatKB = selectedKB.status === 'ready' && selectedKB.total_chunks > 0
+    // Export serializes the KB's sources. With none it downloads a file nobody
+    // can use — the backend refuses it now, so say why before the click.
+    const hasSources = selectedKB.total_sources > 0
     return (
       <>
       <div style={{ height: '100%', display: 'flex', flexDirection: 'column', background: '#1e1e1e', position: 'relative' }}>
@@ -1044,15 +1047,17 @@ export function KnowledgePanel() {
               </button>
               <button
                 onClick={handleExport}
-                disabled={exporting}
-                title="Download this knowledge base as a JSON file"
+                disabled={exporting || !hasSources}
+                title={hasSources
+                  ? 'Download this knowledge base as a JSON file'
+                  : 'Add at least one source to this knowledge base first'}
                 style={{
                   display: 'flex', alignItems: 'center', gap: 6,
                   padding: '6px 12px', fontSize: 12, fontWeight: 600, fontFamily: 'inherit',
                   color: '#e5e5e5', backgroundColor: '#2a2a2a',
                   border: '1px solid #3a3a3a', borderRadius: 6,
-                  cursor: exporting ? 'default' : 'pointer',
-                  opacity: exporting ? 0.5 : 1,
+                  cursor: exporting || !hasSources ? 'default' : 'pointer',
+                  opacity: exporting || !hasSources ? 0.5 : 1,
                 }}
               >
                 {exporting ? <Loader2 size={13} style={{ animation: 'spin 1s linear infinite' }} /> : <Download size={13} />}
@@ -1377,6 +1382,7 @@ export function KnowledgePanel() {
               kbUuid={selectedKB.uuid}
               kbReady={selectedKB.status === 'ready'}
               canManage={canManageKB}
+              kbHasSources={hasSources}
               onCloned={(newUuid) => { refresh(); loadDetail(newUuid) }}
               collapsed={validationCollapsed}
               onToggleCollapsed={() => setValidationCollapsed(c => !c)}


### PR DESCRIPTION
Support ticket: a knowledge base with no sources disabled Chat, Validate & improve, Test Queries, and Run Validation — but three surfaces didn't follow that pattern.

- **Export** downloaded a file whose `sources` list was empty: nothing anyone can import or share.
- **Clone** created a second empty knowledge base.
- **History** (under Validation) rendered the shared timeline's promotional empty state — a "Validate & improve" button for a run that KB can't do — while the "Previous runs" list beside it already says plainly "No prior optimization runs for this KB".

Nothing checked the source count at any layer, so this guards both.

## Backend

- `kb_has_sources()` / `require_kb_sources()` in `knowledge_service`, called from `export_knowledge_base` and `clone_knowledge_base`.
- `GET /knowledge/{uuid}/export` returns 400 instead of an empty file; the clone route already mapped `ValueError` → 400.
- The check counts source rows rather than reading `kb.total_sources`, a denormalized counter only `recalculate_stats` refreshes — a guard a stale counter can open is no guard.
- Clone refuses before reserving a title or inserting anything, so a blocked attempt leaves nothing behind. The library-item clone path already funnels exceptions into its own controlled result, so it doesn't become a 500.

## Frontend

- Export (KB detail) and Clone (KB card) disable with the reason in the title.
- History threads a `blockedReason` through the shared `QualityTimeline`: with no history and no way to run one, it states the absence in the register of the "Previous runs" note and leaves the pitch to the Validate tab. A KB that is merely still indexing keeps the pitch — the flag is `total_sources`-based, not `kbReady`.

## Verification

- New `backend/tests/test_kb_empty_guard.py` (8 tests): stale-counter case, message wording, service refusals with nothing created, both routes at 400, and both happy paths intact.
- Existing `test_knowledge_routes` / `test_knowledge_ingest` / `test_library_service` / `test_kb_source_dedup`: 136 passed, 2 skipped.
- New `KBQualityHistoryTab.test.tsx` plus cases added to `KBGridView.test.tsx` and `KnowledgePanel.test.tsx`: 14 passed. `tsc --noEmit`, ruff, and eslint clean.

Not changed: `import_knowledge_base` still accepts a hand-made payload with zero sources — that just creates an empty KB, same as the Create button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)