### PR TITLE
fix(present): refuse prototype keys in getTrack

### DIFF
--- a/frontend/src/pages/present/content.test.ts
+++ b/frontend/src/pages/present/content.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest'
+import { getTrack, TRACK_ORDER, TRACKS } from './content'
+
+describe('getTrack', () => {
+  it('returns each defined audience', () => {
+    for (const id of TRACK_ORDER) {
+      expect(getTrack(id)).toBe(TRACKS[id])
+    }
+  })
+
+  it('returns undefined for an unknown audience', () => {
+    expect(getTrack('accounting')).toBeUndefined()
+    expect(getTrack('')).toBeUndefined()
+    expect(getTrack(undefined)).toBeUndefined()
+  })
+
+  // /docs/present/$audience is public and unauthenticated. A bare index into
+  // TRACKS resolves inherited members, so these returned a truthy Function —
+  // the caller's `if (!track)` redirect was skipped and the next line
+  // dereferenced .id and .slides on it, blank-screening the page.
+  it.each([
+    'toString',
+    'constructor',
+    'valueOf',
+    'hasOwnProperty',
+    'isPrototypeOf',
+    'propertyIsEnumerable',
+    'toLocaleString',
+    '__proto__',
+    '__defineGetter__',
+  ])('refuses the prototype key %s', (key) => {
+    expect(getTrack(key)).toBeUndefined()
+  })
+
+  it('returns something a caller can safely dereference, or nothing at all', () => {
+    // The property the consumer reaches for immediately after the guard.
+    for (const probe of [...TRACK_ORDER, 'toString', 'nope', '__proto__']) {
+      const track = getTrack(probe)
+      if (track) {
+        expect(Array.isArray(track.slides)).toBe(true)
+        expect(typeof track.id).toBe('string')
+      }
+    }
+  })
+})

--- a/frontend/src/pages/present/content.ts
+++ b/frontend/src/pages/present/content.ts
@@ -621,7 +621,14 @@ export const TRACK_ORDER: AudienceId[] = ['leadership', 'deploy', 'team', 'resea
 
 export function getTrack(id: string | undefined): Track | undefined {
   if (!id) return undefined
-  return (TRACKS as Record<string, Track>)[id]
+  // Index only the audiences we actually define. A bare lookup resolves
+  // inherited members too, so /docs/present/toString returned
+  // Object.prototype.toString — truthy, so the caller's `if (!track)` redirect
+  // was skipped, and dereferencing .id and .slides on a Function threw. That
+  // route is public and unauthenticated, so the failure is a blank screen for
+  // anyone who can reach the page.
+  if (!TRACK_ORDER.includes(id as AudienceId)) return undefined
+  return TRACKS[id as AudienceId]
 }
 
 // Dev-time completeness guard — catches an audience added without full content.


### PR DESCRIPTION
Closes #664.

## The bug

`getTrack` indexed `TRACKS` cast to `Record<string, Track>`, which resolves inherited members as readily as own ones:

```js
getTrack('toString')      // Object.prototype.toString — truthy!
getTrack('constructor')
getTrack('valueOf')
getTrack('__proto__')
```

Because the result is truthy, the caller's guard is skipped:

```ts
if (!track) return <Navigate to="/docs/present" />
const audience = track.id          // undefined on a Function
...track.slides.length             // throws
```

`/docs/present/$audience` is **public and unauthenticated**, so this blank-screens the surface we point prospective institutions at — no login needed to reach it.

## The fix

Index only the audiences `TRACK_ORDER` declares — the list the rest of the file already treats as the definition of a valid audience, including the dev-time completeness guard just below it.

## Tests

`content.test.ts` is new; this page had no coverage at all. Twelve tests, of which the nine prototype-key cases fail against the code as it stood:

```
× refuses the prototype key toString
× refuses the prototype key constructor
× refuses the prototype key valueOf
× refuses the prototype key hasOwnProperty
× refuses the prototype key isPrototypeOf
× refuses the prototype key propertyIsEnumerable
× refuses the prototype key toLocaleString
× refuses the prototype key __proto__
× refuses the prototype key __defineGetter__
```

Verified with `npm run typecheck` (`tsc -b`) and `npm run build`, which is what CI runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
