### PR TITLE
fix(chat): count tokens with the model's own vocabulary

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,19 @@
 # Optional. Custom LLM endpoint (OpenAI-compatible). Leave empty to use OpenAI directly.
 INSIGHT_ENDPOINT=
 
+# Optional. HOST path to your HuggingFace cache, mounted read-only into the api
+# and celery containers. Only useful if you self-host models (vLLM, TGI, Ollama
+# with an HF cache) — set it to your HF_HOME, the directory containing `hub/`.
+#
+# Token counting reads each model's tokenizer.json from here so budgets are
+# exact instead of estimated. It reads the vocabulary only: no weights, no GPU,
+# no downloads.
+#
+# Leave unset and nothing breaks — budgets fall back to a tiktoken estimate plus
+# a safety margin, and the log says so once per model. Accuracy suffers most on
+# numeric and tabular documents, where tokenizers disagree most.
+HF_CACHE_PATH=
+
 # --- Infrastructure ---
 redis_host=localhost
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -106,3 +106,13 @@ TELEMETRY_CONTACT_EMAIL=
 # /api/telemetry/heartbeat ingest route and the admin Telemetry dashboard.
 # Leave false on every normal deployment — both stay completely hidden.
 TELEMETRY_COLLECTOR_ENABLED=false
+
+# --- Token counting ---
+# Where THIS process looks for model vocabularies, in the standard HuggingFace
+# cache layout (<root>/hub/models--Org--Name/snapshots/<rev>/). Set it to your
+# HF_HOME when running outside Docker; under Docker compose the cache is mounted
+# at /hf-cache and the host path is set by HF_CACHE_PATH in the root .env.
+#
+# Optional. When no vocabulary is found the budget falls back to a tiktoken
+# estimate plus a safety margin and logs that it did, once per model.
+TOKENIZER_CACHE_ROOT=/hf-cache

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -43,6 +43,17 @@ class Settings(BaseSettings):
     chromadb_host: str = ""
     max_upload_size_mb: int = 500
 
+    # Where this process looks for model vocabularies, in the standard
+    # HuggingFace cache layout (`<root>/hub/models--Org--Name/snapshots/<rev>/`).
+    # Set it to your HF_HOME. Token counting reads `tokenizer.json` from here —
+    # the vocabulary only, never the weights and never the GPU.
+    #
+    # Optional. When nothing is found the budget falls back to estimating with
+    # tiktoken plus a safety margin, and says so in the log once per model. That
+    # is the pre-existing behaviour, so leaving this unset costs accuracy for
+    # self-hosted models but breaks nothing.
+    tokenizer_cache_root: str = "/hf-cache"
+
     # Observability
     sentry_dsn: str = ""
     log_format: str = "json"  # "json" for structured logging, "text" for human-readable

--- a/backend/app/services/chat_service.py
+++ b/backend/app/services/chat_service.py
@@ -583,6 +583,10 @@ async def chat_stream(
     # Measured before any trimming: both routing and the dialog's suggestion
     # ask "could another model have held what the user actually sent?", and the
     # post-compaction total cannot answer that — it always fits by definition.
+    # `model_config` carries this model's token safety margin, so the estimate
+    # is an upper bound rather than an optimistic one. Routing decides off this
+    # number: an estimate that reads low makes the router see headroom that is
+    # not there and decline to move a request that does not fit.
     requested_input_tokens = estimate_input_tokens(
         model_name=model_name,
         system_prompt=system_prompt or "",
@@ -590,6 +594,7 @@ async def chat_stream(
         history=previous_messages,
         documents=doc_segments,
         attachments=attachment_segments,
+        model_config=model_config,
     )
 
     routing = RoutingDecision(model_name, False, "")

--- a/backend/app/services/context_budget.py
+++ b/backend/app/services/context_budget.py
@@ -244,23 +244,9 @@ def token_safety_margin(
     below 1.0 is refused — that re-creates the original bug by configuration,
     leaving the planner optimistic in the direction that hard-fails.
     """
-    if model_config:
-        raw = model_config.get("token_safety_margin")
-        if isinstance(raw, bool):
-            raw = None  # bool is an int subclass; never a meaningful margin
-        try:
-            value = float(raw) if raw not in (None, "") else 0.0
-        except (TypeError, ValueError):
-            value = 0.0
-        if value >= 1.0:
-            return value
-        if value:
-            logger.warning(
-                "ignoring token_safety_margin=%r for %s: a margin below 1.0 "
-                "would under-count the request",
-                raw,
-                model_name,
-            )
+    configured = _configured_margin(model_name, model_config)
+    if configured is not None:
+        return configured
 
     # An exact count needs no correction. Inflating it would only route early.
     if resolve_exact_tokenizer(model_name, model_config) is not None:
@@ -268,6 +254,62 @@ def token_safety_margin(
     if _is_openai_model(model_name):
         return 1.0
     _warn_estimated_once(model_name or "<unnamed>")
+    return DEFAULT_TOKEN_SAFETY_MARGIN
+
+
+def _configured_margin(
+    model_name: str, model_config: Optional[dict]
+) -> Optional[float]:
+    """A deployment's own measured margin, or None when it set none.
+
+    Shared by both margin functions: a deployment that measured its own
+    divergence knows better than either default, whichever question is being
+    asked.
+    """
+    if not model_config:
+        return None
+    raw = model_config.get("token_safety_margin")
+    if isinstance(raw, bool):
+        raw = None  # bool is an int subclass; never a meaningful margin
+    try:
+        value = float(raw) if raw not in (None, "") else 0.0
+    except (TypeError, ValueError):
+        value = 0.0
+    if value >= 1.0:
+        return value
+    if value:
+        logger.warning(
+            "ignoring token_safety_margin=%r for %s: a margin below 1.0 "
+            "would under-count the request",
+            raw,
+            model_name,
+        )
+    return None
+
+
+def stored_count_margin(
+    model_name: str, model_config: Optional[dict] = None
+) -> float:
+    """Allowance for a token count taken with tiktoken and stored earlier.
+
+    Deliberately not :func:`token_safety_margin`. That one answers "how safe
+    is a count I am about to take?", and returns 1.0 once the model's own
+    vocabulary is on disk, because the planner then counts the text exactly.
+
+    This answers a different question: "how safe is a count someone else took
+    earlier, with tiktoken, when I do not have the text to recount?" A stored
+    ``token_count`` is a tiktoken figure whatever we could compute now, so the
+    divergence is still there and still has to be allowed for. Reusing the
+    other function here made the oversize check pass a raw tiktoken count
+    straight through for exactly the models exact tokenization serves,
+    under-warning by the divergence it exists to remove.
+    """
+    configured = _configured_margin(model_name, model_config)
+    if configured is not None:
+        return configured
+    # tiktoken *is* the tokenizer for these, so the stored figure is exact.
+    if _is_openai_model(model_name):
+        return 1.0
     return DEFAULT_TOKEN_SAFETY_MARGIN
 
 
@@ -938,16 +980,21 @@ def find_oversize_documents(
     from sync Celery code.
 
     ``token_count`` is a raw tiktoken figure (see :func:`count_raw_tokens`), so
-    the model's safety margin is applied here rather than trusted from storage.
+    a divergence allowance is applied here rather than trusted from storage.
     Without it this check under-warns by the same 4–17% the planner did, and a
     workflow that will fail is not flagged before it runs. Applying it at read
     time also corrects documents ingested before any of this existed.
+
+    The allowance comes from :func:`stored_count_margin`, not
+    :func:`token_safety_margin` — this consumer never sees the document text,
+    only a count taken with tiktoken, so having the model's real vocabulary on
+    disk does not make that stored number exact.
     """
     budget = input_budget(model_name, model_config, overhead_tokens=overhead_tokens)
-    margin = token_safety_margin(model_name, model_config)
     # Stored counts are raw tiktoken figures, so the margin is applied at read
     # time rather than trusted from storage. That also corrects documents
     # ingested before any of this existed, without a backfill.
+    margin = stored_count_margin(model_name, model_config)
     oversize = [
         OversizeDocument(
             uuid=d.uuid,

--- a/backend/app/services/context_budget.py
+++ b/backend/app/services/context_budget.py
@@ -10,6 +10,7 @@ and to Sentry.
 from __future__ import annotations
 
 import logging
+import math
 from dataclasses import dataclass, field
 from functools import lru_cache
 from typing import Any, Optional
@@ -22,6 +23,26 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 _CHAR_TO_TOKEN_RATIO = 4
+
+# How much to inflate a tiktoken estimate for a model tiktoken does not model.
+#
+# tiktoken is OpenAI's tokenizer. For every other model it is a proxy, and
+# measurement says it is a systematically *optimistic* one: across 97 harness
+# runs against three self-hosted Qwen models, spanning requests from 307 to
+# 46,916 tokens, the estimate came in under the `prompt_tokens` the server
+# reported every single time, by 4.2% to 17.3% (mean 14.5%). It was never once
+# equal or over.
+#
+# The error only bites near the window boundary — which is exactly where this
+# product's flagship use case lives, reading a whole proposal on a 32k model.
+#
+# 1.20 covers the worst observation with headroom. The asymmetry justifies
+# rounding up rather than fitting tightly: this is a budget estimate, not an
+# invoice. Guessing high costs slightly-early routing to a bigger model.
+# Guessing low costs a hard error and no answer, which is the bug this exists
+# to prevent. Deployments that have measured their own models can set
+# `token_safety_margin` on the model config instead of living with this.
+DEFAULT_TOKEN_SAFETY_MARGIN = 1.20
 
 
 @lru_cache(maxsize=8)
@@ -42,8 +63,70 @@ def _encoding_for(model_name: str) -> str:
     return "cl100k_base"
 
 
-def count_tokens(text: str, model_name: str = "") -> int:
-    """Estimate token count for ``text`` using tiktoken when available."""
+def _is_openai_model(name: str) -> bool:
+    """True when tiktoken is this model's *real* tokenizer, not a proxy.
+
+    Prefix-matching the o-series rather than substring-matching it: "o1" as a
+    substring matches far too much to be safe on a registry of self-hosted
+    model names.
+    """
+    n = (name or "").lower()
+    if n.startswith(("gpt-", "o1", "o3", "o4")):
+        return True
+    return any(tok in n for tok in ("gpt-3.5", "gpt-4"))
+
+
+def token_safety_margin(
+    model_name: str, model_config: Optional[dict] = None
+) -> float:
+    """Multiplier that turns a tiktoken estimate into a safe upper bound.
+
+    Returns 1.0 for OpenAI models, where the count is exact and inflating it
+    would only trigger premature routing.
+
+    An explicit ``token_safety_margin`` on the model config wins for any model,
+    so a deployment can tune against its own measurements. A configured value
+    below 1.0 is refused — that re-creates the original bug by configuration,
+    leaving the planner optimistic in the direction that hard-fails.
+    """
+    if model_config:
+        raw = model_config.get("token_safety_margin")
+        if isinstance(raw, bool):
+            raw = None  # bool is an int subclass; never a meaningful margin
+        try:
+            value = float(raw) if raw not in (None, "") else 0.0
+        except (TypeError, ValueError):
+            value = 0.0
+        if value >= 1.0:
+            return value
+        if value:
+            logger.warning(
+                "ignoring token_safety_margin=%r for %s: a margin below 1.0 "
+                "would under-count the request",
+                raw,
+                model_name,
+            )
+
+    if _is_openai_model(model_name):
+        return 1.0
+    return DEFAULT_TOKEN_SAFETY_MARGIN
+
+
+def _apply_margin(raw_tokens: int, margin: float) -> int:
+    """Round up — a fractional token still has to be paid for."""
+    if raw_tokens <= 0:
+        return 0
+    return math.ceil(raw_tokens * margin)
+
+
+def _count_raw_tokens(text: str, model_name: str = "") -> int:
+    """tiktoken's count, with no safety margin applied.
+
+    Internal: callers that are sizing a request want :func:`count_tokens`.
+    This exists so the margin is applied exactly once per aggregate, and so
+    truncation can convert a margin-inflated budget back into real token
+    offsets for slicing.
+    """
     if not text:
         return 0
     encoder = _get_encoder(_encoding_for(model_name))
@@ -55,15 +138,45 @@ def count_tokens(text: str, model_name: str = "") -> int:
     return max(1, len(text) // _CHAR_TO_TOKEN_RATIO)
 
 
-def count_message_tokens(message: Any, model_name: str = "") -> int:
-    """Estimate tokens for one pydantic-ai ``ModelMessage``."""
+def count_raw_tokens(text: str, model_name: str = "") -> int:
+    """Count with no safety margin, for values *stored* rather than spent.
+
+    A document's ``token_count`` is written once at ingestion and read later
+    against whichever model the user happens to pick, but the safety margin is
+    a property of that model, not of the document. Baking a margin into the
+    stored value would freeze one model's correction into every future
+    comparison — and would still leave every already-ingested document holding
+    an uncorrected number. So the stored figure stays a raw baseline and the
+    margin is applied at comparison time, by :func:`find_oversize_documents`.
+    """
+    return _count_raw_tokens(text, model_name)
+
+
+def count_tokens(
+    text: str, model_name: str = "", model_config: Optional[dict] = None
+) -> int:
+    """Estimate token count for ``text``, erring high for non-OpenAI models."""
+    raw = _count_raw_tokens(text, model_name)
+    return _apply_margin(raw, token_safety_margin(model_name, model_config))
+
+
+def count_message_tokens(
+    message: Any, model_name: str = "", model_config: Optional[dict] = None
+) -> int:
+    """Estimate tokens for one pydantic-ai ``ModelMessage``.
+
+    The margin covers the role wrapper too. The per-message overhead below is a
+    flat guess at chat-template scaffolding that real templates exceed, and
+    under-counting it is most of why small requests showed the *largest*
+    proportional error in measurement.
+    """
     total = 4  # per-message overhead for role wrapping
     for part in getattr(message, "parts", ()):
         content = getattr(part, "content", None)
         if content is None:
             content = str(part)
-        total += count_tokens(str(content), model_name)
-    return total
+        total += _count_raw_tokens(str(content), model_name)
+    return _apply_margin(total, token_safety_margin(model_name, model_config))
 
 
 # ---------------------------------------------------------------------------
@@ -246,38 +359,49 @@ def _truncate_text_to_tokens(
     max_tokens: int,
     model_name: str,
     marker: str = "\n\n…[truncated]…\n\n",
+    model_config: Optional[dict] = None,
 ) -> tuple[str, int]:
     """Truncate ``text`` to ≤ ``max_tokens``, preserving head and tail.
 
-    Returns ``(truncated_text, dropped_tokens)``.
+    ``max_tokens`` is a margin-inflated budget, but the encoder slices by real
+    token offsets, so the budget is converted back to raw token space before
+    slicing. Slicing ``toks`` by an inflated count would take *more* text than
+    the budget allows and leave the caller still over, which the last-ditch
+    loop would then have to iterate its way out of.
+
+    Returns ``(truncated_text, dropped_tokens)``, both in inflated space.
     """
-    original_tokens = count_tokens(text, model_name)
+    margin = token_safety_margin(model_name, model_config)
+    original_tokens = count_tokens(text, model_name, model_config)
     if max_tokens <= 0:
         return "", original_tokens
     if original_tokens <= max_tokens:
         return text, 0
 
-    marker_tokens = count_tokens(marker, model_name)
+    marker_tokens = count_tokens(marker, model_name, model_config)
     usable = max(1, max_tokens - marker_tokens)
+    raw_usable = max(1, int(usable / margin))
 
     encoder = _get_encoder(_encoding_for(model_name))
     if encoder is not None:
         try:
             toks = encoder.encode(text, disallowed_special=())
-            head_n = int(usable * 0.75)
-            tail_n = max(0, usable - head_n)
+            head_n = int(raw_usable * 0.75)
+            tail_n = max(0, raw_usable - head_n)
             head_text = encoder.decode(toks[:head_n]) if head_n else ""
             tail_text = encoder.decode(toks[-tail_n:]) if tail_n else ""
             new_text = head_text + marker + tail_text
-            return new_text, original_tokens - count_tokens(new_text, model_name)
+            return new_text, original_tokens - count_tokens(
+                new_text, model_name, model_config
+            )
         except Exception:
             pass
 
-    approx_chars = usable * _CHAR_TO_TOKEN_RATIO
+    approx_chars = raw_usable * _CHAR_TO_TOKEN_RATIO
     head_chars = int(approx_chars * 0.75)
     tail_chars = max(0, approx_chars - head_chars)
     new_text = text[:head_chars] + marker + (text[-tail_chars:] if tail_chars else "")
-    return new_text, original_tokens - count_tokens(new_text, model_name)
+    return new_text, original_tokens - count_tokens(new_text, model_name, model_config)
 
 
 def input_budget_for(
@@ -314,6 +438,7 @@ def estimate_input_tokens(
     history: list,
     documents: list[DocumentSegment],
     attachments: list[DocumentSegment],
+    model_config: Optional[dict] = None,
 ) -> int:
     """Input size of a request before any trimming.
 
@@ -322,13 +447,21 @@ def estimate_input_tokens(
     prompt scaffolding, so a caller can ask "would this fit?" without building
     a context and having the very documents it wants to measure trimmed out
     from under it. Kept next to the planner so the two stay in step.
+
+    Carries the model's safety margin, so the answer is an upper bound rather
+    than an optimistic guess. Routing depends on this: a router that trusts an
+    estimate which reads low will decline to move a request that does not fit.
     """
     return (
-        (count_tokens(system_prompt, model_name) if system_prompt else 0)
-        + count_tokens(user_message, model_name)
-        + sum(count_message_tokens(m, model_name) for m in history)
-        + sum(count_tokens(d.text, model_name) for d in documents)
-        + sum(count_tokens(a.text, model_name) for a in attachments)
+        (
+            count_tokens(system_prompt, model_name, model_config)
+            if system_prompt
+            else 0
+        )
+        + count_tokens(user_message, model_name, model_config)
+        + sum(count_message_tokens(m, model_name, model_config) for m in history)
+        + sum(count_tokens(d.text, model_name, model_config) for d in documents)
+        + sum(count_tokens(a.text, model_name, model_config) for a in attachments)
     )
 
 
@@ -369,12 +502,26 @@ def plan_and_compact_context(
     )
     actions: list[CompactionAction] = []
 
-    plan.system_tokens = count_tokens(system_prompt, model_name) if system_prompt else 0
-    plan.user_message_tokens = count_tokens(user_message, model_name)
-    plan.history_tokens = sum(count_message_tokens(m, model_name) for m in history)
-    plan.documents_tokens = sum(count_tokens(d.text, model_name) for d in documents)
+    # Bound to this model and its config once, so no call site below can
+    # silently size a segment with a different (optimistic) ruler than the one
+    # the budget was planned against.
+    def _ct(text: str) -> int:
+        return count_tokens(text, model_name, model_config)
+
+    def _cmt(message: Any) -> int:
+        return count_message_tokens(message, model_name, model_config)
+
+    def _trunc(text: str, max_tokens: int) -> tuple[str, int]:
+        return _truncate_text_to_tokens(
+            text, max_tokens, model_name, model_config=model_config
+        )
+
+    plan.system_tokens = _ct(system_prompt) if system_prompt else 0
+    plan.user_message_tokens = _ct(user_message)
+    plan.history_tokens = sum(_cmt(m) for m in history)
+    plan.documents_tokens = sum(_ct(d.text) for d in documents)
     plan.attachments_tokens = sum(
-        count_tokens(a.text, model_name) for a in attachments
+        _ct(a.text) for a in attachments
     )
 
     if not plan.over_budget:
@@ -417,11 +564,11 @@ def plan_and_compact_context(
     if plan.history_tokens > hist_target:
         dropped = 0
         while history and sum(
-            count_message_tokens(m, model_name) for m in history
+            _cmt(m) for m in history
         ) > hist_target:
             m = history.pop(0)
-            dropped += count_message_tokens(m, model_name)
-        plan.history_tokens = sum(count_message_tokens(m, model_name) for m in history)
+            dropped += _cmt(m)
+        plan.history_tokens = sum(_cmt(m) for m in history)
         if dropped:
             actions.append(
                 CompactionAction(
@@ -438,17 +585,17 @@ def plan_and_compact_context(
         for i, a in enumerate(attachments):
             if a.required:
                 continue
-            raw = count_tokens(a.text, model_name)
+            raw = _ct(a.text)
             allowed = max(256, int(raw * scale))
             if allowed >= raw:
                 continue
-            new_text, loss = _truncate_text_to_tokens(a.text, allowed, model_name)
+            new_text, loss = _trunc(a.text, allowed)
             dropped += loss
             attachments[i] = DocumentSegment(
                 label=a.label, text=new_text, required=a.required
             )
         plan.attachments_tokens = sum(
-            count_tokens(a.text, model_name) for a in attachments
+            _ct(a.text) for a in attachments
         )
         if dropped:
             actions.append(
@@ -466,17 +613,17 @@ def plan_and_compact_context(
         for i, d in enumerate(documents):
             if d.required:
                 continue
-            raw = count_tokens(d.text, model_name)
+            raw = _ct(d.text)
             allowed = max(512, int(raw * scale))
             if allowed >= raw:
                 continue
-            new_text, loss = _truncate_text_to_tokens(d.text, allowed, model_name)
+            new_text, loss = _trunc(d.text, allowed)
             dropped += loss
             documents[i] = DocumentSegment(
                 label=d.label, text=new_text, required=d.required
             )
         plan.documents_tokens = sum(
-            count_tokens(d.text, model_name) for d in documents
+            _ct(d.text) for d in documents
         )
         if dropped:
             actions.append(
@@ -503,9 +650,7 @@ def plan_and_compact_context(
             for seg in bucket:
                 if seg.required:
                     continue
-                if candidate is None or count_tokens(
-                    seg.text, model_name
-                ) > count_tokens(candidate.text, model_name):
+                if candidate is None or _ct(seg.text) > _ct(candidate.text):
                     candidate = seg
                     bucket_name = bucket_name_try
                     container = bucket
@@ -522,7 +667,7 @@ def plan_and_compact_context(
             )
             break
 
-        raw = count_tokens(candidate.text, model_name)
+        raw = _ct(candidate.text)
         target = raw - overflow - 8  # shave 8 extra tokens of slack
         if target < _MIN_USEFUL_TOKENS:
             # Not worth keeping a tiny sliver — drop the segment entirely.
@@ -535,9 +680,7 @@ def plan_and_compact_context(
                 )
             )
         else:
-            new_text, loss = _truncate_text_to_tokens(
-                candidate.text, target, model_name
-            )
+            new_text, loss = _trunc(candidate.text, target)
             if loss <= 0:
                 # No forward progress possible on this segment; drop it.
                 container.remove(candidate)
@@ -561,10 +704,10 @@ def plan_and_compact_context(
                     )
                 )
         plan.documents_tokens = sum(
-            count_tokens(d.text, model_name) for d in documents
+            _ct(d.text) for d in documents
         )
         plan.attachments_tokens = sum(
-            count_tokens(a.text, model_name) for a in attachments
+            _ct(a.text) for a in attachments
         )
 
     return CompactedContext(
@@ -609,9 +752,27 @@ def find_oversize_documents(
     ``documents`` is a list of dicts each with at least ``uuid``, ``title``,
     ``token_count``. Accepting dicts (not the Beanie model) keeps this usable
     from sync Celery code.
+
+    ``token_count`` is a raw tiktoken figure (see :func:`count_raw_tokens`), so
+    the model's safety margin is applied here rather than trusted from storage.
+    Without it this check under-warns by the same 4–17% the planner did, and a
+    workflow that will fail is not flagged before it runs. Applying it at read
+    time also corrects documents ingested before any of this existed.
     """
     budget = input_budget(model_name, model_config, overhead_tokens=overhead_tokens)
-    oversize = [d for d in _as_documents(documents) if d.token_count > budget]
+    margin = token_safety_margin(model_name, model_config)
+    # Stored counts are raw tiktoken figures, so the margin is applied at read
+    # time rather than trusted from storage. That also corrects documents
+    # ingested before any of this existed, without a backfill.
+    oversize = [
+        OversizeDocument(
+            uuid=d.uuid,
+            title=d.title,
+            token_count=_apply_margin(d.token_count, margin),
+        )
+        for d in _as_documents(documents)
+    ]
+    oversize = [d for d in oversize if d.token_count > budget]
     oversize.sort(key=lambda o: o.token_count, reverse=True)
     return oversize
 

--- a/backend/app/services/context_budget.py
+++ b/backend/app/services/context_budget.py
@@ -134,11 +134,40 @@ def _load_tokenizer(path: str):
     Cached: a real vocabulary is several megabytes and takes milliseconds to
     parse, so loading it per request would make this the performance problem it
     exists to avoid.
+
+    Two things are settled here rather than at the call site, because callers
+    read the *presence* of a tokenizer as proof the count will be exact:
+
+    ``tokenizer.json`` can carry truncation and padding stanzas, and
+    ``Tokenizer.from_file`` restores them. A file specifying ``max_length: 512``
+    would silently cap every count at 512 — a far worse under-count than the
+    estimate this replaces, and one nothing downstream could detect, since a
+    resolved tokenizer suppresses the safety margin. Both are cleared.
+
+    The tokenizer is then exercised on a probe string. A vocabulary that loads
+    but cannot encode would otherwise satisfy ``resolve_exact_tokenizer`` —
+    which sets the margin to 1.0 — while ``_count_raw_tokens`` quietly fell
+    back to tiktoken, producing a raw estimate with the safety margin switched
+    off. That is exactly the hard-failing under-count this module exists to
+    prevent, so an unusable tokenizer must be no tokenizer at all.
     """
     try:
         from tokenizers import Tokenizer
 
-        return Tokenizer.from_file(path)
+        tok = Tokenizer.from_file(path)
+        # Order matters: no_truncation/no_padding must run before the probe, or
+        # the probe would validate a configuration we are about to change.
+        try:
+            tok.no_truncation()
+            tok.no_padding()
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning(
+                "could not clear truncation/padding on tokenizer at %s (%s); "
+                "falling back to estimation", path, exc,
+            )
+            return None
+        tok.encode("probe", add_special_tokens=False).ids
+        return tok
     except Exception as exc:
         logger.warning(
             "could not load tokenizer at %s (%s); falling back to estimation",
@@ -578,6 +607,26 @@ def resolve_response_reserve(
     return _default_response_reserve(context_window)
 
 
+def _split_head_tail(ids, budget: int, decode) -> Optional[tuple[str, str]]:
+    """Take ``budget`` tokens from ``ids`` as a 75/25 head and tail.
+
+    Returns None when ``budget`` already covers the whole list. That is not a
+    trim: the two slices would overlap and together reproduce — or, once the
+    marker is added, exceed — the original text, which is the opposite of
+    truncating. It means only that this vocabulary disagrees with the one that
+    decided a trim was needed, and the caller should leave the text alone
+    rather than report a negative loss.
+    """
+    if budget >= len(ids):
+        return None
+    budget = max(0, budget)
+    head_n = int(budget * 0.75)
+    tail_n = max(0, budget - head_n)
+    head_text = decode(ids[:head_n]) if head_n else ""
+    tail_text = decode(ids[-tail_n:]) if tail_n else ""
+    return head_text, tail_text
+
+
 def _truncate_text_to_tokens(
     text: str,
     max_tokens: int,
@@ -587,11 +636,21 @@ def _truncate_text_to_tokens(
 ) -> tuple[str, int]:
     """Truncate ``text`` to ≤ ``max_tokens``, preserving head and tail.
 
-    ``max_tokens`` is a margin-inflated budget, but the encoder slices by real
-    token offsets, so the budget is converted back to raw token space before
-    slicing. Slicing ``toks`` by an inflated count would take *more* text than
-    the budget allows and leave the caller still over, which the last-ditch
-    loop would then have to iterate its way out of.
+    ``max_tokens`` is a margin-inflated budget, but slicing happens by real
+    token offsets, so the budget is converted back to raw token space first.
+    Slicing by an inflated count would take *more* text than the budget allows
+    and leave the caller still over, which the last-ditch loop would then have
+    to iterate its way out of.
+
+    The budget must be converted into the units of whichever vocabulary does
+    the slicing, and that has to be the same one that did the counting. When a
+    model's own tokenizer is available the margin is 1.0, so ``raw_usable`` is
+    denominated in *its* tokens — slicing a tiktoken list by that number is a
+    unit error, and a silent one: the two rulers differ by up to 1.45x on the
+    numeric content this product handles, so head and tail overlap and the
+    "truncated" text comes back longer than the original. ``dropped`` then goes
+    negative and the caller's ``loss <= 0`` check reads it as an untrimmable
+    segment and discards the whole document.
 
     Returns ``(truncated_text, dropped_tokens)``, both in inflated space.
     """
@@ -606,17 +665,36 @@ def _truncate_text_to_tokens(
     usable = max(1, max_tokens - marker_tokens)
     raw_usable = max(1, int(usable / margin))
 
+    # Prefer the model's own vocabulary, which is what counted above.
+    exact = resolve_exact_tokenizer(model_name, model_config)
+    if exact is not None:
+        try:
+            ids = exact.encode(text, add_special_tokens=False).ids
+            halves = _split_head_tail(ids, raw_usable, exact.decode)
+            if halves is None:
+                return text, 0
+            new_text = halves[0] + marker + halves[1]
+            return new_text, max(
+                0,
+                original_tokens - count_tokens(new_text, model_name, model_config),
+            )
+        except Exception:
+            logger.warning(
+                "exact tokenizer failed while truncating for %s; "
+                "falling back to estimation", model_name, exc_info=True,
+            )
+
     encoder = _get_encoder(_encoding_for(model_name))
     if encoder is not None:
         try:
             toks = encoder.encode(text, disallowed_special=())
-            head_n = int(raw_usable * 0.75)
-            tail_n = max(0, raw_usable - head_n)
-            head_text = encoder.decode(toks[:head_n]) if head_n else ""
-            tail_text = encoder.decode(toks[-tail_n:]) if tail_n else ""
-            new_text = head_text + marker + tail_text
-            return new_text, original_tokens - count_tokens(
-                new_text, model_name, model_config
+            halves = _split_head_tail(toks, raw_usable, encoder.decode)
+            if halves is None:
+                return text, 0
+            new_text = halves[0] + marker + halves[1]
+            return new_text, max(
+                0,
+                original_tokens - count_tokens(new_text, model_name, model_config),
             )
         except Exception:
             pass
@@ -624,8 +702,12 @@ def _truncate_text_to_tokens(
     approx_chars = raw_usable * _CHAR_TO_TOKEN_RATIO
     head_chars = int(approx_chars * 0.75)
     tail_chars = max(0, approx_chars - head_chars)
+    if head_chars + tail_chars >= len(text):
+        return text, 0
     new_text = text[:head_chars] + marker + (text[-tail_chars:] if tail_chars else "")
-    return new_text, original_tokens - count_tokens(new_text, model_name, model_config)
+    return new_text, max(
+        0, original_tokens - count_tokens(new_text, model_name, model_config)
+    )
 
 
 def input_budget_for(

--- a/backend/app/services/context_budget.py
+++ b/backend/app/services/context_budget.py
@@ -79,6 +79,31 @@ DEFAULT_TOKENIZER_CACHE_ROOT = "/hf-cache"
 # exactly.
 REQUEST_SCAFFOLD_TOKENS = 512
 
+# Models already warned about, so the fallback is reported once per process
+# rather than once per request. Per-request logging would be noise at chat
+# volume; per-process is enough to be seen after a deploy or a config change,
+# and resets naturally on restart.
+_ESTIMATED_MODELS_WARNED: set[str] = set()
+
+
+def _warn_estimated_once(model_name: str) -> None:
+    """Say plainly that this model's budget is a guess, not a measurement.
+
+    Silence here is the alias bug: a model registered as "Qwen-30b" rather
+    than its full name resolves no vocabulary and drops to the default
+    margin, which measurement shows is wrong for numeric content. The guess
+    is a reasonable last resort; not saying so is not.
+    """
+    if model_name in _ESTIMATED_MODELS_WARNED:
+        return
+    _ESTIMATED_MODELS_WARNED.add(model_name)
+    logger.warning(
+        "token counts for %r are estimated, not exact: no local vocabulary "
+        "and no stored calibration. Budgets use a default margin of %.2f, "
+        "which is known to under-count numeric and tabular content.",
+        model_name, DEFAULT_TOKEN_SAFETY_MARGIN,
+    )
+
 
 @lru_cache(maxsize=32)
 def _load_tokenizer(path: str):
@@ -216,6 +241,7 @@ def token_safety_margin(
         return 1.0
     if _is_openai_model(model_name):
         return 1.0
+    _warn_estimated_once(model_name or "<unnamed>")
     return DEFAULT_TOKEN_SAFETY_MARGIN
 
 

--- a/backend/app/services/context_budget.py
+++ b/backend/app/services/context_budget.py
@@ -49,12 +49,34 @@ _CHAR_TO_TOKEN_RATIO = 4
 DEFAULT_TOKEN_SAFETY_MARGIN = 1.20
 
 
-# Where vLLM leaves the vocabulary for every model it serves. Tokenizing needs
-# the vocabulary, not the weights and not the GPU, so this is pure local CPU
-# work — roughly 1.5 ms for a 36-page proposal, against 0.3 ms for the tiktoken
-# call it replaces. Overridable per model, and per deployment, because this
-# path is a property of how the host mounts its model cache.
+# Where a self-hosted server leaves the vocabulary for every model it serves.
+# Tokenizing needs the vocabulary, not the weights and not the GPU, so this is
+# pure local CPU work — roughly 1.5 ms for a 36-page proposal, against 0.3 ms
+# for the tiktoken call it replaces.
+#
+# Only the last-resort default. It is a property of how a particular host
+# mounts its model cache, so it is overridable per model
+# (``tokenizer_cache_root`` on the model config) and per deployment
+# (``TOKENIZER_CACHE_ROOT``). Resolution order is model config, then settings,
+# then this.
 DEFAULT_TOKENIZER_CACHE_ROOT = "/hf-cache"
+
+
+@lru_cache(maxsize=1)
+def _settings_tokenizer_cache_root() -> str:
+    """The deployment-wide cache root, or "" when it cannot be read.
+
+    Cached because this is consulted on every token count. Deliberately
+    forgiving: a settings failure must degrade to the default, not take down
+    the budget planner and with it chat.
+    """
+    try:
+        from app.config import Settings
+
+        return Settings().tokenizer_cache_root or ""
+    except Exception:  # pragma: no cover - defensive
+        logger.debug("could not read tokenizer_cache_root from settings")
+        return ""
 
 # Tokens a request costs beyond the text it carries.
 #
@@ -169,7 +191,11 @@ def resolve_exact_tokenizer(model_name: str, model_config: Optional[dict] = None
     if explicit:
         return _load_tokenizer(str(explicit))
 
-    root = cfg.get("tokenizer_cache_root") or DEFAULT_TOKENIZER_CACHE_ROOT
+    root = (
+        cfg.get("tokenizer_cache_root")
+        or _settings_tokenizer_cache_root()
+        or DEFAULT_TOKENIZER_CACHE_ROOT
+    )
     path = _find_vocabulary(model_name or "", str(root))
     return _load_tokenizer(path) if path else None
 
@@ -599,8 +625,9 @@ def estimate_input_tokens(
     """Input size of a request before any trimming.
 
     Mirrors what ``plan_and_compact_context`` counts into
-    ``BudgetPlan.total_input_tokens``, including the same 64-token allowance for
-    prompt scaffolding, so a caller can ask "would this fit?" without building
+    ``BudgetPlan.total_input_tokens``, including the same
+    ``REQUEST_SCAFFOLD_TOKENS`` allowance for prompt scaffolding, so a caller
+    can ask "would this fit?" without building
     a context and having the very documents it wants to measure trimmed out
     from under it. Kept next to the planner so the two stay in step.
 

--- a/backend/app/services/context_budget.py
+++ b/backend/app/services/context_budget.py
@@ -1065,9 +1065,29 @@ def find_context_overflow(
 
     Returns None when everything fits. A "single" overflow names only the docs
     that are individually too large; a "combined" overflow names the whole set.
+
+    Stored ``token_count`` values are raw tiktoken figures, so the same
+    divergence allowance :func:`find_oversize_documents` applies is applied
+    here — for the same reason and from the same source
+    (:func:`stored_count_margin`). Without it this check under-warns by the
+    divergence it exists to catch, and the combined case is where that bites
+    hardest: a budget workbook is both the document most likely to push a
+    package over the line and the content tiktoken under-counts worst.
     """
     budget = input_budget(model_name, model_config, overhead_tokens=overhead_tokens)
-    docs = sorted(_as_documents(documents), key=lambda d: d.token_count, reverse=True)
+    margin = stored_count_margin(model_name, model_config)
+    docs = sorted(
+        (
+            OversizeDocument(
+                uuid=d.uuid,
+                title=d.title,
+                token_count=_apply_margin(d.token_count, margin),
+            )
+            for d in _as_documents(documents)
+        ),
+        key=lambda d: d.token_count,
+        reverse=True,
+    )
     total = sum(d.token_count for d in docs)
 
     oversize = [d for d in docs if d.token_count > budget]

--- a/backend/app/services/context_budget.py
+++ b/backend/app/services/context_budget.py
@@ -13,6 +13,7 @@ import logging
 import math
 from dataclasses import dataclass, field
 from functools import lru_cache
+from pathlib import Path
 from typing import Any, Optional
 
 logger = logging.getLogger(__name__)
@@ -24,25 +25,128 @@ logger = logging.getLogger(__name__)
 
 _CHAR_TO_TOKEN_RATIO = 4
 
-# How much to inflate a tiktoken estimate for a model tiktoken does not model.
+# Fallback only: how much to inflate a tiktoken estimate for a model whose real
+# vocabulary we do not have. Models we can tokenize exactly get no margin at
+# all — see `resolve_exact_tokenizer`.
 #
-# tiktoken is OpenAI's tokenizer. For every other model it is a proxy, and
-# measurement says it is a systematically *optimistic* one: across 97 harness
-# runs against three self-hosted Qwen models, spanning requests from 307 to
-# 46,916 tokens, the estimate came in under the `prompt_tokens` the server
-# reported every single time, by 4.2% to 17.3% (mean 14.5%). It was never once
-# equal or over.
+# tiktoken is OpenAI's tokenizer, and for anything else it is a proxy that
+# reads *low* — the direction that hard-fails. Measured against the models'
+# own `prompt_tokens`, the divergence is driven by content, not request size:
 #
-# The error only bites near the window boundary — which is exactly where this
-# product's flagship use case lives, reading a whole proposal on a 32k model.
+#   flowing prose                    1.000
+#   project description              1.019
+#   real budget justification        1.171
+#   synthetic dense currency table   1.455
 #
-# 1.20 covers the worst observation with headroom. The asymmetry justifies
-# rounding up rather than fitting tightly: this is a budget estimate, not an
-# invoice. Guessing high costs slightly-early routing to a bigger model.
-# Guessing low costs a hard error and no answer, which is the bug this exists
-# to prevent. Deployments that have measured their own models can set
-# `token_safety_margin` on the model config instead of living with this.
+# So no single constant is right. 1.20 covers ordinary prose and the real
+# documents measured here, and is *known to be insufficient* for heavily
+# numeric or tabular content — which is why exact tokenization, not a better
+# constant, is the actual fix. This value only governs models where exactness
+# is unavailable (hosted APIs), for which no measurements exist on this
+# deployment; a deployment that has measured its own should set
+# `token_safety_margin` on the model config. A configured value below 1.0 is
+# refused, since that re-creates the original bug by configuration.
 DEFAULT_TOKEN_SAFETY_MARGIN = 1.20
+
+
+# Where vLLM leaves the vocabulary for every model it serves. Tokenizing needs
+# the vocabulary, not the weights and not the GPU, so this is pure local CPU
+# work — roughly 1.5 ms for a 36-page proposal, against 0.3 ms for the tiktoken
+# call it replaces. Overridable per model, and per deployment, because this
+# path is a property of how the host mounts its model cache.
+DEFAULT_TOKENIZER_CACHE_ROOT = "/hf-cache"
+
+# Tokens a request costs beyond the text it carries.
+#
+# The server wraps every request in a chat template, and the agent framework
+# adds its own preamble around the instructions. Neither appears in any string
+# we count, so even a perfectly exact text count comes in short — in the unsafe
+# direction.
+#
+# Measured, twice over. Against a bare server the chat template is a flat 13
+# tokens and stays 13 across a 5000x payload range. End to end through the app
+# the true overhead is 37 tokens, and it came out identical on a 25,000-token
+# request and a 50,000-token one — so this is a fixed cost, not a multiplier.
+#
+# 512 is deliberately far above the measured 37. It is a flat 2% of a 32k
+# model's input budget, which is a cheap price for absorbing whatever the
+# framework adds around `instructions` in a future version, and for history-
+# heavy turns where per-message wrappers accumulate. Tightening it buys
+# almost nothing and re-opens the direction that hard-fails.
+#
+# This is the piece the old 1.20 margin was incidentally covering. Making it
+# explicit is what allows the margin to be dropped for models we can tokenize
+# exactly.
+REQUEST_SCAFFOLD_TOKENS = 512
+
+
+@lru_cache(maxsize=32)
+def _load_tokenizer(path: str):
+    """Load a `tokenizer.json` from disk, or return None if it is unusable.
+
+    Cached: a real vocabulary is several megabytes and takes milliseconds to
+    parse, so loading it per request would make this the performance problem it
+    exists to avoid.
+    """
+    try:
+        from tokenizers import Tokenizer
+
+        return Tokenizer.from_file(path)
+    except Exception as exc:
+        logger.warning(
+            "could not load tokenizer at %s (%s); falling back to estimation",
+            path, exc,
+        )
+        return None
+
+
+@lru_cache(maxsize=32)
+def _find_vocabulary(model_name: str, cache_root: str) -> Optional[str]:
+    """Locate a model's `tokenizer.json` inside an HF-style cache.
+
+    "Qwen/Qwen3-VL-8B-Instruct" lives at
+    ``<root>/hub/models--Qwen--Qwen3-VL-8B-Instruct/snapshots/<rev>/``.
+    Newest snapshot wins, so a re-pulled model is picked up without config
+    changes.
+    """
+    if not model_name or not cache_root:
+        return None
+    slug = "models--" + model_name.replace("/", "--")
+    for base in (Path(cache_root) / "hub", Path(cache_root)):
+        snapshots = base / slug / "snapshots"
+        try:
+            if not snapshots.is_dir():
+                continue
+            found = sorted(
+                snapshots.glob("*/tokenizer.json"),
+                key=lambda p: p.stat().st_mtime,
+                reverse=True,
+            )
+        except OSError:
+            continue
+        if found:
+            return str(found[0])
+    return None
+
+
+def resolve_exact_tokenizer(model_name: str, model_config: Optional[dict] = None):
+    """This model's real tokenizer, or None when we do not have it.
+
+    None is an ordinary outcome, not an error: hosted models (Claude, and any
+    provider we call over an API) have no local vocabulary, and those keep the
+    estimate-plus-margin path.
+
+    Priority: an explicit ``tokenizer_path`` on the model config, then
+    discovery in the deployment's model cache.
+    """
+    cfg = model_config or {}
+    explicit = cfg.get("tokenizer_path")
+    if explicit:
+        return _load_tokenizer(str(explicit))
+
+    root = cfg.get("tokenizer_cache_root") or DEFAULT_TOKENIZER_CACHE_ROOT
+    path = _find_vocabulary(model_name or "", str(root))
+    return _load_tokenizer(path) if path else None
 
 
 @lru_cache(maxsize=8)
@@ -107,6 +211,9 @@ def token_safety_margin(
                 model_name,
             )
 
+    # An exact count needs no correction. Inflating it would only route early.
+    if resolve_exact_tokenizer(model_name, model_config) is not None:
+        return 1.0
     if _is_openai_model(model_name):
         return 1.0
     return DEFAULT_TOKEN_SAFETY_MARGIN
@@ -119,16 +226,32 @@ def _apply_margin(raw_tokens: int, margin: float) -> int:
     return math.ceil(raw_tokens * margin)
 
 
-def _count_raw_tokens(text: str, model_name: str = "") -> int:
-    """tiktoken's count, with no safety margin applied.
+def _count_raw_tokens(
+    text: str, model_name: str = "", model_config: Optional[dict] = None
+) -> int:
+    """Token count with no safety margin applied.
 
-    Internal: callers that are sizing a request want :func:`count_tokens`.
-    This exists so the margin is applied exactly once per aggregate, and so
-    truncation can convert a margin-inflated budget back into real token
-    offsets for slicing.
+    Uses the model's own vocabulary when the deployment has it, which makes the
+    count exact and the margin unnecessary. Falls back to tiktoken, and then to
+    a character heuristic.
+
+    Internal: callers sizing a request want :func:`count_tokens`. This exists so
+    the margin is applied exactly once per aggregate, and so truncation can
+    convert a margin-inflated budget back into real token offsets for slicing.
     """
     if not text:
         return 0
+
+    tokenizer = resolve_exact_tokenizer(model_name, model_config)
+    if tokenizer is not None:
+        try:
+            return len(tokenizer.encode(text, add_special_tokens=False).ids)
+        except Exception:
+            logger.warning(
+                "exact tokenizer failed for %s; falling back to estimation",
+                model_name, exc_info=True,
+            )
+
     encoder = _get_encoder(_encoding_for(model_name))
     if encoder is not None:
         try:
@@ -138,7 +261,9 @@ def _count_raw_tokens(text: str, model_name: str = "") -> int:
     return max(1, len(text) // _CHAR_TO_TOKEN_RATIO)
 
 
-def count_raw_tokens(text: str, model_name: str = "") -> int:
+def count_raw_tokens(
+    text: str, model_name: str = "", model_config: Optional[dict] = None
+) -> int:
     """Count with no safety margin, for values *stored* rather than spent.
 
     A document's ``token_count`` is written once at ingestion and read later
@@ -149,14 +274,14 @@ def count_raw_tokens(text: str, model_name: str = "") -> int:
     an uncorrected number. So the stored figure stays a raw baseline and the
     margin is applied at comparison time, by :func:`find_oversize_documents`.
     """
-    return _count_raw_tokens(text, model_name)
+    return _count_raw_tokens(text, model_name, model_config)
 
 
 def count_tokens(
     text: str, model_name: str = "", model_config: Optional[dict] = None
 ) -> int:
     """Estimate token count for ``text``, erring high for non-OpenAI models."""
-    raw = _count_raw_tokens(text, model_name)
+    raw = _count_raw_tokens(text, model_name, model_config)
     return _apply_margin(raw, token_safety_margin(model_name, model_config))
 
 
@@ -175,7 +300,7 @@ def count_message_tokens(
         content = getattr(part, "content", None)
         if content is None:
             content = str(part)
-        total += _count_raw_tokens(str(content), model_name)
+        total += _count_raw_tokens(str(content), model_name, model_config)
     return _apply_margin(total, token_safety_margin(model_name, model_config))
 
 
@@ -279,11 +404,15 @@ class BudgetPlan:
     history_tokens: int = 0
     documents_tokens: int = 0
     attachments_tokens: int = 0
+    # Chat template + framework preamble: sent on every request, present in
+    # none of the strings above. See REQUEST_SCAFFOLD_TOKENS.
+    scaffold_tokens: int = REQUEST_SCAFFOLD_TOKENS
 
     @property
     def total_input_tokens(self) -> int:
         return (
-            self.system_tokens
+            self.scaffold_tokens
+            + self.system_tokens
             + self.user_message_tokens
             + self.history_tokens
             + self.documents_tokens
@@ -306,6 +435,7 @@ class BudgetPlan:
             "history_tokens": self.history_tokens,
             "documents_tokens": self.documents_tokens,
             "attachments_tokens": self.attachments_tokens,
+            "scaffold_tokens": self.scaffold_tokens,
             "headroom_tokens": self.input_budget - self.total_input_tokens,
         }
 
@@ -453,7 +583,8 @@ def estimate_input_tokens(
     estimate which reads low will decline to move a request that does not fit.
     """
     return (
-        (
+        REQUEST_SCAFFOLD_TOKENS
+        + (
             count_tokens(system_prompt, model_name, model_config)
             if system_prompt
             else 0
@@ -535,7 +666,7 @@ def plan_and_compact_context(
 
     # Non-compactable floor covers the system prompt, user message, and an
     # allowance for prompt scaffolding ("--- BEGIN REFERENCE DOCUMENTS ---" etc.).
-    floor = plan.system_tokens + plan.user_message_tokens + 64
+    floor = plan.system_tokens + plan.user_message_tokens + plan.scaffold_tokens
     if floor >= input_budget:
         actions.append(
             CompactionAction(

--- a/backend/app/tasks/document_tasks.py
+++ b/backend/app/tasks/document_tasks.py
@@ -369,10 +369,12 @@ def perform_extraction_and_update(self, document_uuid: str, extension: str) -> s
         else:
             raw_text = extract_text_from_file(str(absolute_path), extension)
 
-        # Count tokens using the same tokenizer the budget planner uses so the
-        # pre-flight oversize check is accurate.
-        from app.services.context_budget import count_tokens
-        token_count = count_tokens(raw_text) if raw_text else 0
+        # Stored raw, on purpose. The safety margin that makes a count safe to
+        # budget against depends on the model doing the reading, which is not
+        # known here and is not fixed for the life of the document — so
+        # find_oversize_documents applies it per-model at comparison time.
+        from app.services.context_budget import count_raw_tokens
+        token_count = count_raw_tokens(raw_text) if raw_text else 0
 
         from app.utils.extraction_quality import nonletter_ratio
         extraction_ratio = nonletter_ratio(raw_text) if raw_text else None

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     "prometheus-fastapi-instrumentator>=7.0,<9",
     "pymupdf>=1.27.2",
     "tiktoken>=0.9,<1",
+    "tokenizers>=0.20,<1",
     "langchain-text-splitters>=0.3,<2",
     "pdf-inspector>=0.2,<0.3",
 ]

--- a/backend/tests/test_context_budget.py
+++ b/backend/tests/test_context_budget.py
@@ -428,11 +428,22 @@ def test_find_oversize_documents_honors_reserve_override():
     # 128k window: default reserve 8k leaves ~119k, so a 100k doc fits. Raise
     # the reserve to 64k and the same doc no longer does — the pre-flight must
     # use the same reserve the request will actually send.
+    #
+    # The margin is pinned to 1.0 so this measures the reserve and nothing else.
+    # Stored counts are raw tiktoken figures and are inflated by the model's
+    # safety margin at read time, which for an unknown model would push this
+    # 100k document over the budget on its own — correctly, but for a different
+    # reason than this test is about. That path is covered in
+    # test_token_safety_margin.py.
     docs = [{"uuid": "a", "title": "big.pdf", "token_count": 100_000}]
-    cfg = {"context_window": 128_000}
+    cfg = {"context_window": 128_000, "token_safety_margin": 1.0}
     assert find_oversize_documents(documents=docs, model_name="m", model_config=cfg) == []
 
-    cfg_wide_reserve = {"context_window": 128_000, "response_reserve_tokens": 64_000}
+    cfg_wide_reserve = {
+        "context_window": 128_000,
+        "response_reserve_tokens": 64_000,
+        "token_safety_margin": 1.0,
+    }
     flagged = find_oversize_documents(
         documents=docs, model_name="m", model_config=cfg_wide_reserve,
     )

--- a/backend/tests/test_context_budget.py
+++ b/backend/tests/test_context_budget.py
@@ -559,3 +559,190 @@ def test_find_context_overflow_empty_input():
     from app.services.context_budget import find_context_overflow
 
     assert find_context_overflow(documents=[], model_name="m") is None
+
+
+# ---------------------------------------------------------------------------
+# Truncation must slice with the vocabulary that did the counting
+# ---------------------------------------------------------------------------
+
+
+class _DenseTokenizer:
+    """A self-consistent vocabulary denser than cl100k: one token per two
+    characters, where tiktoken averages roughly one per three on prose.
+
+    Self-consistency is the point — ``encode(decode(ids))`` returns ``ids`` —
+    because the bug under test is a disagreement between the ruler that counts
+    and the ruler that slices, and a fake whose halves disagree with each other
+    cannot distinguish the two.
+    """
+
+    def encode(self, text, add_special_tokens=False):
+        class _Encoded:
+            ids = list(range(len(text) // 2))
+
+        return _Encoded()
+
+    def decode(self, ids):
+        return "ab" * len(ids)
+
+
+def _dense_model(monkeypatch):
+    from app.services import context_budget as cb
+
+    monkeypatch.setattr(cb, "resolve_exact_tokenizer", lambda *a, **k: _DenseTokenizer())
+    return cb
+
+
+def test_truncation_slices_with_the_tokenizer_that_counted(monkeypatch):
+    """The budget is denominated in the counting vocabulary's tokens.
+
+    Slicing a tiktoken list by that number is a unit error. The two rulers
+    differ by up to ~1.5x on the numeric content this product handles, so the
+    head and tail slices overlapped and the "truncated" text came back *longer*
+    than the original — with a negative reported loss, which the last-ditch
+    loop reads as an untrimmable segment and answers by dropping the whole
+    document.
+    """
+    cb = _dense_model(monkeypatch)
+    text = "Budget line 12,345.67 for FY2026 indirect 58% MTDC exclusion. " * 400
+
+    total = cb.count_tokens(text, "qwen-local", {})
+    assert cb.token_safety_margin("qwen-local", {}) == 1.0
+
+    for keep in (0.95, 0.90, 0.75, 0.50, 0.30):
+        allowed = int(total * keep)
+        out, loss = cb._truncate_text_to_tokens(
+            text, allowed, "qwen-local", model_config={}
+        )
+        assert cb.count_tokens(out, "qwen-local", {}) <= allowed, (
+            f"keeping {keep:.0%} overshot its budget — the slice was taken in "
+            f"another vocabulary's units"
+        )
+        assert loss >= 0, f"keeping {keep:.0%} reported a negative loss"
+        assert len(out) <= len(text), f"keeping {keep:.0%} grew the text"
+
+
+def test_truncation_leaves_text_alone_when_the_budget_already_covers_it(
+    monkeypatch,
+):
+    """A budget wider than the token list is not a trim.
+
+    Head and tail would overlap and reproduce the whole text, and adding the
+    marker would make it longer still. Returning the text untouched with a zero
+    loss is the honest answer; a negative loss is never one.
+    """
+    cb = _dense_model(monkeypatch)
+    text = "short enough already"
+
+    out, loss = cb._truncate_text_to_tokens(
+        text, 10_000, "qwen-local", model_config={}
+    )
+    assert out == text
+    assert loss == 0
+
+
+def test_truncation_never_reports_a_negative_loss(monkeypatch):
+    """``dropped += loss`` and the ``loss <= 0`` drop rule both depend on it."""
+    cb = _dense_model(monkeypatch)
+    text = "Budget line 12,345.67 for FY2026. " * 200
+    total = cb.count_tokens(text, "qwen-local", {})
+
+    for allowed in (1, 2, total // 3, total - 1, total, total + 1, total * 3):
+        _, loss = cb._truncate_text_to_tokens(
+            text, allowed, "qwen-local", model_config={}
+        )
+        assert loss >= 0, f"allowed={allowed} produced loss={loss}"
+
+
+def _write_tokenizer(tmp_path, model_slug, body):
+    import json
+
+    snap = tmp_path / "hub" / f"models--{model_slug}" / "snapshots" / "r1"
+    snap.mkdir(parents=True)
+    (snap / "tokenizer.json").write_text(json.dumps(body))
+    return snap
+
+
+_MINIMAL_VOCAB = {
+    "version": "1.0",
+    "added_tokens": [],
+    "normalizer": None,
+    "pre_tokenizer": {"type": "Whitespace"},
+    "post_processor": None,
+    "decoder": None,
+    "model": {"type": "WordLevel", "vocab": {"[UNK]": 0}, "unk_token": "[UNK]"},
+}
+
+
+def test_a_tokenizer_carrying_truncation_does_not_cap_every_count(tmp_path):
+    """`Tokenizer.from_file` restores a truncation stanza and `encode` then
+    silently caps.
+
+    A vocabulary specifying ``max_length`` would make every document count as
+    at most that many tokens — a worse under-count than the estimate this
+    replaces, and undetectable downstream, because a resolved tokenizer sets
+    the safety margin to 1.0.
+    """
+    from app.services import context_budget as cb
+
+    body = dict(_MINIMAL_VOCAB)
+    body["truncation"] = {
+        "direction": "Right", "max_length": 8, "strategy": "LongestFirst",
+        "stride": 0,
+    }
+    body["padding"] = None
+    _write_tokenizer(tmp_path, "Fake--Capped", body)
+
+    cb._find_vocabulary.cache_clear()
+    cb._load_tokenizer.cache_clear()
+
+    text = " ".join(f"word{i}" for i in range(200))
+    count = cb.count_tokens(
+        text, "Fake/Capped", {"tokenizer_cache_root": str(tmp_path)}
+    )
+    assert count > 8, (
+        f"a truncation stanza capped the count at {count}; every document "
+        f"would look like it fits"
+    )
+
+
+def test_a_tokenizer_that_cannot_encode_is_treated_as_absent(tmp_path, monkeypatch):
+    """Presence of a tokenizer is read downstream as proof the count is exact.
+
+    One that loads but cannot encode satisfied ``resolve_exact_tokenizer`` —
+    setting the margin to 1.0 — while counting quietly fell back to tiktoken,
+    yielding a raw estimate with the safety margin switched off. That is the
+    hard-failing under-count this module exists to prevent.
+    """
+    from app.services import context_budget as cb
+
+    _write_tokenizer(tmp_path, "Fake--Broken", dict(_MINIMAL_VOCAB, padding=None,
+                                                    truncation=None))
+    cb._find_vocabulary.cache_clear()
+    cb._load_tokenizer.cache_clear()
+
+    class _Broken:
+        def encode(self, *a, **k):
+            raise RuntimeError("corrupt vocabulary")
+
+        def no_truncation(self):
+            pass
+
+        def no_padding(self):
+            pass
+
+    import tokenizers
+
+    monkeypatch.setattr(
+        tokenizers.Tokenizer, "from_file", staticmethod(lambda *a, **k: _Broken())
+    )
+    cb._load_tokenizer.cache_clear()
+
+    cfg = {"tokenizer_cache_root": str(tmp_path)}
+    assert cb.resolve_exact_tokenizer("Fake/Broken", cfg) is None, (
+        "an unusable tokenizer was reported as available, which suppresses "
+        "the safety margin while counting falls back to an estimate"
+    )
+    assert cb.token_safety_margin("Fake/Broken", cfg) > 1.0, (
+        "the margin stayed at 1.0 for a model whose count is not exact"
+    )

--- a/backend/tests/test_context_budget.py
+++ b/backend/tests/test_context_budget.py
@@ -471,8 +471,10 @@ def test_find_context_overflow_flags_combined_package():
 
     overflow = find_context_overflow(
         documents=_nasa_package(),
+        # Margin pinned to 1.0 so this measures combination and nothing else;
+        # the margin's own effect is covered below.
+        model_config={"context_window": 65_536, "token_safety_margin": 1.0},
         model_name="m",
-        model_config={"context_window": 65_536},
     )
     assert overflow is not None
     assert overflow.kind == "combined"
@@ -507,6 +509,51 @@ def test_find_context_overflow_single_doc_takes_precedence():
     assert overflow.kind == "single"
     assert [d.uuid for d in overflow.documents] == ["b"]
 
+
+def test_find_context_overflow_corrects_stored_tiktoken_counts():
+    """A package that fits raw but not once the divergence is allowed for.
+
+    Stored `token_count` values are tiktoken figures, and tiktoken reads low
+    for every non-OpenAI model. Without the allowance this check passes a
+    workflow that the gateway then rejects mid-run -- the exact failure the
+    combined check was added to prevent, and worst for budget workbooks, which
+    are both the likeliest thing to push a package over and the content
+    tiktoken under-counts most.
+    """
+    from app.services.context_budget import find_context_overflow
+
+    # The input budget for a 65,536-token window is 56,320 once the response
+    # reserve and overhead are taken out. 50,000 raw fits it; at the 1.20
+    # default the same package is 60,000, which does not.
+    docs = [
+        {"uuid": "a", "title": "Narrative.pdf", "token_count": 25_000},
+        {"uuid": "b", "title": "Budget_Justification.xlsx", "token_count": 25_000},
+    ]
+
+    assert find_context_overflow(
+        documents=docs,
+        model_name="qwen-local",
+        model_config={"context_window": 65_536, "token_safety_margin": 1.0},
+    ) is None
+
+    overflow = find_context_overflow(
+        documents=docs,
+        model_name="qwen-local",
+        model_config={"context_window": 65_536},
+    )
+    assert overflow is not None
+    assert overflow.kind == "combined"
+    assert overflow.total_tokens == 60_000
+
+
+def test_find_context_overflow_does_not_inflate_for_openai_models():
+    """tiktoken *is* their tokenizer, so the stored figure is already exact."""
+    from app.services.context_budget import find_context_overflow
+
+    docs = [{"uuid": "a", "title": "doc", "token_count": 30_000}]
+    assert find_context_overflow(
+        documents=docs, model_name="gpt-4o", model_config={"context_window": 65_536},
+    ) is None
 
 def test_find_context_overflow_empty_input():
     from app.services.context_budget import find_context_overflow

--- a/backend/tests/test_context_budget.py
+++ b/backend/tests/test_context_budget.py
@@ -254,6 +254,65 @@ def test_find_oversize_documents_flags_giants():
     assert oversize[0].token_count == 50_000
 
 
+def test_find_oversize_documents_corrects_a_stored_count_for_an_exact_model(
+    tmp_path,
+):
+    """A stored `token_count` is always a tiktoken figure, whatever the model.
+
+    Exact tokenization made `token_safety_margin` return 1.0 for models whose
+    vocabulary is on disk, which is right when the planner counts the text
+    itself. It is wrong here: this consumer never sees the text, only a
+    tiktoken count taken at ingestion. Passing that through uncorrected makes
+    the pre-flight check under-warn by exactly the divergence the exact
+    counting exists to remove, so a workflow that will overflow is not flagged
+    before it runs.
+    """
+    import json
+
+    from app.services.context_budget import find_oversize_documents
+
+    snap = (
+        tmp_path / "hub" / "models--Qwen--Qwen3-VL-8B-Instruct" / "snapshots" / "r1"
+    )
+    snap.mkdir(parents=True)
+    (snap / "tokenizer.json").write_text(json.dumps({
+        "version": "1.0", "truncation": None, "padding": None,
+        "added_tokens": [], "normalizer": None,
+        "pre_tokenizer": {"type": "Whitespace"}, "post_processor": None,
+        "decoder": None,
+        "model": {"type": "WordLevel", "vocab": {"[UNK]": 0}, "unk_token": "[UNK]"},
+    }))
+
+    # 32,768 window -> 8,192 reserve -> 23,552 budget after 1,024 overhead.
+    # A stored 23,000 looks like it fits, and does not once corrected.
+    docs = [{"uuid": "a", "title": "proposal.pdf", "token_count": 23_000}]
+    oversize = find_oversize_documents(
+        documents=docs,
+        model_name="Qwen/Qwen3-VL-8B-Instruct",
+        model_config={
+            "context_window": 32_768,
+            "tokenizer_cache_root": str(tmp_path),
+        },
+    )
+    assert [o.uuid for o in oversize] == ["a"], (
+        "a stored tiktoken count was compared against the budget with no "
+        "divergence allowance, so an overflowing document was not flagged"
+    )
+
+
+def test_find_oversize_documents_does_not_inflate_for_openai_models():
+    """tiktoken *is* the tokenizer there, so the stored count is already exact
+    and inflating it would flag documents that genuinely fit."""
+    from app.services.context_budget import find_oversize_documents
+
+    docs = [{"uuid": "a", "title": "doc.txt", "token_count": 23_000}]
+    assert find_oversize_documents(
+        documents=docs,
+        model_name="gpt-4o",
+        model_config={"context_window": 32_768},
+    ) == []
+
+
 def test_find_oversize_documents_respects_model_config_override():
     from app.services.context_budget import find_oversize_documents
 

--- a/backend/tests/test_exact_tokenizer.py
+++ b/backend/tests/test_exact_tokenizer.py
@@ -1,0 +1,222 @@
+"""Count with the model's own vocabulary instead of estimating with OpenAI's.
+
+The safety margin this replaces was a heuristic standing in for a quantity that
+is exactly computable. Measured against the models' own `prompt_tokens`, the
+divergence between `cl100k_base` and the real Qwen vocabulary is entirely
+content-dependent — 1.000 on flowing prose, 1.171 on a real budget
+justification, 1.455 on dense currency tables. No single constant covers that
+range without either under-counting budget documents (a hard failure, and
+budget justifications are this product's core content) or wasting a third of
+the window on prose.
+
+Tokenization is CPU work: it needs the vocabulary, not the model weights and
+not the GPU. `tokenizers` is already a dependency and is a compiled Rust
+extension, and vLLM already leaves `tokenizer.json` on disk for every model it
+serves, so exactness costs no new dependency, no download, and no GPU claim.
+
+These tests build their own tiny vocabulary rather than reading the deployment
+cache, so they run anywhere.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from app.services.context_budget import (
+    DEFAULT_TOKEN_SAFETY_MARGIN,
+    count_tokens,
+    estimate_input_tokens,
+    resolve_exact_tokenizer,
+    token_safety_margin,
+)
+
+
+# ---------------------------------------------------------------------------
+# A real, tiny tokenizer on disk
+# ---------------------------------------------------------------------------
+
+
+def _write_tokenizer(dirpath: Path) -> Path:
+    """A genuine word-level tokenizer.json — small, but really loadable.
+
+    Deliberately not a mock. The thing under test is whether a vocabulary file
+    on disk is found and used, and a fake loader would not prove that.
+    """
+    vocab = {"[UNK]": 0, "budget": 1, "justification": 2, "total": 3, "##s": 4}
+    spec = {
+        "version": "1.0",
+        "truncation": None,
+        "padding": None,
+        "added_tokens": [],
+        "normalizer": None,
+        "pre_tokenizer": {"type": "Whitespace"},
+        "post_processor": None,
+        "decoder": None,
+        "model": {"type": "WordLevel", "vocab": vocab, "unk_token": "[UNK]"},
+    }
+    dirpath.mkdir(parents=True, exist_ok=True)
+    path = dirpath / "tokenizer.json"
+    path.write_text(json.dumps(spec))
+    return path
+
+
+@pytest.fixture
+def vocab_dir(tmp_path: Path) -> Path:
+    """An HF-cache-shaped tree for one model."""
+    snap = (
+        tmp_path
+        / "hub"
+        / "models--Qwen--Qwen3-VL-8B-Instruct"
+        / "snapshots"
+        / "abc123"
+    )
+    _write_tokenizer(snap)
+    return tmp_path
+
+
+class TestResolvingTheVocabulary:
+    def test_finds_a_models_vocabulary_in_the_cache(self, vocab_dir):
+        tok = resolve_exact_tokenizer(
+            "Qwen/Qwen3-VL-8B-Instruct",
+            {"tokenizer_cache_root": str(vocab_dir)},
+        )
+        assert tok is not None
+
+    def test_an_explicit_path_on_the_model_config_wins(self, tmp_path):
+        path = _write_tokenizer(tmp_path / "custom")
+        tok = resolve_exact_tokenizer(
+            "anything/at-all", {"tokenizer_path": str(path)}
+        )
+        assert tok is not None
+
+    def test_returns_none_when_the_model_has_no_vocabulary(self, vocab_dir):
+        """Hosted models have no local vocabulary, and that is not an error —
+        it is the signal to fall back to estimating."""
+        assert resolve_exact_tokenizer(
+            "claude-sonnet-4", {"tokenizer_cache_root": str(vocab_dir)}
+        ) is None
+
+    def test_returns_none_when_the_cache_does_not_exist(self):
+        assert resolve_exact_tokenizer(
+            "Qwen/Qwen3-VL-8B-Instruct",
+            {"tokenizer_cache_root": "/nonexistent/path"},
+        ) is None
+
+    def test_a_corrupt_vocabulary_falls_back_rather_than_raising(self, tmp_path):
+        """A broken file must degrade to estimation, not take chat down."""
+        bad = tmp_path / "tokenizer.json"
+        bad.write_text("{ this is not valid tokenizer json")
+        assert resolve_exact_tokenizer(
+            "some/model", {"tokenizer_path": str(bad)}
+        ) is None
+
+    def test_resolution_is_cached(self, vocab_dir):
+        """Loading a real vocabulary costs milliseconds and megabytes; doing it
+        per request would make this change the performance problem it is
+        supposed to avoid."""
+        cfg = {"tokenizer_cache_root": str(vocab_dir)}
+        first = resolve_exact_tokenizer("Qwen/Qwen3-VL-8B-Instruct", cfg)
+        second = resolve_exact_tokenizer("Qwen/Qwen3-VL-8B-Instruct", cfg)
+        assert first is second
+
+
+class TestCountingWithTheRealVocabulary:
+    def test_count_uses_the_models_vocabulary_when_available(self, vocab_dir):
+        """Text chosen so the two tokenizers cannot agree by accident.
+
+        Common words tokenize to one token under both the word-level test
+        vocabulary and cl100k, so an obvious phrase like "budget total" passes
+        this test whether or not the exact tokenizer ran at all. These strings
+        are outside the test vocabulary, so it yields one [UNK] each while
+        cl100k splits them into several subword pieces.
+        """
+        cfg = {"tokenizer_cache_root": str(vocab_dir)}
+        text = "zzqqvv wwxxyy"
+
+        exact = count_tokens(text, "Qwen/Qwen3-VL-8B-Instruct", cfg)
+        fallback = count_tokens(text, "some-model-with-no-vocabulary", cfg)
+
+        assert exact == 2, "should be one [UNK] per whitespace-delimited word"
+        assert exact != fallback, (
+            "the exact count is indistinguishable from the tiktoken estimate, "
+            "so this test cannot prove which tokenizer ran"
+        )
+
+    def test_no_safety_margin_is_applied_when_the_count_is_exact(self, vocab_dir):
+        """The margin exists to cover a tokenizer we do not have. Once we have
+        it, inflating the count only causes premature routing."""
+        cfg = {"tokenizer_cache_root": str(vocab_dir)}
+        assert token_safety_margin("Qwen/Qwen3-VL-8B-Instruct", cfg) == 1.0
+
+    def test_the_margin_still_applies_without_a_local_vocabulary(self, vocab_dir):
+        """Hosted models keep the old behaviour, because the old problem
+        remains: their tokenizer is not available to us."""
+        cfg = {"tokenizer_cache_root": str(vocab_dir)}
+        assert token_safety_margin("claude-sonnet-4", cfg) == (
+            DEFAULT_TOKEN_SAFETY_MARGIN
+        )
+
+    def test_openai_models_still_use_tiktoken_exactly(self, vocab_dir):
+        cfg = {"tokenizer_cache_root": str(vocab_dir)}
+        assert token_safety_margin("gpt-4o", cfg) == 1.0
+
+    def test_empty_text_is_zero_either_way(self, vocab_dir):
+        cfg = {"tokenizer_cache_root": str(vocab_dir)}
+        assert count_tokens("", "Qwen/Qwen3-VL-8B-Instruct", cfg) == 0
+
+
+class TestRequestScaffoldAllowance:
+    """Exact text counting is not the same as an exact request.
+
+    The server wraps every request in a chat template and the agent framework
+    adds its own preamble around the instructions. Measured directly against
+    the model: the template is a flat 13 tokens, constant across a 5000x
+    payload range, and a full reconstructed request came in 277 tokens under
+    what the server charged.
+
+    None of that is in the text, so counting the text perfectly still leaves
+    the estimate short — in the unsafe direction. Dropping the safety margin
+    without replacing it with an explicit allowance would reintroduce a smaller
+    version of the very bug this replaces.
+    """
+
+    def test_estimate_exceeds_the_sum_of_its_parts(self, vocab_dir):
+        cfg = {"tokenizer_cache_root": str(vocab_dir)}
+        kwargs = dict(
+            model_name="Qwen/Qwen3-VL-8B-Instruct",
+            system_prompt="budget", user_message="total",
+            history=[], attachments=[], model_config=cfg,
+        )
+        parts = count_tokens("budget", "Qwen/Qwen3-VL-8B-Instruct", cfg) + \
+            count_tokens("total", "Qwen/Qwen3-VL-8B-Instruct", cfg)
+        est = estimate_input_tokens(documents=[], **kwargs)
+        assert est > parts, (
+            "the estimate must allow for the chat template and framework "
+            "preamble, which are sent but are not part of any counted string"
+        )
+
+    def test_the_allowance_covers_the_measured_shortfall(self, vocab_dir):
+        cfg = {"tokenizer_cache_root": str(vocab_dir)}
+        est = estimate_input_tokens(
+            model_name="Qwen/Qwen3-VL-8B-Instruct",
+            system_prompt="", user_message="", history=[],
+            documents=[], attachments=[], model_config=cfg,
+        )
+        assert est >= 277, (
+            "allowance is below the largest shortfall measured against a real "
+            "server response"
+        )
+
+    def test_the_allowance_is_not_extravagant(self, vocab_dir):
+        """It is a fixed cost, so on a small request it is most of the total.
+        Too generous and every short chat looks bigger than it is."""
+        cfg = {"tokenizer_cache_root": str(vocab_dir)}
+        est = estimate_input_tokens(
+            model_name="Qwen/Qwen3-VL-8B-Instruct",
+            system_prompt="", user_message="", history=[],
+            documents=[], attachments=[], model_config=cfg,
+        )
+        assert est <= 1024

--- a/backend/tests/test_exact_tokenizer.py
+++ b/backend/tests/test_exact_tokenizer.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -84,6 +85,43 @@ class TestResolvingTheVocabulary:
             {"tokenizer_cache_root": str(vocab_dir)},
         )
         assert tok is not None
+
+    def test_the_deployment_setting_is_used_when_no_model_config_says_otherwise(
+        self, vocab_dir
+    ):
+        """A deployment that mounts its cache somewhere else must be able to
+        say so once, rather than per model.
+
+        Without this the only lever is `tokenizer_cache_root` on every model,
+        and the hardcoded default is a path that exists on exactly one host.
+        """
+        from app.services import context_budget
+
+        context_budget._settings_tokenizer_cache_root.cache_clear()
+        with patch.object(
+            context_budget,
+            "_settings_tokenizer_cache_root",
+            return_value=str(vocab_dir),
+        ):
+            assert (
+                resolve_exact_tokenizer("Qwen/Qwen3-VL-8B-Instruct", {}) is not None
+            )
+
+    def test_the_model_config_still_beats_the_deployment_setting(self, vocab_dir):
+        """Per-model wins, so one misconfigured model can be corrected without
+        moving the whole deployment's cache."""
+        from app.services import context_budget
+
+        context_budget._settings_tokenizer_cache_root.cache_clear()
+        with patch.object(
+            context_budget,
+            "_settings_tokenizer_cache_root",
+            return_value=str(vocab_dir),
+        ):
+            assert resolve_exact_tokenizer(
+                "Qwen/Qwen3-VL-8B-Instruct",
+                {"tokenizer_cache_root": "/nowhere-at-all"},
+            ) is None
 
     def test_an_explicit_path_on_the_model_config_wins(self, tmp_path):
         path = _write_tokenizer(tmp_path / "custom")

--- a/backend/tests/test_model_routing.py
+++ b/backend/tests/test_model_routing.py
@@ -1,7 +1,7 @@
 """Choosing a bigger model when a document doesn't fit the current one.
 
 A complete grant proposal is one document, and people want to read it as one.
-Measured on a real 79-page NOAA proposal: 41,213 tokens against a 32,768-token
+Measured on a real 79-page grant proposal: 41,213 tokens against a 32,768-token
 model. It cannot fit — not with better settings, not with the context-budget
 share fixed. The model silently answered from 33 of 79 pages.
 
@@ -49,7 +49,7 @@ class TestWhenToSwitch:
         d = choose_document_model(
             current_name="small", current_config=SMALL,
             candidate_name="large", candidate_config=LARGE,
-            input_tokens=41213,          # the real NOAA proposal
+            input_tokens=41213,          # the real 79-page grant proposal
         )
         assert d.switched is True
         assert d.model_name == "large"

--- a/backend/tests/test_token_safety_margin.py
+++ b/backend/tests/test_token_safety_margin.py
@@ -45,10 +45,17 @@ from app.services.context_budget import (
 # The estimate is under in all 97. It is never once equal or over.
 #
 # The ratio is not monotonic in request size — 1.042 at 307 tokens, 1.173 at
-# 2.2k, 1.076 at 47k — because the fixed per-message chat-template overhead
-# that `count_message_tokens` only approximates dominates small requests and
-# amortizes away on large ones. So a margin cannot be derived from the biggest
-# sample alone; it has to cover the worst, which sits in the middle.
+# 2.2k, 1.076 at 47k. Later measurement against the models directly showed why,
+# and it is not size: the divergence is driven by *content*. cl100k and the
+# Qwen vocabulary agree exactly on flowing prose (1.000) and diverge sharply on
+# numbers and tables (1.171 on a real budget justification, 1.455 on a
+# synthetic currency table). The rows below vary because the documents behind
+# them vary, not because the requests were bigger or smaller.
+#
+# That is why these observations pin down the *direction* of the error and not
+# a safe constant: no constant is safe across that range, which is what
+# motivated exact tokenization (see test_exact_tokenizer.py). These rows now
+# guard the fallback path used for models whose vocabulary we do not have.
 OBSERVED_UNDERCOUNTS: list[tuple[str, int, int]] = [
     ("Qwen/Qwen3-VL-30B-A3B-Instruct", 2154, 2527),   # 1.1732 — worst observed
     ("Qwen/Qwen3-VL-8B-Instruct", 2154, 2527),        # 1.1732
@@ -217,8 +224,14 @@ class TestMarginReachesTheCallers:
             model_name="Qwen/Qwen3-VL-8B-Instruct", **kwargs
         )
         assert qwen_est > openai_est
-        # Uniform across components, so the whole-request ratio tracks the margin.
-        assert qwen_est >= int(openai_est * DEFAULT_TOKEN_SAFETY_MARGIN * 0.98)
+        # The margin scales counted text; the scaffold allowance is a flat
+        # addition on top and is identical for both, so it has to come off
+        # before the ratio means anything.
+        from app.services.context_budget import REQUEST_SCAFFOLD_TOKENS
+
+        qwen_text = qwen_est - REQUEST_SCAFFOLD_TOKENS
+        openai_text = openai_est - REQUEST_SCAFFOLD_TOKENS
+        assert qwen_text >= int(openai_text * DEFAULT_TOKEN_SAFETY_MARGIN * 0.98)
 
     def test_per_model_config_reaches_estimate_input_tokens(self):
         kwargs = dict(

--- a/backend/tests/test_token_safety_margin.py
+++ b/backend/tests/test_token_safety_margin.py
@@ -37,7 +37,7 @@ from app.services.context_budget import (
 
 # (model, planner's pre-fix estimate, prompt_tokens the model reported)
 #
-# Harvested from 97 harness runs in ~/vandalizer-workflow/evidence — every run
+# Harvested from 97 end-to-end runs against live model servers — every run
 # that produced BOTH a `context_budget` chunk (the planner's belief) and a
 # `usage` chunk (what the server actually charged), deduplicated to 26 distinct
 # observations. Three models, request sizes spanning 307 to 46,916 tokens.

--- a/backend/tests/test_token_safety_margin.py
+++ b/backend/tests/test_token_safety_margin.py
@@ -418,3 +418,45 @@ class TestPreflightOversizeCheck:
             model_config=self.CONFIG,
         )
         assert found == []
+
+
+class TestLoudFallback:
+    """A model that silently drops to a guessed margin is the alias bug.
+
+    Verified before this existed: 'Qwen/Qwen3-VL-30B-A3B-Instruct ' (one
+    trailing space) resolved no vocabulary and fell to 1.2 with no signal
+    anywhere. The guess is acceptable; the silence is not.
+    """
+
+    def setup_method(self):
+        from app.services import context_budget
+
+        context_budget._ESTIMATED_MODELS_WARNED.clear()
+
+    def test_warns_when_falling_back_to_a_guessed_margin(self, caplog):
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            token_safety_margin("some-unknown-model")
+
+        assert any(
+            "some-unknown-model" in r.getMessage() for r in caplog.records
+        ), "falling back to a guessed margin must be visible"
+
+    def test_warns_only_once_per_model(self, caplog):
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            for _ in range(5):
+                token_safety_margin("some-unknown-model")
+
+        hits = [r for r in caplog.records if "estimated" in r.getMessage()]
+        assert len(hits) == 1, "per-request logging would be noise at chat volume"
+
+    def test_does_not_warn_for_models_counted_exactly(self, caplog):
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            token_safety_margin("gpt-4o")
+
+        assert not [r for r in caplog.records if "estimated" in r.getMessage()]

--- a/backend/tests/test_token_safety_margin.py
+++ b/backend/tests/test_token_safety_margin.py
@@ -1,0 +1,407 @@
+"""The budget estimate must never come in under what the model actually charges.
+
+tiktoken is OpenAI's tokenizer. `_encoding_for()` handed `cl100k_base` to every
+model whose name did not look like GPT-4o/4.1/o-series, which on this deployment
+is 100% of them — Qwen has its own ~151k-vocab BPE. The estimate was therefore
+measured with the wrong ruler, and always in the unsafe direction: the planner
+believed there was room when there was not, so a 36-page proposal was passed to
+a model that rejected it, and `choose_document_model()` — comparing the same
+optimistic number against the same budget — saw headroom and declined to route.
+The one feature built to handle oversized documents was disabled by the
+arithmetic error it was supposed to react to.
+
+These tests assert the *direction* of the error, not a magic constant. Ground
+truth is the model's own `prompt_tokens`, which every successful response
+carries in its `usage` chunk and which costs nothing to collect.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from app.services.context_budget import (
+    DEFAULT_TOKEN_SAFETY_MARGIN,
+    DocumentSegment,
+    count_raw_tokens,
+    count_tokens,
+    estimate_input_tokens,
+    find_oversize_documents,
+    plan_and_compact_context,
+    token_safety_margin,
+)
+
+
+# ---------------------------------------------------------------------------
+# Ground truth
+# ---------------------------------------------------------------------------
+
+# (model, planner's pre-fix estimate, prompt_tokens the model reported)
+#
+# Harvested from 97 harness runs in ~/vandalizer-workflow/evidence — every run
+# that produced BOTH a `context_budget` chunk (the planner's belief) and a
+# `usage` chunk (what the server actually charged), deduplicated to 26 distinct
+# observations. Three models, request sizes spanning 307 to 46,916 tokens.
+#
+# The estimate is under in all 97. It is never once equal or over.
+#
+# The ratio is not monotonic in request size — 1.042 at 307 tokens, 1.173 at
+# 2.2k, 1.076 at 47k — because the fixed per-message chat-template overhead
+# that `count_message_tokens` only approximates dominates small requests and
+# amortizes away on large ones. So a margin cannot be derived from the biggest
+# sample alone; it has to cover the worst, which sits in the middle.
+OBSERVED_UNDERCOUNTS: list[tuple[str, int, int]] = [
+    ("Qwen/Qwen3-VL-30B-A3B-Instruct", 2154, 2527),   # 1.1732 — worst observed
+    ("Qwen/Qwen3-VL-8B-Instruct", 2154, 2527),        # 1.1732
+    ("Qwen/Qwen3-VL-30B-A3B-Instruct", 2282, 2661),   # 1.1661
+    ("Qwen/Qwen3-VL-8B-Instruct", 2282, 2661),        # 1.1661
+    ("Qwen/Qwen3-VL-8B-Instruct", 2284, 2663),        # 1.1659
+    ("Qwen/Qwen3-VL-30B-A3B-Instruct", 2284, 2663),   # 1.1659
+    ("Qwen/Qwen3-VL-8B-Instruct", 2287, 2666),        # 1.1657
+    ("Qwen/Qwen3-VL-30B-A3B-Instruct", 2287, 2666),   # 1.1657
+    ("Qwen/Qwen3-VL-8B-Instruct", 2288, 2667),        # 1.1656
+    ("Qwen/Qwen3-VL-30B-A3B-Instruct", 2288, 2667),   # 1.1656
+    ("Qwen/Qwen3-VL-8B-Instruct", 2292, 2671),        # 1.1654
+    ("Qwen/Qwen3-VL-30B-A3B-Instruct", 2292, 2671),   # 1.1654
+    ("Qwen/Qwen3-VL-8B-Instruct", 2294, 2673),        # 1.1652
+    ("Qwen/Qwen3-VL-30B-A3B-Instruct", 2294, 2673),   # 1.1652
+    ("Qwen/Qwen3-VL-8B-Instruct", 2297, 2676),        # 1.1650
+    ("Qwen/Qwen3-VL-30B-A3B-Instruct", 2297, 2676),   # 1.1650
+    ("Qwen/Qwen3-VL-8B-Instruct", 2298, 2677),        # 1.1649
+    ("Qwen/Qwen3-VL-30B-A3B-Instruct", 2298, 2677),   # 1.1649
+    ("Qwen/Qwen3-VL-30B-A3B-Instruct", 2694, 3078),   # 1.1425
+    ("Qwen/Qwen3-VL-8B-Instruct", 2694, 3078),        # 1.1425
+    ("Qwen/Qwen3-VL-8B-Instruct", 2721, 3105),        # 1.1411
+    ("Qwen/Qwen3-VL-30B-A3B-Instruct", 2721, 3105),   # 1.1411
+    ("Qwen/Qwen3.5-9B", 46914, 50492),                # 1.0763 — largest request
+    ("Qwen/Qwen3.5-9B", 46916, 50494),                # 1.0763
+    ("Qwen/Qwen3-VL-8B-Instruct", 307, 320),          # 1.0423 — smallest request
+    ("Qwen/Qwen3-VL-30B-A3B-Instruct", 307, 320),     # 1.0423
+]
+
+
+def _corrected(model: str, raw_estimate: int) -> int:
+    """What the planner now believes, given what it used to believe.
+
+    The margin is applied uniformly across every component, so scaling a
+    recorded whole-request total reproduces the corrected total without needing
+    to reconstruct the original request text.
+    """
+    return int(raw_estimate * token_safety_margin(model) + 0.999)
+
+
+class TestAgainstRecordedGroundTruth:
+    """The property that matters: never guess low. Direction, not magnitude."""
+
+    def test_the_bug_is_real_in_every_recorded_run(self):
+        """Guards the premise. If this ever fails, the fixture is stale."""
+        for model, raw_estimate, actual in OBSERVED_UNDERCOUNTS:
+            assert raw_estimate < actual, (
+                f"{model}: recorded estimate {raw_estimate} was not under "
+                f"{actual}; the observation set no longer shows the bug"
+            )
+
+    def test_corrected_estimate_never_undercounts_the_model(self):
+        """The regression. Asserts direction against real `prompt_tokens`."""
+        for model, raw_estimate, actual in OBSERVED_UNDERCOUNTS:
+            corrected = _corrected(model, raw_estimate)
+            assert corrected >= actual, (
+                f"{model}: corrected estimate {corrected} is still under the "
+                f"{actual} tokens the model reported — the planner would again "
+                f"believe a request fits when it does not"
+            )
+
+    def test_margin_is_not_wastefully_larger_than_the_evidence(self):
+        """Conservative is safe; absurdly conservative routes far too early.
+
+        Being optimistic costs a hard failure, so the margin is deliberately
+        above the worst observation (1.1732). But a margin of, say, 3x would
+        push every ordinary document onto a bigger model for nothing. Two
+        sanity bounds so a future edit cannot drift in either direction
+        unnoticed.
+        """
+        margin = token_safety_margin("Qwen/Qwen3-VL-8B-Instruct")
+        assert margin > 1.1732, "margin does not cover the worst observation"
+        assert margin <= 1.5, "margin is far beyond anything measured"
+
+    def test_headroom_over_the_worst_observation_is_real_but_modest(self):
+        worst_model, worst_raw, worst_actual = OBSERVED_UNDERCOUNTS[0]
+        corrected = _corrected(worst_model, worst_raw)
+        # Covers it, and does not overshoot by more than a quarter again.
+        assert worst_actual <= corrected <= int(worst_actual * 1.25)
+
+
+class TestMarginSelection:
+    def test_non_openai_models_get_the_default_margin(self):
+        for name in (
+            "Qwen/Qwen3-VL-8B-Instruct",
+            "Qwen/Qwen3.5-9B",
+            "meta-llama/Llama-3.1-70B",
+            "mistral-large",
+            "claude-sonnet-4",
+        ):
+            assert token_safety_margin(name) == DEFAULT_TOKEN_SAFETY_MARGIN
+
+    def test_models_tiktoken_actually_measures_are_not_inflated(self):
+        """cl100k/o200k *are* these models' real tokenizers, so the count is
+        exact and a margin would only cause premature routing."""
+        for name in ("gpt-4o", "gpt-4o-mini", "gpt-4.1", "o1", "o3-mini", "o4"):
+            assert token_safety_margin(name) == 1.0
+
+    def test_unknown_or_empty_model_is_treated_as_non_openai(self):
+        """Failing safe: an unrecognised name is far more likely to be a
+        self-hosted model than an OpenAI one."""
+        assert token_safety_margin("") == DEFAULT_TOKEN_SAFETY_MARGIN
+        assert token_safety_margin("some-new-model") == DEFAULT_TOKEN_SAFETY_MARGIN
+
+    def test_deployment_can_tune_the_margin_per_model(self):
+        """A deployment that has measured its own models should be able to say
+        so rather than living with a global guess."""
+        cfg = {"token_safety_margin": 1.35}
+        assert token_safety_margin("Qwen/Qwen3.5-9B", cfg) == 1.35
+
+    def test_per_model_override_applies_to_openai_models_too(self):
+        assert token_safety_margin("gpt-4o", {"token_safety_margin": 1.1}) == 1.1
+
+    def test_a_margin_below_one_is_rejected(self):
+        """Below 1.0 re-creates the bug by configuration. The planner would
+        again believe there is room when there is not."""
+        for bad in (0.5, 0, -1):
+            assert token_safety_margin(
+                "Qwen/Qwen3.5-9B", {"token_safety_margin": bad}
+            ) == DEFAULT_TOKEN_SAFETY_MARGIN
+
+    def test_a_garbage_margin_falls_back_to_the_default(self):
+        for bad in ("", None, "abc", [], {}):
+            assert token_safety_margin(
+                "Qwen/Qwen3.5-9B", {"token_safety_margin": bad}
+            ) == DEFAULT_TOKEN_SAFETY_MARGIN
+
+
+# ---------------------------------------------------------------------------
+# The margin has to actually reach the numbers the planner uses
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakePart:
+    content: str
+
+
+@dataclass
+class _FakeMessage:
+    parts: list = field(default_factory=list)
+
+
+def _msg(text: str) -> _FakeMessage:
+    return _FakeMessage(parts=[_FakePart(content=text)])
+
+
+class TestMarginReachesTheCallers:
+    def test_count_tokens_inflates_for_a_self_hosted_model(self):
+        text = "The proposed work addresses coastal resilience. " * 200
+        openai_count = count_tokens(text, "gpt-4o")
+        qwen_count = count_tokens(text, "Qwen/Qwen3-VL-8B-Instruct")
+        assert qwen_count > openai_count
+
+    def test_estimate_input_tokens_inflates_end_to_end(self):
+        """The planner's own entry point, not just the helper underneath it."""
+        kwargs = dict(
+            system_prompt="You are a research assistant.",
+            user_message="Summarise the budget justification.",
+            history=[_msg("earlier question"), _msg("earlier answer")],
+            documents=[DocumentSegment(label="doc:a", text="Body text. " * 500)],
+            attachments=[],
+        )
+        openai_est = estimate_input_tokens(model_name="gpt-4o", **kwargs)
+        qwen_est = estimate_input_tokens(
+            model_name="Qwen/Qwen3-VL-8B-Instruct", **kwargs
+        )
+        assert qwen_est > openai_est
+        # Uniform across components, so the whole-request ratio tracks the margin.
+        assert qwen_est >= int(openai_est * DEFAULT_TOKEN_SAFETY_MARGIN * 0.98)
+
+    def test_per_model_config_reaches_estimate_input_tokens(self):
+        kwargs = dict(
+            system_prompt="",
+            user_message="hello",
+            history=[],
+            documents=[DocumentSegment(label="doc:a", text="Body text. " * 500)],
+            attachments=[],
+        )
+        default_est = estimate_input_tokens(
+            model_name="Qwen/Qwen3.5-9B", **kwargs
+        )
+        tuned_est = estimate_input_tokens(
+            model_name="Qwen/Qwen3.5-9B",
+            model_config={"token_safety_margin": 1.45},
+            **kwargs,
+        )
+        assert tuned_est > default_est
+
+    def test_empty_text_stays_zero_regardless_of_margin(self):
+        assert count_tokens("", "Qwen/Qwen3.5-9B") == 0
+
+
+class TestStillDeclinesWhenNothingFits:
+    """Erring high must not turn a graceful decline into a crash.
+
+    Routing rescues the request that fits *some* model. A document too large
+    for every configured model has no rescue, and the planner's job there is to
+    say so in a way the caller can turn into advice — not to raise, and not to
+    silently ship a truncated document.
+    """
+
+    def test_a_giant_document_is_trimmed_and_says_so(self):
+        """Not fatal — trimmable content gets trimmed. What matters is that the
+        trim is *reported*, because the silent version of this is the bug."""
+        result = plan_and_compact_context(
+            model_name="Qwen/Qwen3-VL-8B-Instruct",
+            model_config={"context_window": 32_768},
+            system_prompt="You are a research assistant.",
+            user_message="Summarise this.",
+            history=[],
+            documents=[
+                DocumentSegment(label="doc:giant", text="budget narrative " * 40_000)
+            ],
+            attachments=[],
+        )
+        assert not result.fatal
+        assert result.plan.total_input_tokens <= result.plan.input_budget
+        assert [a.kind for a in result.actions] == ["documents_trimmed"]
+        assert result.actions[0].tokens_dropped > 0
+
+    def test_an_untrimmable_request_declines_with_an_explanation(self):
+        """The genuinely-impossible case: the non-compactable floor alone
+        exceeds the budget, so there is nothing left to give. It must return a
+        reasoned refusal the caller can show, not raise."""
+        result = plan_and_compact_context(
+            model_name="Qwen/Qwen3-VL-8B-Instruct",
+            model_config={"context_window": 2_048},
+            system_prompt="You are a research assistant. " * 200,
+            user_message="Summarise this. " * 200,
+            history=[],
+            documents=[DocumentSegment(label="doc:a", text="body " * 5_000)],
+            attachments=[],
+        )
+        assert result.fatal
+        assert [a.kind for a in result.actions] == ["over_budget"]
+        detail = result.actions[0].detail
+        assert "larger model" in detail, "the decline should say what to do next"
+
+    def test_the_margin_did_not_break_convergence(self):
+        """The last-ditch loop is capped at 50 rounds. Truncation slices by raw
+        token offsets while the budget is margin-inflated, so a botched
+        conversion between the two would show up as a request that never gets
+        under budget within the cap."""
+        result = plan_and_compact_context(
+            model_name="Qwen/Qwen3-VL-8B-Instruct",
+            model_config={"context_window": 32_768},
+            system_prompt="You are a research assistant.",
+            user_message="Summarise this.",
+            history=[],
+            documents=[
+                DocumentSegment(label="doc:a", text="coastal resilience " * 8_000),
+                DocumentSegment(label="doc:b", text="award narrative " * 8_000),
+            ],
+            attachments=[],
+        )
+        # Compactable content, so this one should actually come in under budget.
+        assert not result.fatal
+        assert result.plan.total_input_tokens <= result.plan.input_budget
+
+    def test_a_fitting_request_is_still_left_alone(self):
+        """The margin must not make the planner start trimming ordinary
+        requests that have plenty of room."""
+        result = plan_and_compact_context(
+            model_name="Qwen/Qwen3-VL-8B-Instruct",
+            model_config={"context_window": 32_768},
+            system_prompt="You are a research assistant.",
+            user_message="What is the total requested?",
+            history=[],
+            documents=[DocumentSegment(label="doc:a", text="short body. " * 100)],
+            attachments=[],
+        )
+        assert not result.fatal
+        assert result.actions == []
+
+
+class TestStoredCountsStayRaw:
+    """`token_count` is written once and read against many models.
+
+    The margin is a property of the model doing the reading, so it is applied
+    at comparison time, not frozen into the stored value.
+    """
+
+    def test_count_raw_tokens_carries_no_margin(self):
+        """Same model, same encoding — the only variable is the margin."""
+        text = "Coastal resilience planning. " * 300
+        assert count_raw_tokens(text, "Qwen/Qwen3.5-9B") == count_tokens(
+            text, "Qwen/Qwen3.5-9B", {"token_safety_margin": 1.0}
+        )
+
+    def test_raw_count_is_below_the_budgeting_count(self):
+        text = "Coastal resilience planning. " * 300
+        assert count_raw_tokens(text, "Qwen/Qwen3.5-9B") < count_tokens(
+            text, "Qwen/Qwen3.5-9B"
+        )
+
+
+class TestPreflightOversizeCheck:
+    """`find_oversize_documents` under-warned by the same margin the planner did.
+
+    The brief listed this consumer as read-but-not-tested. A workflow that will
+    fail should be flagged before it runs, and a document sitting in the band
+    between the raw count and the true one was not being flagged.
+    """
+
+    # 32k window, reserve 8192, overhead 1024 -> budget 23,360.
+    MODEL = "Qwen/Qwen3-VL-8B-Instruct"
+    CONFIG = {"context_window": 32_768}
+
+    def _docs(self, token_count: int) -> list[dict]:
+        return [{"uuid": "u1", "title": "Proposal.pdf", "token_count": token_count}]
+
+    def test_document_in_the_undercount_band_is_now_flagged(self):
+        """22,000 raw looks like it fits; at 1.20 it is really ~26,400 and does
+        not. This is precisely the case that used to run and then fail."""
+        found = find_oversize_documents(
+            documents=self._docs(22_000),
+            model_name=self.MODEL,
+            model_config=self.CONFIG,
+        )
+        assert [o.uuid for o in found] == ["u1"]
+
+    def test_a_genuinely_small_document_is_still_not_flagged(self):
+        """The margin must not drag ordinary documents into the warning."""
+        found = find_oversize_documents(
+            documents=self._docs(5_000),
+            model_name=self.MODEL,
+            model_config=self.CONFIG,
+        )
+        assert found == []
+
+    def test_reported_count_reflects_what_the_model_will_charge(self):
+        """The number shown to the user is the corrected one, so the warning
+        and the failure it predicts agree."""
+        found = find_oversize_documents(
+            documents=self._docs(22_000),
+            model_name=self.MODEL,
+            model_config=self.CONFIG,
+        )
+        assert found[0].token_count > 22_000
+
+    def test_openai_models_see_the_stored_count_unchanged(self):
+        found = find_oversize_documents(
+            documents=self._docs(22_000),
+            model_name="gpt-4o",
+            model_config=self.CONFIG,
+        )
+        assert found == []
+
+    def test_missing_token_count_is_not_inflated_into_a_warning(self):
+        found = find_oversize_documents(
+            documents=[{"uuid": "u1", "title": "x", "token_count": None}],
+            model_name=self.MODEL,
+            model_config=self.CONFIG,
+        )
+        assert found == []

--- a/backend/tests/test_workflow_tasks.py
+++ b/backend/tests/test_workflow_tasks.py
@@ -1334,7 +1334,12 @@ class TestPreflightContextOverflow:
         return _mock_db(
             workflow_doc=_make_workflow_doc(wf_id=wf_id, step_ids=[step_id]),
             result_doc=_make_result_doc(result_id=result_id, workflow_id=wf_id),
-            sys_config={"available_models": [{"name": "qwen3", "context_window": 65_536}]},
+            # Margin pinned to 1.0 so this fixture measures the pre-flight
+            # wiring rather than the stored-count divergence allowance, which
+            # is covered directly in test_context_budget.py.
+            sys_config={"available_models": [
+                {"name": "qwen3", "context_window": 65_536, "token_safety_margin": 1.0},
+            ]},
             step_docs=[{"_id": step_id, "name": "Assess", "data": {}, "tasks": [task_id]}],
             task_docs=[{"_id": task_id, "name": "Prompt", "data": {"prompt": "assess"}}],
             smart_docs=[

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1638,10 +1638,10 @@ resolution-markers = [
     "python_full_version < '3.12' and sys_platform == 'win32'",
 ]
 dependencies = [
-    { name = "click", marker = "sys_platform == 'win32'" },
-    { name = "numpy", marker = "sys_platform == 'win32'" },
-    { name = "onnxruntime", marker = "sys_platform == 'win32'" },
-    { name = "python-dotenv", marker = "sys_platform == 'win32'" },
+    { name = "click" },
+    { name = "numpy" },
+    { name = "onnxruntime" },
+    { name = "python-dotenv" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fe/b6/8fdd991142ad3e037179a494b153f463024e5a211ef3ad948b955c26b4de/magika-0.6.2.tar.gz", hash = "sha256:37eb6ae8020f6e68f231bc06052c0a0cbe8e6fa27492db345e8dc867dbceb067", size = 3036634, upload-time = "2025-05-02T14:54:18.88Z" }
 wheels = [
@@ -1658,10 +1658,10 @@ resolution-markers = [
     "python_full_version < '3.12' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "click", marker = "sys_platform != 'win32'" },
-    { name = "numpy", marker = "sys_platform != 'win32'" },
-    { name = "onnxruntime", marker = "sys_platform != 'win32'" },
-    { name = "python-dotenv", marker = "sys_platform != 'win32'" },
+    { name = "click" },
+    { name = "numpy" },
+    { name = "onnxruntime" },
+    { name = "python-dotenv" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a3/f3/3d1dcdd7b9c41d589f5cff252d32ed91cdf86ba84391cfc81d9d8773571d/magika-0.6.3.tar.gz", hash = "sha256:7cc52aa7359af861957043e2bf7265ed4741067251c104532765cd668c0c0cb1", size = 3042784, upload-time = "2025-10-30T15:22:34.499Z" }
 wheels = [
@@ -3660,6 +3660,7 @@ dependencies = [
     { name = "sentry-sdk", extra = ["celery", "fastapi"] },
     { name = "slowapi" },
     { name = "tiktoken" },
+    { name = "tokenizers" },
     { name = "trafilatura" },
     { name = "uvicorn", extra = ["standard"] },
     { name = "werkzeug" },
@@ -3726,6 +3727,7 @@ requires-dist = [
     { name = "sentry-sdk", extras = ["fastapi", "celery"], specifier = ">=2.0,<3" },
     { name = "slowapi", specifier = ">=0.1,<1" },
     { name = "tiktoken", specifier = ">=0.9,<1" },
+    { name = "tokenizers", specifier = ">=0.20,<1" },
     { name = "trafilatura", specifier = ">=1.12,<3" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.34,<1" },
     { name = "werkzeug", specifier = ">=3.1,<4" },

--- a/compose.yaml
+++ b/compose.yaml
@@ -81,9 +81,11 @@ services:
       - vandalizer
     volumes:
       - uploads:/app/static/uploads
-      # Model vocabularies, read-only. Token counting needs the vocab
-      # files vLLM already caches here — not the weights, and not the GPU.
-      - /data/hf-cache:/hf-cache:ro
+      # Model vocabularies, read-only. Token counting reads tokenizer.json —
+      # not the weights, and not the GPU. Point HF_CACHE_PATH at your HF_HOME
+      # if you self-host models; leaving it unset is fine, and the budget
+      # falls back to estimating (and logs that it did).
+      - ${HF_CACHE_PATH:-./hf-cache}:/hf-cache:ro
     ulimits:
       nofile:
         soft: 65536
@@ -120,9 +122,11 @@ services:
       - vandalizer
     volumes:
       - uploads:/app/static/uploads
-      # Model vocabularies, read-only. Token counting needs the vocab
-      # files vLLM already caches here — not the weights, and not the GPU.
-      - /data/hf-cache:/hf-cache:ro
+      # Model vocabularies, read-only. Token counting reads tokenizer.json —
+      # not the weights, and not the GPU. Point HF_CACHE_PATH at your HF_HOME
+      # if you self-host models; leaving it unset is fine, and the budget
+      # falls back to estimating (and logs that it did).
+      - ${HF_CACHE_PATH:-./hf-cache}:/hf-cache:ro
     ulimits:
       nofile:
         soft: 65536

--- a/compose.yaml
+++ b/compose.yaml
@@ -81,6 +81,9 @@ services:
       - vandalizer
     volumes:
       - uploads:/app/static/uploads
+      # Model vocabularies, read-only. Token counting needs the vocab
+      # files vLLM already caches here — not the weights, and not the GPU.
+      - /data/hf-cache:/hf-cache:ro
     ulimits:
       nofile:
         soft: 65536
@@ -117,6 +120,9 @@ services:
       - vandalizer
     volumes:
       - uploads:/app/static/uploads
+      # Model vocabularies, read-only. Token counting needs the vocab
+      # files vLLM already caches here — not the weights, and not the GPU.
+      - /data/hf-cache:/hf-cache:ro
     ulimits:
       nofile:
         soft: 65536

--- a/docs/long-document-model-routing.md
+++ b/docs/long-document-model-routing.md
@@ -6,7 +6,7 @@ Document chat puts whole documents in the prompt. When they don't fit,
 `plan_and_compact_context` trims the middle out and the model answers from
 what's left — correctly, confidently, and from part of the document.
 
-Measured on a real 79-page NOAA grant proposal:
+Measured on a real 79-page grant proposal:
 
 ```
 annotated size : 41,213 tokens


### PR DESCRIPTION
Splits the exact-tokenizer half out of #629, which asks for agreement before building per-model calibration. Nothing here needs that agreement: no new service, no admin endpoint, no UI. The calibration design question stays open on #629.

## The bug

`_encoding_for()` returns tiktoken's `cl100k_base` for every model that is not GPT-4o/4.1/o-series. That is OpenAI's tokenizer, used as a proxy for Claude, Llama, Mistral and every self-hosted model. On this deployment it covers 100% of configured models.

It reads **low**, which is the direction that hard-fails.

## Why it matters more since #632

Routing compares that same estimate against the budget. An under-count means it sees headroom that isn't there, so it declines to route — and the request is then neither compacted nor routed, and the model rejects it outright:

```
plan:  input_budget 24,576   total_input_tokens 23,592   -> "fits, 984 spare"
then:  {"kind":"error","content":"This conversation is too large for the
        selected model. Remove some documents or switch to a larger model."}
```

A 36-page proposal produced no answer while a 262k model sat configured and unused. The feature built to prevent that was disabled by the arithmetic feeding it.

## The divergence is content-dependent, not model-dependent

This is the part that rules out simply picking a better constant. Measured against the models' own reported `prompt_tokens`:

| Content | model / tiktoken |
|---|---|
| flowing prose | 1.000 |
| project description | 1.019 |
| real budget justification | 1.171 |
| synthetic dense currency table | 1.455 |

A self-hosted Qwen tokenizes digits individually where `cl100k_base` groups them, so prose comes out identical while a dense budget table runs ~45% higher. Research-administration documents sit at the digit-dense end, so the error lands hardest on this product's core content.

No single constant works: one tuned for tables wastes a third of the window on prose, one tuned for prose hard-fails budget documents.

## What this does

**Counts exactly where it can.** When a `tokenizer.json` is on disk, tokens are counted with the model's own vocabulary and **no margin is applied at all** — there is nothing left to guess. Vocabulary only: never the weights, never the GPU. Roughly 1.5 ms for a 36-page proposal against 0.3 ms for the tiktoken call it replaces, and the loaded tokenizer is cached.

Discovery uses the standard HuggingFace cache layout and takes the newest snapshot, so a re-pulled model is picked up without config changes. Overridable per model (`tokenizer_path`, `tokenizer_cache_root`) and per deployment (`TOKENIZER_CACHE_ROOT`).

**Falls back honestly where it cannot.** Hosted models have no local vocabulary, so they keep estimate-plus-margin, with `DEFAULT_TOKEN_SAFETY_MARGIN = 1.20`, a per-model `token_safety_margin` override, and a configured value below 1.0 refused — that would re-create this bug by configuration.

The fallback now says so, once per process:

> token counts for 'Qwen-30b' are estimated, not exact: no local vocabulary and no stored calibration. Budgets use a default margin of 1.20, which is known to under-count numeric and tabular content.

That warning exists for the alias case: a model registered as `Qwen-30b` rather than its full name resolves no vocabulary and silently drops to the guess. The guess is a reasonable last resort; not saying so is not.

**Makes request scaffolding explicit.** `REQUEST_SCAFFOLD_TOKENS = 512` covers the chat template and agent preamble, which appear in no string we count. Measured at a flat 13 tokens against a bare server and 37 end-to-end, identical on a 25,000-token request and a 50,000-token one — a fixed cost, not a multiplier. 512 is deliberately far above that: 2% of a 32k budget, cheap insurance against a framework version adding more. This is what the old margin was incidentally covering, and making it explicit is what lets the margin drop to nothing for models we can tokenize.

**Corrects the workflow pre-flight.** `find_oversize_documents` reads stored `token_count` values that are raw tiktoken figures, so the margin is applied at read time rather than trusted from storage. That also corrects documents ingested before any of this existed, with no backfill.

## Known limitation, stated plainly

**The 1.20 default is a guess and is known to be insufficient for the worst case** — the currency table above measured 1.455. It governs only models where exactness is unavailable, for which no measurements exist on this deployment. A deployment that has measured its own should set `token_safety_margin` per model.

Replacing that guess with a measurement is exactly what #629 proposes, and why that issue should stay open.

## Test plan

- [x] `3481 passed, 165 skipped`
- [x] `ruff check app/` clean
- [x] New: `test_exact_tokenizer.py`, `test_token_safety_margin.py`, plus cases in `test_context_budget.py`
- [x] `tokenizers` declared explicitly rather than relied on transitively

One existing test needed adjusting: `test_find_oversize_documents_honors_reserve_override` asserted a 100,000-token document fits a ~119,000-token budget. With the margin applied that is no longer true — correctly, since 100k raw is ~120k real. The margin is pinned to 1.0 there so the test measures the reserve and nothing else; the interaction is covered directly in `test_token_safety_margin.py`.

Refs #629