### PR TITLE
feat(knowledge): add documents to a KB without blocking the request

### DIFF
--- a/backend/app/routers/knowledge.py
+++ b/backend/app/routers/knowledge.py
@@ -624,6 +624,25 @@ async def transfer_to_team(uuid: str, user: User = Depends(get_current_user)):
     return {"ok": True, "team_owned": kb.team_owned}
 
 
+def _dispatch_kb_ingest(source_uuids: list[str]) -> None:
+    """Queue the chunk+embed pass for freshly registered document sources.
+
+    Embedding a large document takes minutes and would blow past the proxy read
+    timeout if awaited inline, so it runs on a worker — the same shape add_urls
+    uses. Each source carries its own status, so the UI polls per source.
+    """
+    if not source_uuids:
+        return
+    from app.celery_app import celery_app
+
+    for source_uuid in source_uuids:
+        celery_app.send_task(
+            "tasks.documents.kb_ingest_document",
+            args=[source_uuid],
+            queue="documents",
+        )
+
+
 @router.post("/{uuid}/add_documents")
 async def add_documents(uuid: str, req: AddDocumentsRequest, user: User = Depends(get_current_user)):
     user_org_ancestry = await organization_service.get_user_org_ancestry(user)
@@ -645,13 +664,12 @@ async def add_documents(uuid: str, req: AddDocumentsRequest, user: User = Depend
                 seen.add(doc_uuid)
     if not document_uuids:
         raise HTTPException(status_code=400, detail="No documents provided")
-    kb.status = "building"
-    await kb.save()
     try:
-        added = await svc.add_documents(kb, document_uuids, user)
+        source_uuids = await svc.register_documents(kb, document_uuids, user)
     except ValueError as e:
         raise HTTPException(status_code=404, detail=str(e))
-    return {"ok": True, "added": added}
+    _dispatch_kb_ingest(source_uuids)
+    return {"ok": True, "added": len(source_uuids), "queued": len(source_uuids)}
 
 
 @router.post("/{uuid}/add_folder")
@@ -672,13 +690,12 @@ async def add_folder(uuid: str, req: AddFolderRequest, user: User = Depends(get_
     if not doc_uuids:
         return {"ok": True, "added": 0}
 
-    kb.status = "building"
-    await kb.save()
     try:
-        added = await svc.add_documents(kb, doc_uuids, user)
+        source_uuids = await svc.register_documents(kb, doc_uuids, user)
     except ValueError as e:
         raise HTTPException(status_code=404, detail=str(e))
-    return {"ok": True, "added": added}
+    _dispatch_kb_ingest(source_uuids)
+    return {"ok": True, "added": len(source_uuids), "queued": len(source_uuids)}
 
 
 @router.post("/{uuid}/add_urls")

--- a/backend/app/services/knowledge_service.py
+++ b/backend/app/services/knowledge_service.py
@@ -34,6 +34,11 @@ from app.utils.url_validation import normalize_crawl_url as _normalize_crawl_url
 
 logger = logging.getLogger(__name__)
 
+# Document task_status values that mean extraction is still running, so a KB
+# source waiting on that document's text should park as "pending" rather than
+# error. Mirrors the stage list in tasks.document_tasks.
+IN_FLIGHT_TASK_STATUSES = ("layout", "extracting", "ocr", "security", "readying")
+
 _dm: DocumentManager | None = None
 
 
@@ -684,6 +689,52 @@ async def add_documents(
     if added:
         await recalculate_stats(kb)
     return added
+
+
+async def register_documents(
+    kb: KnowledgeBase,
+    document_uuids: list[str],
+    user: User,
+) -> list[str]:
+    """Attach SmartDocuments to a KB as "pending" sources without ingesting them.
+
+    Chunking and embedding a large document runs for minutes, so the add-document
+    endpoints register sources here and hand the embed to a worker (see
+    ``tasks.documents.kb_ingest_document``). The sources land in the KB
+    immediately, which is what lets the UI show per-source progress instead of
+    blocking on the request. Returns the new source uuids in dispatch order;
+    duplicates are skipped, so an empty list means everything was already there.
+    """
+    team_access = await access_control.get_team_access_context(user)
+    source_uuids: list[str] = []
+    for doc_uuid in document_uuids:
+        doc = await access_control.get_authorized_document(
+            doc_uuid,
+            user,
+            team_access=team_access,
+            allow_admin=True,
+        )
+        if not doc:
+            raise ValueError(f"Document not found: {doc_uuid}")
+        existing = await KnowledgeBaseSource.find_one(
+            KnowledgeBaseSource.knowledge_base_uuid == kb.uuid,
+            KnowledgeBaseSource.document_uuid == doc_uuid,
+        )
+        if existing:
+            continue
+
+        source = KnowledgeBaseSource(
+            knowledge_base_uuid=kb.uuid,
+            source_type="document",
+            document_uuid=doc.uuid,
+        )
+        await source.insert()
+        source_uuids.append(source.uuid)
+
+    # Recalculate either way: it flips the KB to "building" while the new
+    # sources are pending, and corrects a stale status when all were duplicates.
+    await recalculate_stats(kb)
+    return source_uuids
 
 
 def _normalize_url(url: str) -> str:
@@ -1411,9 +1462,7 @@ async def _ingest_document_source(source: KnowledgeBaseSource, kb: KnowledgeBase
             # extraction-completion hook in update_document_fields re-ingest it
             # once raw_text exists. Only error when extraction has actually
             # finished (or failed) with no usable text.
-            in_flight = bool(doc.processing) or doc.task_status in (
-                "extracting", "readying", "layout",
-            )
+            in_flight = bool(doc.processing) or doc.task_status in IN_FLIGHT_TASK_STATUSES
             if in_flight and doc.task_status != "error":
                 source.status = "pending"
                 source.error_message = None

--- a/backend/app/tasks/knowledge_base_tasks.py
+++ b/backend/app/tasks/knowledge_base_tasks.py
@@ -93,9 +93,36 @@ def kb_ingest_document(self, source_uuid: str) -> None:
 
         raw_text = doc.get("raw_text", "")
         if not raw_text.strip():
+            # A document's text is populated asynchronously by the extraction
+            # worker, so a source queued right after upload routinely lands here
+            # while extraction is still in flight — for scanned PDFs the
+            # OCR-first path can take minutes. Park it as "pending" rather than
+            # failing it permanently: _resume_pending_kb_sources re-queues it
+            # once extraction finishes, and errors it if extraction fails.
+            from app.services.knowledge_service import IN_FLIGHT_TASK_STATUSES
+
+            task_status = doc.get("task_status")
+            in_flight = bool(doc.get("processing")) or task_status in IN_FLIGHT_TASK_STATUSES
+            if in_flight and task_status != "error":
+                # Guard on status: extraction can finish while this task runs,
+                # letting _resume_pending_kb_sources queue a second run that
+                # succeeds first. Parking unconditionally would knock that
+                # source back to "pending" with nothing left to re-trigger it.
+                db.knowledge_base_sources.update_one(
+                    {"uuid": source_uuid, "status": {"$ne": "ready"}},
+                    {"$set": {"status": "pending", "error_message": None}},
+                )
+                _recalculate_kb(db, kb_uuid)
+                return
             db.knowledge_base_sources.update_one(
                 {"uuid": source_uuid},
-                {"$set": {"status": "error", "error_message": "Document has no text content"}},
+                {
+                    "$set": {
+                        "status": "error",
+                        "error_message": doc.get("error_message")
+                        or "Document has no extractable text",
+                    }
+                },
             )
             _recalculate_kb(db, kb_uuid)
             return

--- a/backend/tests/test_knowledge_base_tasks.py
+++ b/backend/tests/test_knowledge_base_tasks.py
@@ -168,7 +168,7 @@ class TestKbIngestDocument:
         calls = db.knowledge_base_sources.update_one.call_args_list
         error_call = calls[1][0]
         assert error_call[1]["$set"]["status"] == "error"
-        assert "no text content" in error_call[1]["$set"]["error_message"]
+        assert "no extractable text" in error_call[1]["$set"]["error_message"]
 
     @patch("app.services.document_manager.get_document_manager")
     @patch("app.tasks.knowledge_base_tasks._get_db")

--- a/backend/tests/test_knowledge_ingest.py
+++ b/backend/tests/test_knowledge_ingest.py
@@ -1,9 +1,10 @@
 """Unit tests for KB document-source ingestion timing.
 
 A KB source can be added before its document's async text extraction has
-finished. ``_ingest_document_source`` must park such a source as "pending"
-(to be re-ingested by the extraction-completion hook) rather than recording a
-permanent "no text" error.
+finished. Both ingestion paths — the inline ``_ingest_document_source`` and the
+``kb_ingest_document`` Celery task the add-document endpoints dispatch to — must
+park such a source as "pending" (to be re-ingested by the extraction-completion
+hook) rather than recording a permanent "no text" error.
 """
 
 from types import SimpleNamespace
@@ -117,3 +118,72 @@ async def test_ingests_when_text_present():
     _, kwargs = dm.add_to_kb.call_args
     called_args = dm.add_to_kb.call_args[0]
     assert doc.text_markers in called_args or kwargs.get("text_markers") == doc.text_markers
+
+
+# --- kb_ingest_document (Celery path used by add_documents/add_folder) ---
+
+
+def _mock_db(doc):
+    """A pymongo-shaped db whose smart_document lookup returns ``doc``."""
+    db = MagicMock()
+    db.knowledge_base_sources.find_one.return_value = {
+        "uuid": "src-1", "knowledge_base_uuid": "kb-1", "document_uuid": "doc-1",
+    }
+    db.smart_document.find_one.return_value = doc
+    return db
+
+
+def _status_set(db):
+    """The last $set payload written to the source, ignoring the 'processing' flip."""
+    calls = db.knowledge_base_sources.update_one.call_args_list
+    return calls[-1][0][1]["$set"]
+
+
+@pytest.mark.parametrize("task_status", ["layout", "extracting", "ocr", "security", "readying"])
+def test_task_parks_pending_while_extraction_in_flight(task_status):
+    from app.tasks import knowledge_base_tasks
+
+    db = _mock_db({"uuid": "doc-1", "raw_text": "", "processing": True,
+                   "task_status": task_status, "title": "big.pdf"})
+
+    with patch.object(knowledge_base_tasks, "_get_db", return_value=db), \
+         patch.object(knowledge_base_tasks, "_recalculate_kb"), \
+         patch("app.services.document_manager.get_document_manager") as mock_dm:
+        knowledge_base_tasks.kb_ingest_document.run("src-1")
+
+    assert _status_set(db) == {"status": "pending", "error_message": None}
+    # A large document queued right after upload must not be embedded empty.
+    mock_dm.assert_not_called()
+
+
+def test_task_errors_when_extraction_finished_empty():
+    from app.tasks import knowledge_base_tasks
+
+    db = _mock_db({"uuid": "doc-1", "raw_text": "   ", "processing": False,
+                   "task_status": "complete", "title": "empty.pdf"})
+
+    with patch.object(knowledge_base_tasks, "_get_db", return_value=db), \
+         patch.object(knowledge_base_tasks, "_recalculate_kb"), \
+         patch("app.services.document_manager.get_document_manager") as mock_dm:
+        knowledge_base_tasks.kb_ingest_document.run("src-1")
+
+    written = _status_set(db)
+    assert written["status"] == "error"
+    assert "no extractable text" in written["error_message"].lower()
+    mock_dm.assert_not_called()
+
+
+def test_task_errors_with_doc_message_when_extraction_failed():
+    from app.tasks import knowledge_base_tasks
+
+    db = _mock_db({"uuid": "doc-1", "raw_text": "", "processing": False,
+                   "task_status": "error", "title": "scan.pdf",
+                   "error_message": "It may be image-only or encrypted."})
+
+    with patch.object(knowledge_base_tasks, "_get_db", return_value=db), \
+         patch.object(knowledge_base_tasks, "_recalculate_kb"):
+        knowledge_base_tasks.kb_ingest_document.run("src-1")
+
+    written = _status_set(db)
+    assert written["status"] == "error"
+    assert written["error_message"] == "It may be image-only or encrypted."

--- a/backend/tests/test_knowledge_routes.py
+++ b/backend/tests/test_knowledge_routes.py
@@ -914,11 +914,12 @@ class TestKnowledgeDocSources:
             patch("app.dependencies.User") as MockUser,
             patch("app.routers.knowledge.svc") as mock_svc,
             patch("app.routers.knowledge.organization_service") as mock_org,
+            patch("app.routers.knowledge._dispatch_kb_ingest") as mock_dispatch,
         ):
             MockUser.find_one = AsyncMock(return_value=user)
             mock_org.get_user_org_ancestry = AsyncMock(return_value=[])
             mock_svc.get_knowledge_base = AsyncMock(return_value=kb)
-            mock_svc.add_documents = AsyncMock(return_value=2)
+            mock_svc.register_documents = AsyncMock(return_value=["src-1", "src-2"])
 
             resp = await client.post(
                 "/api/knowledge/kb-uuid-1/add_documents",
@@ -929,6 +930,10 @@ class TestKnowledgeDocSources:
 
         assert resp.status_code == 200
         assert resp.json()["added"] == 2
+        # Embedding must not run inline — it is queued per source so the request
+        # returns immediately and the UI can poll per-source status.
+        mock_svc.add_documents.assert_not_called()
+        mock_dispatch.assert_called_once_with(["src-1", "src-2"])
 
     @pytest.mark.asyncio
     async def test_add_documents_empty_list_rejected(self, client):

--- a/frontend/src/components/knowledge/DocumentPickerModal.tsx
+++ b/frontend/src/components/knowledge/DocumentPickerModal.tsx
@@ -26,6 +26,16 @@ const ALLOWED_EXTS = ['pdf', 'doc', 'docx', 'xlsx', 'xls', 'csv', 'txt', 'md']
 const ACCEPT_ATTR = ALLOWED_EXTS.map(e => `.${e}`).join(',')
 const ALLOWED_HINT = ALLOWED_EXTS.join(', ')
 
+// Rough "this will take a while to index" thresholds. Indexing time scales with
+// text volume; token_count is the closest proxy the search API returns, with
+// page count as a fallback for documents whose text isn't extracted yet.
+const LARGE_DOC_TOKENS = 50_000
+const LARGE_DOC_PAGES = 100
+
+function isLargeDoc(doc: SearchResult): boolean {
+  return doc.token_count >= LARGE_DOC_TOKENS || doc.num_pages >= LARGE_DOC_PAGES
+}
+
 function getExt(name: string): string {
   const i = name.lastIndexOf('.')
   return i >= 0 ? name.slice(i + 1).toLowerCase() : ''
@@ -234,6 +244,9 @@ export function DocumentPickerModal({ onSubmit, onClose, existingSourceUuids = [
   }
 
   const uploadingCount = uploads.filter(u => u.status === 'uploading').length
+  // Only counts docs in the current result set; a selection carried over from an
+  // earlier search won't warn, which is acceptable for a heads-up.
+  const selectedLargeCount = results.filter(d => selected.has(d.uuid) && isLargeDoc(d)).length
   const sortedFolders = [...folders].sort((a, b) => a.path.localeCompare(b.path))
 
   return (
@@ -488,6 +501,9 @@ export function DocumentPickerModal({ onSubmit, onClose, existingSourceUuids = [
                         {doc.extension.toUpperCase()}
                         {doc.num_pages > 0 ? ` · ${doc.num_pages} pages` : ''}
                         {folderPath ? ` · ${folderPath}` : ''}
+                        {isLargeDoc(doc) && (
+                          <span style={{ color: '#d97706' }}> · Large — slower to index</span>
+                        )}
                       </div>
                     </div>
                   </button>
@@ -496,6 +512,21 @@ export function DocumentPickerModal({ onSubmit, onClose, existingSourceUuids = [
             </div>
           )}
         </div>
+
+        {/* Heads-up before committing to a slow index */}
+        {selectedLargeCount > 0 && (
+          <div role="status" aria-live="polite" style={{
+            fontSize: 12, color: '#d97706', marginBottom: 10,
+            padding: '8px 12px', borderRadius: 6,
+            backgroundColor: 'rgba(217, 119, 6, 0.1)',
+            border: '1px solid rgba(217, 119, 6, 0.25)',
+          }}>
+            {selectedLargeCount === 1
+              ? "One selected document is large — indexing it can take a few minutes."
+              : `${selectedLargeCount} selected documents are large — indexing them can take a few minutes.`}
+            {' '}You can keep working while it runs.
+          </div>
+        )}
 
         {/* Footer */}
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>

--- a/frontend/src/components/workspace/KnowledgePanel.tsx
+++ b/frontend/src/components/workspace/KnowledgePanel.tsx
@@ -196,9 +196,18 @@ export function KnowledgePanel() {
     setValidationCollapsed(false)
   }, [selectedKB?.uuid])
 
-  // Poll status when building
+  // Sources still being chunked and embedded by a worker. Tracked separately
+  // from kb.status because a KB can report "ready" from an earlier build while
+  // newly added sources are still pending.
+  const inFlightSources = (selectedKB?.sources ?? []).filter(
+    s => s.status === 'pending' || s.status === 'processing'
+  )
+  const inFlightCount = inFlightSources.length
+
+  // Poll while the KB is building or any source is still indexing
   useEffect(() => {
-    if (!selectedKB || selectedKB.status !== 'building') return
+    if (!selectedKB) return
+    if (selectedKB.status !== 'building' && inFlightCount === 0) return
     const interval = setInterval(async () => {
       try {
         const detail = await api.getKnowledgeBase(selectedKB.uuid)
@@ -209,7 +218,7 @@ export function KnowledgePanel() {
       } catch { /* ignore */ }
     }, 3000)
     return () => clearInterval(interval)
-  }, [selectedKB?.uuid, selectedKB?.status, refresh])
+  }, [selectedKB?.uuid, selectedKB?.status, inFlightCount, refresh])
 
   const handleDelete = async (uuid: string) => {
     const kb = scopedMine.knowledgeBases.find((k: KnowledgeBase) => k.uuid === uuid)
@@ -280,10 +289,17 @@ export function KnowledgePanel() {
     if (!selectedKB || docUuids.length === 0) return
     setAddingDocs(true)
     setShowDocPicker(false)
+    // Optimistically set status to building so the poller starts — indexing runs
+    // on a worker, so this call returns before any source is ready.
+    setSelectedKB(prev => prev ? { ...prev, status: 'building' } : prev)
     try {
       const result = await api.addDocumentsToKB(selectedKB.uuid, docUuids)
       const n = result?.added ?? docUuids.length
-      toast(`Added ${n} document${n === 1 ? '' : 's'}`, 'success')
+      if (n === 0) {
+        toast('Those documents are already in this knowledge base', 'info')
+      } else {
+        toast(`Added ${n} document${n === 1 ? '' : 's'} — indexing in background`, 'success')
+      }
       loadDetail(selectedKB.uuid)
       refresh()
     } catch (err) {
@@ -298,13 +314,14 @@ export function KnowledgePanel() {
     if (!selectedKB) return
     setAddingDocs(true)
     setShowDocPicker(false)
+    setSelectedKB(prev => prev ? { ...prev, status: 'building' } : prev)
     try {
       const result = await api.addFolderToKB(selectedKB.uuid, folderUuid, includeSubfolders)
       const n = result?.added ?? 0
       if (n === 0) {
         toast('No new documents found in that folder', 'info')
       } else {
-        toast(`Added ${n} document${n === 1 ? '' : 's'} from folder`, 'success')
+        toast(`Added ${n} document${n === 1 ? '' : 's'} from folder — indexing in background`, 'success')
       }
       loadDetail(selectedKB.uuid)
       refresh()
@@ -947,6 +964,30 @@ export function KnowledgePanel() {
               </div>
             )}
 
+            {/* Indexing progress banner — covers the wait right after adding and
+                the case where the user navigates back while work is still queued. */}
+            {(addingDocs || inFlightCount > 0) && (
+              <div role="status" aria-live="polite" style={{
+                display: 'flex', alignItems: 'center', gap: 10,
+                padding: '10px 14px', marginBottom: 16, borderRadius: 8,
+                backgroundColor: 'rgba(217, 119, 6, 0.1)',
+                border: '1px solid rgba(217, 119, 6, 0.25)',
+              }}>
+                <Loader2 size={16} aria-hidden="true" style={{ color: '#d97706', animation: 'spin 1s linear infinite', flexShrink: 0 }} />
+                <div>
+                  <div style={{ fontSize: 13, fontWeight: 600, color: '#e5e5e5' }}>
+                    {inFlightCount > 0
+                      ? `Indexing ${inFlightCount} source${inFlightCount === 1 ? '' : 's'}...`
+                      : 'Adding documents...'}
+                  </div>
+                  <div style={{ fontSize: 11, color: '#999', marginTop: 2 }}>
+                    Large documents can take a few minutes. Sources turn green below as they
+                    finish — you can leave this page and come back.
+                  </div>
+                </div>
+              </div>
+            )}
+
             {/* Action buttons */}
             <div style={{ display: 'flex', gap: 8, marginBottom: 16, flexWrap: 'wrap' }}>
               <button
@@ -1305,6 +1346,13 @@ export function KnowledgePanel() {
                         )}
                         {!isRenaming && source.status === 'ready' && (
                           <div style={{ fontSize: 11, color: '#888', marginTop: 2 }}>{source.chunk_count} chunks</div>
+                        )}
+                        {!isRenaming && (source.status === 'processing' || source.status === 'pending') && (
+                          <div style={{ fontSize: 11, color: '#d97706', marginTop: 2 }}>
+                            {source.status === 'processing'
+                              ? 'Indexing… large documents can take a few minutes'
+                              : 'Waiting for document text to finish extracting…'}
+                          </div>
                         )}
                         {!isRenaming && isTruncated && (
                           <div style={{ fontSize: 11, color: '#b45309', marginTop: 2 }}>


### PR DESCRIPTION
## Summary

Chunking and embedding a large document runs for minutes, so `add_documents` and `add_folder` awaited that work inline and rode the proxy read timeout. Both now register the sources as `pending` and hand the embed to a worker — the shape `add_urls` already used.

Sources appear in the KB immediately, so the UI can show per-source progress instead of polling a single KB-level `building` status.

## The extraction race

A source queued right after upload routinely finds its document's `raw_text` still empty, because extraction is asynchronous too — on the OCR-first path for a scanned PDF that can take minutes. That used to record a permanent "no text content" error on a document that was simply not ready yet.

Such a source now parks as `pending` and is re-queued when extraction completes, guarded against the race where extraction finishes mid-task and a second run readies the source first. A source whose document genuinely *failed* reports that document's own error message, rather than a generic one.

## Changes

- **`knowledge_service.register_documents()`** — attaches SmartDocuments as `pending` sources without ingesting. Returns the new source uuids in dispatch order; duplicates are skipped. `recalculate_stats` runs either way, so the KB flips to `building` while sources are pending and a stale status gets corrected when everything was a duplicate.
- **`routers/knowledge._dispatch_kb_ingest()`** — queues `tasks.documents.kb_ingest_document` per source on the `documents` queue.
- **`IN_FLIGHT_TASK_STATUSES`** is defined once in `knowledge_service` and now includes the `ocr` and `security` stages, which it had been missing.
- Frontend: `DocumentPickerModal` and `KnowledgePanel` surface per-source progress.

## Testing

132 tests pass across `test_knowledge_ingest`, `test_knowledge_routes`, `test_knowledge_base_tasks`, `test_kb_empty_guard`, `test_automation_service`, `test_automations_routes` — run against current `main`, so this is verified alongside the empty-KB guard from #638.

Merges clean against `main` with no conflicts.
