### PR TITLE
fix(workflows): download batch outputs (per document + zip all)

### DIFF
--- a/backend/app/routers/workflows.py
+++ b/backend/app/routers/workflows.py
@@ -306,6 +306,44 @@ def _zip_member_for_step(step_name: str, value):
     return f"{safe_name}.txt", str(value).encode()
 
 
+def _safe_zip_member(name: str) -> str:
+    """Reduce a caller-supplied filename to a single safe archive member name.
+
+    ``filename`` on a DataExport/DocumentRenderer/PackageBuilder step is free
+    text from the workflow's own configuration and reaches us unsanitised, so a
+    step named ``../../evil`` would be written into the ZIP verbatim. Archive
+    tools that do not normalise member paths then extract it outside the target
+    directory. Keep the last path component only, and refuse the traversal
+    spellings outright.
+    """
+    cleaned = name.replace("\\", "/").split("/")[-1].strip()
+    cleaned = "".join(c if c.isalnum() or c in " _-." else "_" for c in cleaned)
+    cleaned = cleaned.lstrip(".") or "output"
+    return cleaned
+
+
+def _unique_member(member: str, seen: dict[str, int]) -> str:
+    """A member name not yet used in this archive.
+
+    The counter has to record the *resolved* name, not just the original:
+    otherwise ``report.pdf`` colliding once yields ``report_1.pdf``, and a later
+    run legitimately named ``report_1.pdf`` is not in ``seen`` and is written
+    under the same name — zipfile emits a duplicate-name warning and one entry
+    silently wins on extraction.
+    """
+    if member not in seen:
+        seen[member] = 0
+        return member
+    stem, _, m_ext = member.rpartition(".")
+    while True:
+        seen[member] += 1
+        n = seen[member]
+        candidate = f"{stem}_{n}.{m_ext}" if m_ext else f"{member}_{n}"
+        if candidate not in seen:
+            seen[candidate] = 0
+            return candidate
+
+
 def _session_base_filename(status: dict, session_id: str) -> str:
     """Build a filesystem-safe base name (no extension) unique per session.
 
@@ -511,15 +549,16 @@ async def download_batch_results(
             if not status:
                 continue
             content, _media_type, ext, explicit_name = _render_workflow_output(status, format, parse_structured)
-            member = explicit_name or f"{_session_base_filename(status, sid)}.{ext}"
-            # Disambiguate collisions so no member silently overwrites another.
-            if member in seen:
-                seen[member] += 1
-                stem, _, m_ext = member.rpartition(".")
-                member = f"{stem}_{seen[member]}.{m_ext}" if m_ext else f"{member}_{seen[member]}"
+            base = _session_base_filename(status, sid)
+            if explicit_name:
+                # A step-supplied filename is static config, identical for every
+                # run in the batch, so on its own it says nothing about which
+                # document produced it. Prefix the per-run base so the bundle
+                # stays readable.
+                member = f"{base}-{_safe_zip_member(explicit_name)}"
             else:
-                seen[member] = 0
-            zf.writestr(member, content)
+                member = f"{base}.{ext}"
+            zf.writestr(_unique_member(member, seen), content)
     zip_buf.seek(0)
 
     zip_name = "".join(c if c.isalnum() or c in " _-." else "_" for c in f"batch-{batch_id}").strip()

--- a/backend/app/routers/workflows.py
+++ b/backend/app/routers/workflows.py
@@ -306,48 +306,39 @@ def _zip_member_for_step(step_name: str, value):
     return f"{safe_name}.txt", str(value).encode()
 
 
-@router.get("/download")
-async def download_results(
-    session_id: str,
-    format: str = "json",
-    parse_structured: bool = False,
-    user: User = Depends(get_current_user),
-):
-    """Download workflow results in specified format.
+def _session_base_filename(status: dict, session_id: str) -> str:
+    """Build a filesystem-safe base name (no extension) unique per session.
 
-    If the workflow has multiple steps marked as deliverables (is_output), the
-    response is a ZIP bundle containing one file per marked step. With 0 or 1
-    marked steps the single-output formatting paths below apply.
+    Browsers cap auto-suffixing of duplicate downloads at ~5; past that, the same
+    Content-Disposition name causes older files to be overwritten. Embedding the
+    session id guarantees uniqueness across manual runs.
     """
-    if format not in VALID_EXPORT_FORMATS:
-        raise HTTPException(status_code=400, detail=f"Invalid format. Use one of: {sorted(VALID_EXPORT_FORMATS)}")
-
-    status = await svc.get_workflow_status(session_id, user=user)
-    if not status:
-        raise HTTPException(status_code=404, detail="Workflow result not found")
-
-    # Build a base filename unique per session. Browsers cap auto-suffixing of
-    # duplicate downloads at ~5; past that, the same Content-Disposition name
-    # causes older files to be overwritten. Embedding the session id in the
-    # name guarantees uniqueness across manual runs.
     workflow_name = status.get("workflow_name")
     document_title = status.get("document_title")
-    name_parts: list[str] = []
-    if workflow_name:
-        name_parts.append(workflow_name)
-    else:
-        name_parts.append("results")
+    name_parts: list[str] = [workflow_name or "results"]
     if document_title:
         doc_stem = document_title.rsplit(".", 1)[0] if "." in document_title else document_title
         name_parts.append(doc_stem)
     name_parts.append(session_id[:8])
     raw_base = "-".join(name_parts)
-    base_filename = "".join(c if c.isalnum() or c in " _-." else "_" for c in raw_base).strip() or f"results-{session_id[:8]}"
+    return "".join(c if c.isalnum() or c in " _-." else "_" for c in raw_base).strip() or f"results-{session_id[:8]}"
 
+
+def _render_workflow_output(status: dict, format: str, parse_structured: bool) -> tuple[bytes, str, str, str | None]:
+    """Render a workflow result to bytes for download.
+
+    Returns ``(content, media_type, ext, explicit_filename)``. When
+    ``explicit_filename`` is set (a file-producing step already named its own
+    file), the caller should use it verbatim; otherwise it should name the file
+    ``<base>.<ext>``. Shared by the single-session download endpoint and the
+    batch bundle so both format outputs identically.
+    """
+    workflow_name = status.get("workflow_name")
     final_output = status.get("final_output", {})
     steps_output = status.get("steps_output", {}) or {}
     output_step_names = [n for n in (status.get("output_step_names") or []) if n in steps_output]
 
+    # Multiple deliverable steps → bundle one file per step into a ZIP.
     if len(output_step_names) >= 2:
         zip_buf = io.BytesIO()
         with zipfile.ZipFile(zip_buf, "w", zipfile.ZIP_DEFLATED) as zf:
@@ -363,28 +354,21 @@ async def download_results(
                 else:
                     seen[filename] = 0
                 zf.writestr(filename, payload)
-        zip_buf.seek(0)
-        return StreamingResponse(
-            zip_buf,
-            media_type="application/zip",
-            headers={"Content-Disposition": f'attachment; filename="{base_filename}.zip"'},
-        )
+        return zip_buf.getvalue(), "application/zip", "zip", None
 
     if len(output_step_names) == 1:
         output_data = _step_output_value(steps_output.get(output_step_names[0]))
     else:
         output_data = final_output.get("output", "") if isinstance(final_output, dict) else final_output
 
-    # Check for file_download type (e.g., from DataExport or DocumentRenderer)
+    # A step already produced a file (e.g. DataExport or DocumentRenderer) — hand
+    # its bytes back untouched under its own filename, ignoring the requested format.
     if isinstance(output_data, dict) and output_data.get("type") == "file_download":
         file_bytes = base64.b64decode(output_data["data_b64"])
         media_type_map = {"pdf": "application/pdf", "csv": "text/csv", "xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", "json": "application/json", "zip": "application/zip"}
-        media_type = media_type_map.get(output_data.get("file_type", ""), "application/octet-stream")
-        return StreamingResponse(
-            io.BytesIO(file_bytes),
-            media_type=media_type,
-            headers={"Content-Disposition": f'attachment; filename="{output_data.get("filename", "output")}"'},
-        )
+        file_type = output_data.get("file_type", "")
+        media_type = media_type_map.get(file_type, "application/octet-stream")
+        return file_bytes, media_type, file_type or "bin", output_data.get("filename", "output")
 
     if format == "csv":
         buf = io.StringIO()
@@ -421,11 +405,7 @@ async def download_results(
             for line in text.split("\n"):
                 if line.strip():
                     writer.writerow([line])
-        return StreamingResponse(
-            io.BytesIO(buf.getvalue().encode()),
-            media_type="text/csv",
-            headers={"Content-Disposition": f'attachment; filename="{base_filename}.csv"'},
-        )
+        return buf.getvalue().encode(), "text/csv", "csv", None
 
     if format == "text":
         if isinstance(output_data, str):
@@ -439,46 +419,114 @@ async def download_results(
             text = "\n".join(str(item) for item in output_data)
         else:
             text = str(output_data)
-        return StreamingResponse(
-            io.BytesIO(text.encode()),
-            media_type="text/plain",
-            headers={"Content-Disposition": f'attachment; filename="{base_filename}.txt"'},
-        )
+        return text.encode(), "text/plain", "txt", None
 
     if format == "markdown":
         from app.services.output_handlers import render_workflow_markdown
 
         md_text = render_workflow_markdown(output_data, title=workflow_name or "Workflow Results")
-        return StreamingResponse(
-            io.BytesIO(md_text.encode()),
-            media_type="text/markdown",
-            headers={"Content-Disposition": f'attachment; filename="{base_filename}.md"'},
-        )
+        return md_text.encode(), "text/markdown", "md", None
 
     if format == "pdf":
         from app.services.pdf_service import render_workflow_pdf
 
         pdf_bytes = render_workflow_pdf(output_data, title="Workflow Results")
-        return StreamingResponse(
-            io.BytesIO(pdf_bytes),
-            media_type="application/pdf",
-            headers={"Content-Disposition": f'attachment; filename="{base_filename}.pdf"'},
-        )
+        return pdf_bytes, "application/pdf", "pdf", None
 
     if format == "docx":
         docx_bytes = data_to_docx_bytes(output_data)
-        return StreamingResponse(
-            io.BytesIO(docx_bytes),
-            media_type="application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-            headers={"Content-Disposition": f'attachment; filename="{base_filename}.docx"'},
+        return (
+            docx_bytes,
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            "docx",
+            None,
         )
 
     # Default: JSON
     json_bytes = json.dumps(output_data, indent=2, default=str).encode()
+    return json_bytes, "application/json", "json", None
+
+
+@router.get("/download")
+async def download_results(
+    session_id: str,
+    format: str = "json",
+    parse_structured: bool = False,
+    user: User = Depends(get_current_user),
+):
+    """Download workflow results in specified format.
+
+    If the workflow has multiple steps marked as deliverables (is_output), the
+    response is a ZIP bundle containing one file per marked step. With 0 or 1
+    marked steps the single-output formatting paths apply.
+    """
+    if format not in VALID_EXPORT_FORMATS:
+        raise HTTPException(status_code=400, detail=f"Invalid format. Use one of: {sorted(VALID_EXPORT_FORMATS)}")
+
+    status = await svc.get_workflow_status(session_id, user=user)
+    if not status:
+        raise HTTPException(status_code=404, detail="Workflow result not found")
+
+    base_filename = _session_base_filename(status, session_id)
+    content, media_type, ext, explicit_name = _render_workflow_output(status, format, parse_structured)
+    filename = explicit_name or f"{base_filename}.{ext}"
     return StreamingResponse(
-        io.BytesIO(json_bytes),
-        media_type="application/json",
-        headers={"Content-Disposition": f'attachment; filename="{base_filename}.json"'},
+        io.BytesIO(content),
+        media_type=media_type,
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )
+
+
+@router.get("/batch-download")
+async def download_batch_results(
+    batch_id: str,
+    format: str = "json",
+    parse_structured: bool = False,
+    share_token: str | None = Query(default=None),
+    user: User = Depends(get_current_user),
+):
+    """Bundle every completed run in a batch into a single ZIP.
+
+    One member per completed run, each formatted like the single-session
+    download. Not-yet-finished and failed runs are skipped. 404 if the batch is
+    unknown/unauthorized; 409 if it has no completed runs to bundle.
+    """
+    if format not in VALID_EXPORT_FORMATS:
+        raise HTTPException(status_code=400, detail=f"Invalid format. Use one of: {sorted(VALID_EXPORT_FORMATS)}")
+
+    batch = await svc.get_batch_status(batch_id, user=user, share_token=share_token)
+    if not batch:
+        raise HTTPException(status_code=404, detail="Batch not found")
+
+    completed = [it for it in batch["items"] if it["status"] == "completed"]
+    if not completed:
+        raise HTTPException(status_code=409, detail="No completed runs to download yet")
+
+    zip_buf = io.BytesIO()
+    seen: dict[str, int] = {}
+    with zipfile.ZipFile(zip_buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        for item in completed:
+            sid = item["session_id"]
+            status = await svc.get_workflow_status(sid, user=user, share_token=share_token)
+            if not status:
+                continue
+            content, _media_type, ext, explicit_name = _render_workflow_output(status, format, parse_structured)
+            member = explicit_name or f"{_session_base_filename(status, sid)}.{ext}"
+            # Disambiguate collisions so no member silently overwrites another.
+            if member in seen:
+                seen[member] += 1
+                stem, _, m_ext = member.rpartition(".")
+                member = f"{stem}_{seen[member]}.{m_ext}" if m_ext else f"{member}_{seen[member]}"
+            else:
+                seen[member] = 0
+            zf.writestr(member, content)
+    zip_buf.seek(0)
+
+    zip_name = "".join(c if c.isalnum() or c in " _-." else "_" for c in f"batch-{batch_id}").strip()
+    return StreamingResponse(
+        zip_buf,
+        media_type="application/zip",
+        headers={"Content-Disposition": f'attachment; filename="{zip_name}.zip"'},
     )
 
 

--- a/backend/tests/test_workflow_routes_extended.py
+++ b/backend/tests/test_workflow_routes_extended.py
@@ -632,6 +632,105 @@ class TestDownloadBatchResults:
         # Only the two completed runs are bundled, not the running one.
         assert len(zf.namelist()) == 2
 
+    async def test_a_step_supplied_filename_cannot_escape_the_archive(self, client):
+        """`filename` on a DataExport/DocumentRenderer/PackageBuilder step is
+        free text from the workflow's own configuration and reached writestr
+        unsanitised, so a step named ``../../evil`` produced a ZIP member that
+        archive tools which do not normalise paths extract outside the target
+        directory.
+        """
+        import io
+        import zipfile
+
+        user = _make_user()
+        cookies, headers = _auth()
+
+        def evil_status(sid):
+            st = self._session_status(sid)
+            st["final_output"] = {
+                "output": {
+                    "type": "file_download",
+                    "data_b64": "cHduZWQ=",
+                    "file_type": "csv",
+                    "filename": "../../evil.csv",
+                },
+            }
+            return st
+
+        with patch("app.dependencies.decode_token", return_value={"sub": "testuser", "type": "access"}), \
+             patch("app.dependencies.User") as MockUser, \
+             patch("app.routers.workflows.svc") as mock_svc:
+            MockUser.find_one = AsyncMock(return_value=user)
+            mock_svc.get_batch_status = AsyncMock(
+                return_value=self._batch([("s1", "completed")])
+            )
+            mock_svc.get_workflow_status = AsyncMock(side_effect=lambda sid, **kw: evil_status(sid))
+
+            resp = await client.get(
+                "/api/workflows/batch-download?batch_id=b1&format=json",
+                cookies=cookies, headers=headers,
+            )
+
+        assert resp.status_code == 200
+        names = zipfile.ZipFile(io.BytesIO(resp.content)).namelist()
+        assert names, "nothing was bundled"
+        for name in names:
+            assert ".." not in name, f"member {name!r} can traverse out of the archive"
+            assert not name.startswith("/"), f"member {name!r} is an absolute path"
+            assert "/" not in name and "\\" not in name, (
+                f"member {name!r} still carries a path component"
+            )
+
+    async def test_identical_step_filenames_stay_distinct_and_attributed(self, client):
+        """A step-supplied filename is static config, identical across every run
+        in the batch. Used bare it told the reader nothing about which document
+        produced which file, and the collision counter — keyed only on the
+        original name — could still emit two members with the same name.
+        """
+        import io
+        import zipfile
+
+        user = _make_user()
+        cookies, headers = _auth()
+
+        def same_name(sid):
+            st = self._session_status(sid)
+            st["final_output"] = {
+                "output": {
+                    "type": "file_download",
+                    "data_b64": "cHduZWQ=",
+                    "file_type": "csv",
+                    "filename": "export.csv",
+                },
+            }
+            return st
+
+        with patch("app.dependencies.decode_token", return_value={"sub": "testuser", "type": "access"}), \
+             patch("app.dependencies.User") as MockUser, \
+             patch("app.routers.workflows.svc") as mock_svc:
+            MockUser.find_one = AsyncMock(return_value=user)
+            mock_svc.get_batch_status = AsyncMock(
+                return_value=self._batch([
+                    ("s1", "completed"), ("s2", "completed"), ("s3", "completed"),
+                ])
+            )
+            mock_svc.get_workflow_status = AsyncMock(side_effect=lambda sid, **kw: same_name(sid))
+
+            resp = await client.get(
+                "/api/workflows/batch-download?batch_id=b1&format=json",
+                cookies=cookies, headers=headers,
+            )
+
+        assert resp.status_code == 200
+        names = zipfile.ZipFile(io.BytesIO(resp.content)).namelist()
+        assert len(names) == 3
+        assert len(set(names)) == 3, f"duplicate members in the archive: {names}"
+        # Each member names the run it came from, not just the step's config.
+        for sid in ("s1", "s2", "s3"):
+            assert any(sid in n for n in names), (
+                f"no member attributable to {sid} in {names}"
+            )
+
     async def test_no_completed_runs_returns_409(self, client):
         user = _make_user()
         cookies, headers = _auth()

--- a/backend/tests/test_workflow_routes_extended.py
+++ b/backend/tests/test_workflow_routes_extended.py
@@ -564,6 +564,128 @@ class TestDownloadResults:
 
 
 # ---------------------------------------------------------------------------
+# GET /api/workflows/batch-download — ZIP bundle of a batch's outputs
+# ---------------------------------------------------------------------------
+
+class TestDownloadBatchResults:
+    def _batch(self, item_statuses):
+        """Batch-status dict with one item per (session_id, status) pair."""
+        return {
+            "status": "running",
+            "total": len(item_statuses),
+            "completed": sum(1 for _, s in item_statuses if s == "completed"),
+            "failed": 0,
+            "items": [
+                {
+                    "session_id": sid,
+                    "document_title": f"{sid}.pdf",
+                    "status": s,
+                    "num_steps_completed": 1,
+                    "num_steps_total": 1,
+                    "current_step_name": None,
+                    "final_output": {"output": {"who": sid}},
+                }
+                for sid, s in item_statuses
+            ],
+        }
+
+    def _session_status(self, sid):
+        return {
+            "status": "completed",
+            "num_steps_completed": 1,
+            "num_steps_total": 1,
+            "current_step_name": None,
+            "current_step_detail": None,
+            "current_step_preview": None,
+            "final_output": {"output": {"who": sid}},
+            "steps_output": {},
+            "workflow_name": "My WF",
+            "document_title": f"{sid}.pdf",
+        }
+
+    async def test_bundles_only_completed_runs(self, client):
+        import io
+        import zipfile
+
+        user = _make_user()
+        cookies, headers = _auth()
+
+        with patch("app.dependencies.decode_token", return_value={"sub": "testuser", "type": "access"}), \
+             patch("app.dependencies.User") as MockUser, \
+             patch("app.routers.workflows.svc") as mock_svc:
+            MockUser.find_one = AsyncMock(return_value=user)
+            mock_svc.get_batch_status = AsyncMock(
+                return_value=self._batch([("s1", "completed"), ("s2", "running"), ("s3", "completed")])
+            )
+            mock_svc.get_workflow_status = AsyncMock(
+                side_effect=lambda sid, **kw: self._session_status(sid)
+            )
+
+            resp = await client.get(
+                "/api/workflows/batch-download?batch_id=b1&format=json",
+                cookies=cookies, headers=headers,
+            )
+
+        assert resp.status_code == 200
+        assert "application/zip" in resp.headers["content-type"]
+        zf = zipfile.ZipFile(io.BytesIO(resp.content))
+        # Only the two completed runs are bundled, not the running one.
+        assert len(zf.namelist()) == 2
+
+    async def test_no_completed_runs_returns_409(self, client):
+        user = _make_user()
+        cookies, headers = _auth()
+
+        with patch("app.dependencies.decode_token", return_value={"sub": "testuser", "type": "access"}), \
+             patch("app.dependencies.User") as MockUser, \
+             patch("app.routers.workflows.svc") as mock_svc:
+            MockUser.find_one = AsyncMock(return_value=user)
+            mock_svc.get_batch_status = AsyncMock(
+                return_value=self._batch([("s1", "running"), ("s2", "queued")])
+            )
+
+            resp = await client.get(
+                "/api/workflows/batch-download?batch_id=b1&format=json",
+                cookies=cookies, headers=headers,
+            )
+
+        assert resp.status_code == 409
+
+    async def test_unknown_batch_returns_404(self, client):
+        user = _make_user()
+        cookies, headers = _auth()
+
+        with patch("app.dependencies.decode_token", return_value={"sub": "testuser", "type": "access"}), \
+             patch("app.dependencies.User") as MockUser, \
+             patch("app.routers.workflows.svc") as mock_svc:
+            MockUser.find_one = AsyncMock(return_value=user)
+            mock_svc.get_batch_status = AsyncMock(return_value=None)
+
+            resp = await client.get(
+                "/api/workflows/batch-download?batch_id=missing&format=json",
+                cookies=cookies, headers=headers,
+            )
+
+        assert resp.status_code == 404
+
+    async def test_invalid_format_returns_400(self, client):
+        user = _make_user()
+        cookies, headers = _auth()
+
+        with patch("app.dependencies.decode_token", return_value={"sub": "testuser", "type": "access"}), \
+             patch("app.dependencies.User") as MockUser, \
+             patch("app.routers.workflows.svc") as mock_svc:
+            MockUser.find_one = AsyncMock(return_value=user)
+
+            resp = await client.get(
+                "/api/workflows/batch-download?batch_id=b1&format=xlsx",
+                cookies=cookies, headers=headers,
+            )
+
+        assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------------
 # POST /api/workflows/steps/test
 # ---------------------------------------------------------------------------
 

--- a/frontend/src/api/workflows.ts
+++ b/frontend/src/api/workflows.ts
@@ -260,6 +260,15 @@ export function downloadResults(sessionId: string, format: string = 'json', opts
   return `/api/workflows/download?${params.toString()}`
 }
 
+// URL for a ZIP bundling every completed run in a batch, one file per document
+// in the given format. Individual batch runs download via downloadResults with
+// their own session_id.
+export function downloadBatchResults(batchId: string, format: string = 'json', opts?: { parseStructured?: boolean }) {
+  const params = new URLSearchParams({ batch_id: batchId, format })
+  if (opts?.parseStructured) params.set('parse_structured', 'true')
+  return `/api/workflows/batch-download?${params.toString()}`
+}
+
 export type SaveOutputFormat = 'pdf' | 'docx' | 'markdown' | 'csv' | 'json' | 'text'
 
 export function saveResultToFolder(

--- a/frontend/src/api/workflows.ts
+++ b/frontend/src/api/workflows.ts
@@ -254,18 +254,30 @@ export function getTestStepStatus(taskId: string) {
   return apiFetch<{ status: string; result?: unknown; error?: string }>(`/api/workflows/steps/test/${taskId}`)
 }
 
-export function downloadResults(sessionId: string, format: string = 'json', opts?: { parseStructured?: boolean }) {
+export function downloadResults(
+  sessionId: string,
+  format: string = 'json',
+  opts?: { parseStructured?: boolean; shareToken?: string },
+) {
   const params = new URLSearchParams({ session_id: sessionId, format })
   if (opts?.parseStructured) params.set('parse_structured', 'true')
+  // The route authorizes with the share token when there is one; without it a
+  // share-link recipient who is not on the owner's team 404s on their own run.
+  if (opts?.shareToken) params.set('share_token', opts.shareToken)
   return `/api/workflows/download?${params.toString()}`
 }
 
 // URL for a ZIP bundling every completed run in a batch, one file per document
 // in the given format. Individual batch runs download via downloadResults with
 // their own session_id.
-export function downloadBatchResults(batchId: string, format: string = 'json', opts?: { parseStructured?: boolean }) {
+export function downloadBatchResults(
+  batchId: string,
+  format: string = 'json',
+  opts?: { parseStructured?: boolean; shareToken?: string },
+) {
   const params = new URLSearchParams({ batch_id: batchId, format })
   if (opts?.parseStructured) params.set('parse_structured', 'true')
+  if (opts?.shareToken) params.set('share_token', opts.shareToken)
   return `/api/workflows/batch-download?${params.toString()}`
 }
 

--- a/frontend/src/components/workspace/WorkflowEditorPanel.tsx
+++ b/frontend/src/components/workspace/WorkflowEditorPanel.tsx
@@ -18,7 +18,7 @@ import { useConfirm } from '../shared/useConfirm'
 import { getProjectDocuments } from '../../api/projects'
 import {
   getWorkflow, addStep, deleteStep, addTask, deleteTask, updateTask,
-  updateWorkflow, updateStep, downloadResults, testStep, getTestStepStatus,
+  updateWorkflow, updateStep, downloadResults, downloadBatchResults, testStep, getTestStepStatus,
   reorderSteps, validateWorkflow, runWorkflow, streamWorkflowStatus, createTempDocuments,
   getWorkflowQualityHistory, getWorkflowImprovementSuggestions, getWorkflowQualityStatus,
   getValidationPlan, updateValidationPlan, generateValidationPlan, validationReportUrl,
@@ -889,6 +889,7 @@ export function WorkflowEditorPanel() {
               runnerStatus={runner.status}
               runnerRunning={runner.running}
               runnerSessionId={runner.sessionId}
+              runnerBatchId={runner.batchId}
               batchStatus={runner.batchStatus}
               runElapsed={runElapsed}
               showDownloadPopup={showDownloadPopup}
@@ -1332,6 +1333,7 @@ function DesignCanvas({
   runnerStatus,
   runnerRunning,
   runnerSessionId,
+  runnerBatchId,
   batchStatus,
   runElapsed,
   showDownloadPopup,
@@ -1347,6 +1349,7 @@ function DesignCanvas({
   runnerStatus: WorkflowStatus | null
   runnerRunning: boolean
   runnerSessionId: string | null
+  runnerBatchId: string | null
   batchStatus: BatchStatus | null
   runElapsed: number
   showDownloadPopup: boolean
@@ -1520,6 +1523,7 @@ function DesignCanvas({
         <>
           <ConnectionLine />
           <BatchOutputCard
+            batchId={runnerBatchId}
             batchStatus={batchStatus}
             running={runnerRunning}
             runElapsed={runElapsed}
@@ -5343,7 +5347,8 @@ function ConvertWorkflowDocsButton({
 // Batch output card
 // ---------------------------------------------------------------------------
 
-function BatchOutputCard({ batchStatus, running, runElapsed }: {
+function BatchOutputCard({ batchId, batchStatus, running, runElapsed }: {
+  batchId: string | null
   batchStatus: BatchStatus
   running: boolean
   runElapsed: number
@@ -5352,6 +5357,7 @@ function BatchOutputCard({ batchStatus, running, runElapsed }: {
   const isError = batchStatus.status === 'failed'
   const isCanceled = batchStatus.status === 'canceled'
   const [expandedIdx, setExpandedIdx] = useState<number | null>(null)
+  const completedCount = batchStatus.items.filter(it => it.status === 'completed').length
 
   const renderOutput = (data: unknown): string => {
     if (data === null || data === undefined) return ''
@@ -5433,6 +5439,22 @@ function BatchOutputCard({ batchStatus, running, runElapsed }: {
                   <span style={{ fontSize: 11, color: '#6b7280', flexShrink: 0 }}>{item.current_step_name}</span>
                 )}
                 {itemDone && (
+                  <a
+                    href={downloadResults(item.session_id, 'json')}
+                    onClick={e => e.stopPropagation()}
+                    title="Download this output (JSON)"
+                    aria-label={`Download output for ${item.document_title || item.session_id}`}
+                    style={{
+                      display: 'flex', alignItems: 'center', flexShrink: 0,
+                      color: '#6b7280', textDecoration: 'none',
+                    }}
+                    onMouseEnter={e => { e.currentTarget.style.color = '#111827' }}
+                    onMouseLeave={e => { e.currentTarget.style.color = '#6b7280' }}
+                  >
+                    <Download style={{ width: 14, height: 14 }} />
+                  </a>
+                )}
+                {itemDone && (
                   <ChevronDown style={{
                     width: 14, height: 14, color: '#6b7280', flexShrink: 0,
                     transition: 'transform 0.15s',
@@ -5459,6 +5481,26 @@ function BatchOutputCard({ batchStatus, running, runElapsed }: {
           )
         })}
       </div>
+
+      {/* Download all completed outputs as a ZIP of JSON files. Shown as soon as
+          any run finishes, so completed outputs are grabbable mid-batch. */}
+      {batchId && completedCount > 0 && (
+        <div style={{ marginTop: 12, display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap' }}>
+          <a
+            href={downloadBatchResults(batchId, 'json')}
+            style={{
+              display: 'flex', alignItems: 'center', gap: 6, padding: '8px 16px',
+              fontSize: 13, fontWeight: 600, fontFamily: 'inherit',
+              border: '1px solid #d1d5db', borderRadius: 6,
+              backgroundColor: '#fff', cursor: 'pointer', color: '#374151', textDecoration: 'none',
+            }}
+          >
+            <Package style={{ width: 14, height: 14 }} />
+            Download all (.zip)
+            {completedCount < batchStatus.total && <span style={{ fontWeight: 400, color: '#6b7280' }}>({completedCount})</span>}
+          </a>
+        </div>
+      )}
     </div>
   )
 }

--- a/frontend/src/components/workspace/WorkflowEditorPanel.tsx
+++ b/frontend/src/components/workspace/WorkflowEditorPanel.tsx
@@ -4836,6 +4836,9 @@ function WorkflowOutputCard({ status, sessionId, workflowName, running, runElaps
   showDownloadPopup: boolean
   setShowDownloadPopup: (v: boolean) => void
 }) {
+  // Same as the batch card: a share-link recipient authorizes with the token.
+  const { openWorkflowShareToken } = useWorkspace()
+  const shareToken = openWorkflowShareToken ?? undefined
   const isCompleted = status?.status === 'completed'
   const isError = status?.status === 'error' || status?.status === 'failed'
   const isCanceled = status?.status === 'canceled'
@@ -5168,7 +5171,7 @@ function WorkflowOutputCard({ status, sessionId, workflowName, running, runElaps
                 ] as const).map(({ fmt, label, desc, parseStructured }) => (
                   <a
                     key={label}
-                    href={downloadResults(sessionId, fmt, { parseStructured })}
+                    href={downloadResults(sessionId, fmt, { parseStructured, shareToken })}
                     onClick={() => setShowDownloadPopup(false)}
                     style={{
                       display: 'flex', flexDirection: 'column', gap: 1,
@@ -5353,6 +5356,11 @@ function BatchOutputCard({ batchId, batchStatus, running, runElapsed }: {
   running: boolean
   runElapsed: number
 }) {
+  // A recipient who reached this workflow through a share link authorizes with
+  // the token, not team membership — without it both downloads 404 on a batch
+  // they just watched run.
+  const { openWorkflowShareToken } = useWorkspace()
+  const shareToken = openWorkflowShareToken ?? undefined
   const isCompleted = batchStatus.status === 'completed'
   const isError = batchStatus.status === 'failed'
   const isCanceled = batchStatus.status === 'canceled'
@@ -5440,8 +5448,11 @@ function BatchOutputCard({ batchId, batchStatus, running, runElapsed }: {
                 )}
                 {itemDone && (
                   <a
-                    href={downloadResults(item.session_id, 'json')}
+                    href={downloadResults(item.session_id, 'json', { shareToken })}
                     onClick={e => e.stopPropagation()}
+                    // The row cancels Enter/Space to toggle itself, which would
+                    // swallow the link's own activation for a keyboard user.
+                    onKeyDown={e => e.stopPropagation()}
                     title="Download this output (JSON)"
                     aria-label={`Download output for ${item.document_title || item.session_id}`}
                     style={{
@@ -5487,7 +5498,7 @@ function BatchOutputCard({ batchId, batchStatus, running, runElapsed }: {
       {batchId && completedCount > 0 && (
         <div style={{ marginTop: 12, display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap' }}>
           <a
-            href={downloadBatchResults(batchId, 'json')}
+            href={downloadBatchResults(batchId, 'json', { shareToken })}
             style={{
               display: 'flex', alignItems: 'center', gap: 6, padding: '8px 16px',
               fontSize: 13, fontWeight: 600, fontFamily: 'inherit',


### PR DESCRIPTION
Closes #656.

## ⚠️ This PR is stacked on #658
It targets `fix/batch-run-stop` (PR #658), **not** `main`, because both PRs modify the shared `BatchOutputCard`. **The diff shown here is only the download changes** — #658's changes are excluded. **Merge #658 first;** GitHub will then auto-retarget this PR to `main`.

## Problem
Batch (**Run per document**) outputs could only be viewed, not downloaded — no per-document download and no bulk download.

## Change
**Frontend**
- A download icon on each *completed* run (reuses the existing per-session `/download` endpoint with its `session_id`).
- A **Download all (.zip)** button that bundles every completed run as JSON — one file per document. Shows a `(n)` count while the batch is still finishing.

**Backend**
- New endpoint `GET /api/workflows/batch-download` — zips every completed run in the batch (404 unknown batch, 409 when nothing is complete yet).
- Extracted a shared `_render_workflow_output()` helper from the single-session download so the single `/download` and the batch bundle format outputs identically (reuse, not duplication).

## Design note
Downloads are **JSON only** (per product decision) — no format picker, to keep the batch UI simple.

## Tests / verification
- `backend/tests/test_workflow_routes_extended.py`: `TestDownloadBatchResults` — bundles only completed runs, 409 when none complete, 404 unknown, 400 bad format. Backend green (101 passed).
- Frontend `tsc -b` clean for changed files.
- Manually exercised: per-row download + Download all (.zip) on a completed batch.

## Merge order (batch of 3 related PRs)
- #658 — batch Stop button → `main`
- **#659 (this)** — batch output downloads → `fix/batch-run-stop`, **stacked on #658**
- #660 — Test Step output download → `main`

Merge #658 first → this retargets to `main` automatically → review this (now-simple) diff and merge. #660 is independent.

## Note on CI
Same pre-existing `main` frontend-build failure as noted in #658 (`SupportCenter.tsx` / `TeamsDropdown.tsx`, TanStack Router param types) — unrelated to this PR.