### PR TITLE
fix(automations): switching action type left a dangling action target

### DIFF
--- a/backend/app/routers/automations.py
+++ b/backend/app/routers/automations.py
@@ -32,6 +32,20 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
+WORKFLOW_ACTION_TYPES = ("workflow", "task")
+
+
+def _action_target_family(action_type: str | None) -> str | None:
+    """Which kind of resource an action_type's action_id names.
+
+    workflow and task both link a Workflow, so an action_id stays valid across
+    that swap; extraction links a SearchSet and does not.
+    """
+    if action_type in WORKFLOW_ACTION_TYPES:
+        return "workflow"
+    return action_type
+
+
 async def _validate_action_target(
     action_type: str | None,
     action_id: str | None,
@@ -39,7 +53,7 @@ async def _validate_action_target(
 ) -> None:
     if not action_type or not action_id:
         return
-    if action_type in ("workflow", "task"):
+    if action_type in WORKFLOW_ACTION_TYPES:
         workflow = await get_authorized_workflow(action_id, user)
         if not workflow:
             raise HTTPException(status_code=404, detail="Linked workflow not found")
@@ -428,8 +442,19 @@ async def get_automation(automation_id: str, user: User = Depends(get_current_us
 async def update_automation(automation_id: str, req: UpdateAutomationRequest, user: User = Depends(get_current_user)):
     current, _ = await _load_authorized_automation(automation_id, user, manage=True)
 
+    # Switching to an action type that names a different kind of resource
+    # (workflow/task <-> extraction) leaves the stored action_id dangling: it
+    # points at a Workflow that can't resolve as a SearchSet, or vice versa.
+    # Drop the stale link instead of validating it against the new type — the
+    # UI's flow is pick the new type, then pick its target, same two-step shape
+    # as a trigger_type switch.
+    clear_action_id = (
+        req.action_type is not None
+        and req.action_id is None
+        and _action_target_family(req.action_type) != _action_target_family(current.action_type)
+    )
     action_type = req.action_type if req.action_type is not None else current.action_type
-    action_id = req.action_id if req.action_id is not None else current.action_id
+    action_id = None if clear_action_id else (req.action_id if req.action_id is not None else current.action_id)
     await _validate_action_target(action_type, action_id, user)
 
     auto = await svc.apply_automation_update(
@@ -441,6 +466,7 @@ async def update_automation(automation_id: str, req: UpdateAutomationRequest, us
         trigger_config=req.trigger_config,
         action_type=req.action_type,
         action_id=req.action_id,
+        clear_action_id=clear_action_id,
         shared_with_team=req.shared_with_team,
         output_config=req.output_config,
     )
@@ -596,7 +622,12 @@ async def trigger_automation(
 
 
 async def _dispatch_action(auto, user, all_doc_uuids, callback_url, wait, timeout, temp_doc_uuids=None):
-    if auto.action_type in ("workflow", "task"):
+    if not auto.action_id:
+        raise HTTPException(
+            status_code=400,
+            detail="This automation has no action target selected yet.",
+        )
+    if auto.action_type in WORKFLOW_ACTION_TYPES:
         # Resolve document UUIDs to ObjectIds for the trigger event
         doc_records = await SmartDocument.find(
             {"uuid": {"$in": all_doc_uuids}},

--- a/backend/app/services/automation_service.py
+++ b/backend/app/services/automation_service.py
@@ -73,6 +73,7 @@ async def apply_automation_update(
     action_id: str | None = None,
     shared_with_team: bool | None = None,
     output_config: dict | None = None,
+    clear_action_id: bool = False,
 ) -> Automation:
     if name is not None:
         auto.name = name
@@ -86,7 +87,11 @@ async def apply_automation_update(
         auto.trigger_config = trigger_config
     if action_type is not None:
         auto.action_type = action_type
-    if action_id is not None:
+    # None means "not supplied" for every other field here, so clearing the
+    # link needs its own flag.
+    if clear_action_id:
+        auto.action_id = None
+    elif action_id is not None:
         auto.action_id = action_id
     if shared_with_team is not None:
         auto.shared_with_team = shared_with_team

--- a/backend/tests/test_automation_service.py
+++ b/backend/tests/test_automation_service.py
@@ -180,3 +180,20 @@ class TestApplyAutomationUpdate:
         assert auto.action_id == "wf-2"
         assert auto.shared_with_team is True
         assert auto.output_config == {"dest": "/out"}
+
+    @pytest.mark.asyncio
+    async def test_clear_action_id_drops_the_stale_link(self):
+        auto = _auto(action_type="workflow", action_id="wf-1")
+
+        await apply_automation_update(auto, action_type="extraction", clear_action_id=True)
+
+        assert auto.action_type == "extraction"
+        assert auto.action_id is None
+
+    @pytest.mark.asyncio
+    async def test_clear_action_id_defaults_off(self):
+        auto = _auto(action_type="workflow", action_id="wf-1")
+
+        await apply_automation_update(auto, name="Renamed")
+
+        assert auto.action_id == "wf-1"

--- a/backend/tests/test_automations_routes.py
+++ b/backend/tests/test_automations_routes.py
@@ -1,10 +1,22 @@
 """Integration tests for automation API routes."""
 
 import datetime
+import secrets
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from httpx import ASGITransport, AsyncClient
+
+from app.config import Settings
+from app.utils.security import create_access_token
+
+_TEST_SETTINGS = Settings(jwt_secret_key="test-secret-key", environment="development")
+
+
+def _auth(user_id: str = "testuser"):
+    token = create_access_token(user_id, _TEST_SETTINGS)
+    csrf = secrets.token_urlsafe(32)
+    return {"access_token": token, "csrf_token": csrf}, {"X-CSRF-Token": csrf}
 
 
 def _make_api_user(user_id="testuser", current_team=None):
@@ -35,6 +47,23 @@ def _make_automation(action_type="extraction", action_id="search-set-1"):
     auto.action_id = action_id
     auto.output_config = {}
     return auto
+
+
+def _response_stub(action_type):
+    """Minimal payload satisfying AutomationResponse, so the route's own logic
+    is what these tests exercise rather than _to_response's DB lookups."""
+    now = datetime.datetime.now(datetime.timezone.utc).isoformat()
+    return {
+        "id": "automation-id",
+        "name": "My Automation",
+        "enabled": True,
+        "trigger_type": "folder_watch",
+        "trigger_config": {},
+        "action_type": action_type,
+        "user_id": "testuser",
+        "created_at": now,
+        "updated_at": now,
+    }
 
 
 @pytest.fixture
@@ -157,3 +186,64 @@ class TestAutomationTriggerAuth:
             user_id="testuser",
             extraction_event_id="ext-event-1",
         )
+
+
+class TestUpdateActionType:
+    """Switching action type has to drop an action_id that named the other kind
+    of resource — validating the stale id against the new type 404'd the PATCH,
+    which the UI showed as the click doing nothing."""
+
+    async def _patch_action_type(self, client, *, current_type, current_id, new_type):
+        user = _make_api_user()
+        auto = _make_automation(action_type=current_type, action_id=current_id)
+        cookies, headers = _auth()
+
+        with patch("app.dependencies.decode_token", return_value={"sub": user.user_id, "type": "access"}), \
+             patch("app.dependencies.User") as MockUser, \
+             patch("app.routers.automations._load_authorized_automation",
+                   new=AsyncMock(return_value=(auto, MagicMock()))), \
+             patch("app.routers.automations.svc.apply_automation_update",
+                   new_callable=AsyncMock) as mock_apply, \
+             patch("app.routers.automations._to_response",
+                   new=AsyncMock(return_value=_response_stub(new_type))):
+            MockUser.find_one = AsyncMock(return_value=user)
+            mock_apply.return_value = auto
+
+            resp = await client.patch(
+                "/api/automations/automation-id",
+                json={"action_type": new_type},
+                cookies=cookies,
+                headers=headers,
+            )
+
+        return resp, mock_apply
+
+    @pytest.mark.asyncio
+    async def test_workflow_to_extraction_clears_stale_workflow_link(self, client):
+        resp, mock_apply = await self._patch_action_type(
+            client, current_type="workflow", current_id="wf-1", new_type="extraction"
+        )
+
+        assert resp.status_code == 200
+        assert mock_apply.await_args.kwargs["clear_action_id"] is True
+
+    @pytest.mark.asyncio
+    async def test_extraction_to_workflow_clears_stale_extraction_link(self, client):
+        resp, mock_apply = await self._patch_action_type(
+            client, current_type="extraction", current_id="search-set-1", new_type="workflow"
+        )
+
+        assert resp.status_code == 200
+        assert mock_apply.await_args.kwargs["clear_action_id"] is True
+
+    @pytest.mark.asyncio
+    async def test_workflow_to_task_keeps_the_link(self, client):
+        """Both execute the same Workflow, so the selection stays valid."""
+        with patch("app.routers.automations.get_authorized_workflow",
+                   new=AsyncMock(return_value=MagicMock())):
+            resp, mock_apply = await self._patch_action_type(
+                client, current_type="workflow", current_id="wf-1", new_type="task"
+            )
+
+        assert resp.status_code == 200
+        assert mock_apply.await_args.kwargs["clear_action_id"] is False

--- a/frontend/src/components/workspace/AutomationEditorPanel.tsx
+++ b/frontend/src/components/workspace/AutomationEditorPanel.tsx
@@ -6,6 +6,7 @@ import { apiFetch } from '../../api/client'
 import { useWorkflows } from '../../hooks/useWorkflows'
 import { useSearchSets } from '../../hooks/useExtractions'
 import { useConfirm } from '../shared/useConfirm'
+import { useToast } from '../../contexts/ToastContext'
 import { ItemPickerModal } from './ItemPickerModal'
 import { AutomationsExplainer } from './AutomationsExplainer'
 import type { Automation, TriggerType, ActionType } from '../../types/automation'
@@ -26,6 +27,7 @@ export function AutomationEditorPanel() {
   const { workflows } = useWorkflows()
   const { searchSets } = useSearchSets()
   const confirm = useConfirm()
+  const { toast } = useToast()
   const [automation, setAutomation] = useState<Automation | null>(null)
   const [loading, setLoading] = useState(true)
   const [showActionPicker, setShowActionPicker] = useState(false)
@@ -60,10 +62,16 @@ export function AutomationEditorPanel() {
   const save = useCallback(async (updates: Parameters<typeof updateAutomation>[1]) => {
     if (!openAutomationId) return
     if (automation && !automation.can_manage) return
-    const updated = await updateAutomation(openAutomationId, updates)
-    setAutomation(updated)
-    window.dispatchEvent(new Event('automations-updated'))
-  }, [openAutomationId, automation])
+    try {
+      const updated = await updateAutomation(openAutomationId, updates)
+      setAutomation(updated)
+      window.dispatchEvent(new Event('automations-updated'))
+    } catch (err) {
+      // A rejected save used to leave the panel showing the old value with no
+      // explanation, reading as "the click did nothing".
+      toast(err instanceof Error ? err.message : 'Failed to save automation', 'error')
+    }
+  }, [openAutomationId, automation, toast])
 
   const debouncedSave = useCallback((updates: Parameters<typeof updateAutomation>[1]) => {
     if (saveTimeoutRef.current) clearTimeout(saveTimeoutRef.current)
@@ -117,7 +125,10 @@ export function AutomationEditorPanel() {
 
   const handleActionTypeChange = async (type: ActionType) => {
     if (!canManage) return
-    await save({ action_type: type, action_id: undefined })
+    // Omitting action_id lets the server drop the old link when the new type
+    // names a different resource — sending undefined here read as "clear it"
+    // but JSON.stringify drops the key, so the stale id survived the switch.
+    await save({ action_type: type })
   }
 
   const handleActionSelect = async (id: string) => {


### PR DESCRIPTION
## The bug

Switching an automation's action type left the old `action_id` pointing at the wrong kind of resource, and the PATCH then 404'd. In the UI the click read as doing nothing — the panel kept showing the old value with no explanation.

## Root cause

Two halves.

**The stale id survived the switch.** `handleActionTypeChange` sent `{ action_type: type, action_id: undefined }`, intending to clear the link. `JSON.stringify` drops `undefined` keys, so the request body carried only `action_type`. The route's `None` means "not supplied" for every field, so it kept `current.action_id` — and `_validate_action_target` then looked up a Workflow id as a SearchSet and raised 404.

**A rejected save was silent.** `save()` had no error handling, so the 404 never reached the user.

## The fix

- `_action_target_family()` in the router: `workflow` and `task` both name a `Workflow`, so an `action_id` stays valid across that swap; `extraction` names a `SearchSet` and does not. Only a cross-family switch drops the link.
- `apply_automation_update` gains an explicit `clear_action_id` flag, because `None` already means "not supplied" for every other field there.
- The clear happens instead of validating the stale id against the new type, matching the UI's two-step shape (pick the type, then pick its target) — the same flow a `trigger_type` switch already has.
- `AutomationEditorPanel` toasts a failed save instead of silently keeping the old value.

## Testing

16 tests pass across `test_automation_service.py` and `test_automations_routes.py`, including the negative case: `workflow` → `task` **keeps** the link, since both execute the same Workflow.

Verified against current `main` (merges clean, no conflicts).
