### PR TITLE
fix(workflows): an empty workflow could be run

### DIFF
--- a/backend/app/routers/workflows.py
+++ b/backend/app/routers/workflows.py
@@ -549,7 +549,7 @@ async def export_workflow(workflow_id: str, user: User = Depends(get_current_use
     wf = await get_authorized_workflow(workflow_id, user)
     if not wf:
         raise HTTPException(status_code=404, detail="Workflow not found")
-    if not wf.steps:
+    if not await svc.workflow_has_executable_steps(wf):
         raise HTTPException(
             status_code=400,
             detail="This workflow has no steps yet — add at least one step before exporting it.",
@@ -872,6 +872,13 @@ async def run_workflow(request: Request, workflow_id: str, req: RunWorkflowReque
     wf = await get_authorized_workflow(workflow_id, user, share_token=req.share_token)
     if not wf:
         raise HTTPException(status_code=404, detail="Workflow not found")
+    # Checked here rather than only in the service so a blocked click doesn't
+    # leave a failed activity behind in History for every attempt.
+    if not await svc.workflow_has_executable_steps(wf):
+        raise HTTPException(
+            status_code=400,
+            detail="This workflow has no steps yet — add at least one step before running it.",
+        )
     document_uuids = await _authorize_documents(req.document_uuids, user)
     if req.folder_uuids:
         from app.services import folder_service

--- a/backend/app/services/workflow_service.py
+++ b/backend/app/services/workflow_service.py
@@ -513,6 +513,11 @@ async def run_workflow(
         if not wf:
             raise ValueError("Workflow not found")
 
+    if not await workflow_has_executable_steps(wf):
+        raise ValueError(
+            "This workflow has no steps yet — add at least one step before running it.",
+        )
+
     if not model:
         model = await get_user_model_name(user_id)
 
@@ -702,6 +707,11 @@ async def run_workflow_batch(
         if not wf:
             raise ValueError("Workflow not found")
 
+    if not await workflow_has_executable_steps(wf):
+        raise ValueError(
+            "This workflow has no steps yet — add at least one step before running it.",
+        )
+
     if not model:
         model = await get_user_model_name(user_id)
 
@@ -884,9 +894,36 @@ async def reorder_steps(workflow_id: str, step_ids: list[str], user: User) -> bo
 # Validation Plan
 # ---------------------------------------------------------------------------
 
+def _is_trigger_step(step: dict) -> bool:
+    """True for the empty "Document" step that stands in for the run's input.
+
+    The engine prepends one of these at execution time, and some stored
+    workflows carry their own copy — which the design canvas hides. A workflow
+    whose only step is that trigger is empty as far as the user is concerned.
+    """
+    return step.get("name") == "Document" and not step.get("tasks")
+
+
 def workflow_has_steps(wf_data: dict | None) -> bool:
-    """True when the dereferenced workflow definition has at least one step."""
-    return bool((wf_data or {}).get("steps"))
+    """True when the dereferenced definition has a step that does something."""
+    return any(
+        not _is_trigger_step(step)
+        for step in ((wf_data or {}).get("steps") or [])
+    )
+
+
+async def workflow_has_executable_steps(wf: Workflow) -> bool:
+    """``workflow_has_steps`` for a raw Workflow doc, whose steps are ids.
+
+    One query, and none at all for the empty case — this sits on the run path.
+    """
+    if not wf.steps:
+        return False
+    steps = await WorkflowStep.find({"_id": {"$in": wf.steps}}).to_list()
+    return any(
+        not _is_trigger_step({"name": step.name, "tasks": step.tasks})
+        for step in steps
+    )
 
 
 def require_workflow_steps(wf_data: dict | None, action: str) -> None:

--- a/backend/tests/test_workflow_authz.py
+++ b/backend/tests/test_workflow_authz.py
@@ -480,6 +480,7 @@ class TestWorkflowRunAuthz:
              patch("beanie.PydanticObjectId", side_effect=lambda x: x):
             MockUser.find_one = AsyncMock(return_value=user)
             mock_svc.run_workflow = AsyncMock(return_value="session-123")
+            mock_svc.workflow_has_executable_steps = AsyncMock(return_value=True)
 
             resp = await client.post(
                 f"/api/workflows/{self._FAKE_OID}/run",
@@ -513,6 +514,7 @@ class TestWorkflowRunAuthz:
              patch("beanie.PydanticObjectId", side_effect=lambda x: x):
             MockUser.find_one = AsyncMock(return_value=user)
             mock_svc.run_workflow = AsyncMock(return_value="session-123")
+            mock_svc.workflow_has_executable_steps = AsyncMock(return_value=True)
 
             resp = await client.post(
                 f"/api/workflows/{self._FAKE_OID}/run",

--- a/backend/tests/test_workflow_empty_guard.py
+++ b/backend/tests/test_workflow_empty_guard.py
@@ -18,6 +18,7 @@ from app.services.workflow_service import (
     generate_validation_plan,
     require_workflow_steps,
     validate_workflow,
+    workflow_has_executable_steps,
     workflow_has_steps,
 )
 from app.utils.security import create_access_token
@@ -70,6 +71,61 @@ def test_workflow_has_steps():
     assert workflow_has_steps({"steps": []}) is False
     assert workflow_has_steps({}) is False
     assert workflow_has_steps(None) is False
+
+
+def test_workflow_has_steps_ignores_the_hidden_trigger_step():
+    """The empty "Document" step is the run's input placeholder, and the canvas
+    hides it — a workflow carrying only that one reads as empty to the user."""
+    trigger = {"name": "Document", "is_output": False, "tasks": []}
+    assert workflow_has_steps({"steps": [trigger]}) is False
+    assert workflow_has_steps({"steps": [trigger, _STEP]}) is True
+    # A step the user named "Document" that actually does something counts.
+    assert workflow_has_steps({
+        "steps": [{"name": "Document", "tasks": [{"name": "Prompt", "data": {}}]}],
+    }) is True
+
+
+def _stub_step_lookup(found):
+    """Patch the one query workflow_has_executable_steps makes."""
+    step_cls = MagicMock()
+    step_cls.find.return_value.to_list = AsyncMock(return_value=found)
+    return patch("app.services.workflow_service.WorkflowStep", step_cls)
+
+
+@pytest.mark.asyncio
+async def test_workflow_has_executable_steps_resolves_step_ids():
+    wf = MagicMock()
+    wf.steps = ["s1", "s2"]
+    trigger = MagicMock(); trigger.name = "Document"; trigger.tasks = []
+    real = MagicMock(); real.name = "Summarize"; real.tasks = ["t1"]
+
+    with _stub_step_lookup([trigger, real]):
+        assert await workflow_has_executable_steps(wf) is True
+
+    with _stub_step_lookup([trigger]):
+        assert await workflow_has_executable_steps(wf) is False
+
+
+@pytest.mark.asyncio
+async def test_workflow_has_executable_steps_skips_the_query_when_empty():
+    """The run path pays for this check on every run — no steps, no query."""
+    wf = MagicMock()
+    wf.steps = []
+    step_cls = MagicMock()
+
+    with patch("app.services.workflow_service.WorkflowStep", step_cls):
+        assert await workflow_has_executable_steps(wf) is False
+
+    step_cls.find.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_workflow_has_executable_steps_handles_dangling_ids():
+    """Step ids whose documents are gone resolve to nothing, so they don't count."""
+    wf = MagicMock()
+    wf.steps = ["missing"]
+    with _stub_step_lookup([]):
+        assert await workflow_has_executable_steps(wf) is False
 
 
 def test_require_workflow_steps_names_the_action():
@@ -141,6 +197,145 @@ async def test_validate_still_reports_a_missing_plan_when_steps_exist():
 
 
 # ---------------------------------------------------------------------------
+# Running
+# ---------------------------------------------------------------------------
+
+
+def _step(name="Summarize", tasks=("t1",)):
+    step = MagicMock()
+    step.name = name  # can't go through the MagicMock ctor — `name` is reserved
+    step.tasks = list(tasks)
+    return step
+
+
+def _run_workflow_patches(stored_steps):
+    """Patch everything run_workflow touches, resolving its steps to *stored_steps*."""
+    wf = MagicMock()
+    wf.id = "wf-oid"
+    wf.steps = [f"step-{i}" for i in range(len(stored_steps))]
+    doc = MagicMock()
+    doc.uuid = "doc-uuid"
+
+    return wf, (
+        patch("app.services.workflow_service.get_authorized_workflow",
+              new=AsyncMock(return_value=wf)),
+        patch("app.services.workflow_service.get_team_access_context",
+              new=AsyncMock(return_value=MagicMock())),
+        patch("app.services.workflow_service.get_authorized_document",
+              new=AsyncMock(return_value=doc)),
+        _stub_step_lookup(stored_steps),
+        patch("app.services.workflow_service.get_user_model_name",
+              new=AsyncMock(return_value="test-model")),
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_rejects_workflow_with_no_steps():
+    """The run used to complete in ~120ms and hand back the input document's
+    uuid as its output, marked Completed in History."""
+    from app.services.workflow_service import run_workflow
+
+    user = _make_user()
+    _, patches = _run_workflow_patches([])
+    send_task = MagicMock()
+    result_cls = MagicMock()
+
+    with patches[0], patches[1], patches[2], patches[3], patches[4], \
+         patch("app.services.workflow_service.celery_app.send_task", send_task), \
+         patch("app.services.workflow_service.WorkflowResult", result_cls):
+        with pytest.raises(ValueError, match="no steps yet"):
+            await run_workflow("wf", ["doc-uuid"], "u", user=user)
+
+    send_task.assert_not_called()
+    result_cls.assert_not_called()  # no WorkflowResult, so nothing lands in History
+
+
+@pytest.mark.asyncio
+async def test_run_rejects_workflow_whose_only_step_is_the_trigger():
+    from app.services.workflow_service import run_workflow
+
+    user = _make_user()
+    _, patches = _run_workflow_patches([_step(name="Document", tasks=())])
+    send_task = MagicMock()
+
+    with patches[0], patches[1], patches[2], patches[3], patches[4], \
+         patch("app.services.workflow_service.celery_app.send_task", send_task), \
+         patch("app.services.workflow_service.WorkflowResult", MagicMock()):
+        with pytest.raises(ValueError, match="no steps yet"):
+            await run_workflow("wf", ["doc-uuid"], "u", user=user)
+
+    send_task.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_run_dispatches_when_a_real_step_exists():
+    from app.services.workflow_service import run_workflow
+
+    user = _make_user()
+    _, patches = _run_workflow_patches([_step(name="Document", tasks=()), _step()])
+    send_task = MagicMock()
+    result = MagicMock()
+    result.id = "result-oid"
+    result.insert = AsyncMock()
+
+    with patches[0], patches[1], patches[2], patches[3], patches[4], \
+         patch("app.services.workflow_service.celery_app.send_task", send_task), \
+         patch("app.services.workflow_service.WorkflowResult", MagicMock(return_value=result)):
+        session_id = await run_workflow("wf", ["doc-uuid"], "u", user=user)
+
+    assert session_id
+    send_task.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_batch_run_rejects_workflow_with_no_steps():
+    from app.services.workflow_service import run_workflow_batch
+
+    user = _make_user()
+    _, patches = _run_workflow_patches([])
+    send_task = MagicMock()
+
+    with patches[0], patches[1], patches[2], patches[3], patches[4], \
+         patch("app.services.workflow_service.celery_app.send_task", send_task), \
+         patch("app.services.workflow_service.WorkflowResult", MagicMock()):
+        with pytest.raises(ValueError, match="no steps yet"):
+            await run_workflow_batch("wf", ["doc-uuid"], "u", user=user)
+
+    send_task.assert_not_called()
+
+
+class TestRunRoute:
+    @pytest.mark.asyncio
+    async def test_run_route_returns_400_without_starting_an_activity(self, client):
+        """A blocked click must not leave a failed activity behind in History."""
+        user = _make_user()
+        cookies, headers = _auth()
+        wf = MagicMock()
+        wf.name = "Empty WF"
+        wf.steps = []
+        activity_start = AsyncMock()
+
+        with patch("app.dependencies.decode_token", return_value={"sub": "testuser", "type": "access"}), \
+             patch("app.dependencies.User") as MockUser, \
+             patch("app.routers.workflows.get_authorized_workflow", AsyncMock(return_value=wf)), \
+             patch("app.routers.workflows.svc.workflow_has_executable_steps",
+                   AsyncMock(return_value=False)), \
+             patch("app.services.activity_service.activity_start", activity_start):
+            MockUser.find_one = AsyncMock(return_value=user)
+
+            resp = await client.post(
+                "/api/workflows/wf-id/run",
+                json={"document_uuids": ["doc-uuid"]},
+                cookies=cookies,
+                headers=headers,
+            )
+
+        assert resp.status_code == 400
+        assert "no steps yet" in resp.json()["detail"]
+        activity_start.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
 # Export route
 # ---------------------------------------------------------------------------
 
@@ -155,7 +350,9 @@ class TestExportGuard:
 
         with patch("app.dependencies.decode_token", return_value={"sub": "testuser", "type": "access"}), \
              patch("app.dependencies.User") as MockUser, \
-             patch("app.routers.workflows.get_authorized_workflow", AsyncMock(return_value=wf)):
+             patch("app.routers.workflows.get_authorized_workflow", AsyncMock(return_value=wf)), \
+             patch("app.routers.workflows.svc.workflow_has_executable_steps",
+                   AsyncMock(return_value=False)):
             MockUser.find_one = AsyncMock(return_value=user)
 
             resp = await client.get("/api/workflows/wf-id/export", cookies=cookies, headers=headers)
@@ -173,6 +370,8 @@ class TestExportGuard:
         with patch("app.dependencies.decode_token", return_value={"sub": "testuser", "type": "access"}), \
              patch("app.dependencies.User") as MockUser, \
              patch("app.routers.workflows.get_authorized_workflow", AsyncMock(return_value=wf)), \
+             patch("app.routers.workflows.svc.workflow_has_executable_steps",
+                   AsyncMock(return_value=True)), \
              patch("app.services.export_import_service.export_workflow",
                    AsyncMock(return_value={"items": [{"name": "My WF", "steps": [{"name": "Summarize"}]}]})):
             MockUser.find_one = AsyncMock(return_value=user)

--- a/backend/tests/test_workflow_service.py
+++ b/backend/tests/test_workflow_service.py
@@ -644,16 +644,33 @@ class TestBuildResult:
 # run_workflow
 # ---------------------------------------------------------------------------
 
+def _stub_steps(mock_step_cls, names):
+    """Resolve the workflow's step ids to real-looking steps.
+
+    Runs are refused for a workflow with nothing to do, so the run path now
+    reads the step docs to tell a real step from the empty "Document" trigger.
+    """
+    docs = []
+    for step_name in names:
+        step = MagicMock()
+        step.name = step_name  # `name` is reserved in the MagicMock ctor
+        step.tasks = ["task-id"]
+        docs.append(step)
+    mock_step_cls.find.return_value.to_list = AsyncMock(return_value=docs)
+
+
 class TestRunWorkflow:
     @patch("app.services.workflow_service.celery_app")
     @patch("app.services.workflow_service.WorkflowResult")
     @patch("app.services.workflow_service.get_user_model_name", new_callable=AsyncMock, return_value="gpt-4o")
     @patch("app.services.workflow_service.Workflow")
-    async def test_run_workflow_creates_result_and_sends_task(self, mock_wf_cls, mock_model, mock_wr_cls, mock_celery):
+    @patch("app.services.workflow_service.WorkflowStep")
+    async def test_run_workflow_creates_result_and_sends_task(self, mock_step_cls, mock_wf_cls, mock_model, mock_wr_cls, mock_celery):
         from app.services.workflow_service import run_workflow
 
         wf = _make_workflow(steps=[_fake_oid(), _fake_oid()])
         mock_wf_cls.get = AsyncMock(return_value=wf)
+        _stub_steps(mock_step_cls, ["Extract", "Summarize"])
 
         mock_result = MagicMock()
         mock_result.id = _fake_oid()
@@ -691,11 +708,13 @@ class TestRunWorkflowBatch:
     @patch("app.services.workflow_service.WorkflowResult")
     @patch("app.services.workflow_service.get_user_model_name", new_callable=AsyncMock, return_value="gpt-4o")
     @patch("app.services.workflow_service.Workflow")
-    async def test_batch_creates_one_result_per_doc(self, mock_wf_cls, mock_model, mock_wr_cls, mock_celery):
+    @patch("app.services.workflow_service.WorkflowStep")
+    async def test_batch_creates_one_result_per_doc(self, mock_step_cls, mock_wf_cls, mock_model, mock_wr_cls, mock_celery):
         from app.services.workflow_service import run_workflow_batch
 
         wf = _make_workflow(steps=[_fake_oid()])
         mock_wf_cls.get = AsyncMock(return_value=wf)
+        _stub_steps(mock_step_cls, ["Summarize"])
 
         mock_result = MagicMock()
         mock_result.id = _fake_oid()

--- a/frontend/src/components/workspace/WorkflowEditorPanel.tsx
+++ b/frontend/src/components/workspace/WorkflowEditorPanel.tsx
@@ -558,9 +558,15 @@ export function WorkflowEditorPanel() {
   // — unless a project is active, in which case the run falls back to all of
   // the project's files.
   const missingInput = isNoInput ? false : isTextInput ? !textInput.trim() : (selectedDocUuids.length === 0 && !activeProjectUuid)
+  // A workflow with nothing to do still "runs": it completes in milliseconds
+  // and hands back the input document's uuid as its output. The empty
+  // "Document" step is the run's own input placeholder — the canvas hides it,
+  // so a workflow carrying only that one reads as empty and is treated as
+  // such here too.
+  const hasSteps = (workflow?.steps ?? []).some(s => !(s.name === 'Document' && s.tasks.length === 0))
 
   const handleRun = async () => {
-    if (!openWorkflowId) return
+    if (!openWorkflowId || !hasSteps) return
 
     try {
       if (isNoInput) {
@@ -646,10 +652,6 @@ export function WorkflowEditorPanel() {
 
   // --- tab badge counts ---
   const inputBadge = 0
-
-  // Validation and export both describe a workflow's steps. With none, they
-  // have nothing to describe — the tabs prompt for a first step instead.
-  const hasSteps = (workflow.steps?.length ?? 0) > 0
 
   // --- render ---
 
@@ -1083,7 +1085,13 @@ export function WorkflowEditorPanel() {
             </label>
           )
         )}
-        {!isTextInput && !isNoInput && selectedDocUuids.length === 0 && (
+        {!hasSteps && (
+          <div style={{ fontSize: 12, color: '#6b7280', marginBottom: 10, display: 'flex', alignItems: 'center', gap: 4 }}>
+            <Info style={{ width: 12, height: 12 }} />
+            Add a step below — there is nothing for this workflow to do yet
+          </div>
+        )}
+        {hasSteps && !isTextInput && !isNoInput && selectedDocUuids.length === 0 && (
           <div style={{ fontSize: 12, color: '#6b7280', marginBottom: 10, display: 'flex', alignItems: 'center', gap: 4 }}>
             <FileText style={{ width: 12, height: 12 }} />
             {activeProjectUuid ? 'Will run on all files in this project' : 'Select a document to run this workflow'}
@@ -1126,15 +1134,21 @@ export function WorkflowEditorPanel() {
         ) : (
           <button
             onClick={handleRun}
-            disabled={runner.running || missingInput}
-            title={runner.running && runner.batchId ? 'Stop is not yet available for batch runs' : undefined}
+            disabled={runner.running || missingInput || !hasSteps}
+            title={
+              !hasSteps
+                ? 'Add at least one step before running this workflow'
+                : runner.running && runner.batchId
+                  ? 'Stop is not yet available for batch runs'
+                  : undefined
+            }
             style={{
               width: '100%', padding: '12px 16px', fontSize: 14, fontWeight: 700,
               fontFamily: 'inherit', borderRadius: 'var(--ui-radius, 8px)', border: 'none',
               backgroundColor: 'var(--highlight-color, #eab308)',
               color: 'var(--highlight-text-color, #000)',
-              cursor: runner.running || missingInput ? 'not-allowed' : 'pointer',
-              opacity: missingInput && !runner.running ? 0.5 : 1,
+              cursor: runner.running || missingInput || !hasSteps ? 'not-allowed' : 'pointer',
+              opacity: (missingInput || !hasSteps) && !runner.running ? 0.5 : 1,
               textTransform: 'uppercase', letterSpacing: '0.05em',
               display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 8,
             }}


### PR DESCRIPTION
Follow-up to fb66941c, which stopped an empty workflow being validated, graded and exported. Running one was still allowed: the run completed in about 120ms and handed back the input document's uuid as its output, landing in History marked **Completed** — a success that did nothing.

## Two gaps

**The run paths had no guard.** `run_workflow` and `run_workflow_batch` now refuse a workflow with nothing to do. The router checks before starting the activity, so a blocked click doesn't leave a failed run behind in History for every attempt.

**The guard counted the hidden trigger step.** The engine prepends an empty `Document` step to stand in for the run's input, and some stored workflows carry their own copy — which the design canvas hides. A workflow whose only step is that one looks empty to the user, and now counts as empty everywhere: export, validation and running. A step the user actually named "Document" that does something still counts as real.

`workflow_has_executable_steps()` is the raw-`Workflow` counterpart to `workflow_has_steps()`, resolving step ids in one query — and none at all in the empty case, since it sits on the run path.

## Frontend

`WorkflowEditorPanel` disables **Run** for an empty workflow with a tooltip explaining why, and swaps the "select a document" hint for "add a step below", rather than letting the click make the round trip.

## Verification

- 100 tests pass across `test_workflow_empty_guard.py`, `test_workflow_service.py`, `test_workflow_authz.py`, including new coverage for the dangling-step-id case, the no-query-when-empty fast path, and the route returning 400 without starting an activity.
- `ruff check app/` clean, `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
