### PR TITLE
fix(verification): link a submission notification to the submission

### DIFF
--- a/backend/app/services/email_service.py
+++ b/backend/app/services/email_service.py
@@ -405,10 +405,21 @@ def verification_submitted_email(
     item_name: str,
     summary: str | None,
     frontend_url: str,
+    request_uuid: str | None = None,
 ) -> tuple[str, str]:
     """Returns (subject, html_body) telling a reviewer a new submission is queued."""
     kind_label = item_kind.replace("_", " ")
     subject = f'New verification submission: "{item_name}"'
+    # Link to the submission, not the queue. A reviewer clicking through
+    # otherwise has to find the right row themselves, which is worst at exactly
+    # this moment — they have the least context about which item the mail was
+    # for — and gets worse as the queue grows. The approval flow already links
+    # to /reviews/{uuid}; this is the same idea for verification.
+    queue_link = f"{frontend_url}/verification"
+    button_label = "Open Queue"
+    if request_uuid:
+        queue_link = f"{queue_link}?request={request_uuid}"
+        button_label = "Open Submission"
 
     summary_block = ""
     if summary:
@@ -423,7 +434,7 @@ def verification_submitted_email(
       <h1>New submission awaiting review</h1>
       <p>Hi {reviewer_name}, <strong style="color:#fff">{submitter_name}</strong> submitted the {kind_label} <span class="highlight">{item_name}</span> for verification.</p>
       {summary_block}
-      <p style="margin-top:24px"><a class="btn" href="{frontend_url}/verification">Open Queue</a></p>
+      <p style="margin-top:24px"><a class="btn" href="{queue_link}">{button_label}</a></p>
       <div class="footer">Vandalizer</div>
     </div></div></body></html>"""
     return subject, html

--- a/backend/app/services/verification_service.py
+++ b/backend/app/services/verification_service.py
@@ -1599,7 +1599,7 @@ async def _notify_examiners(req: VerificationRequest) -> None:
                 kind="verification_submitted",
                 title=f'New submission: "{item_name}"',
                 body=f"{submitter_display} submitted a {req.item_kind.replace('_', ' ')} for verification.",
-                link="/verification",
+                link=f"/verification?request={req.uuid}",
                 item_kind=req.item_kind,
                 item_id=str(req.item_id),
                 item_name=item_name,
@@ -1619,6 +1619,7 @@ async def _notify_examiners(req: VerificationRequest) -> None:
                 item_name=item_name,
                 summary=req.summary,
                 frontend_url=settings.frontend_url,
+                request_uuid=req.uuid,
             )
             await send_email(reviewer.email, subject, html, settings, email_type="verification_submitted")
     except Exception:

--- a/backend/tests/test_verification_service.py
+++ b/backend/tests/test_verification_service.py
@@ -1251,7 +1251,9 @@ async def test_notify_examiners_notifies_admins_and_examiners(mock_name, mock_us
 
     assert [c[1]["user_id"] for c in mock_create.call_args_list] == ["admin", "exam"]
     assert mock_create.call_args_list[0][1]["kind"] == "verification_submitted"
-    assert mock_create.call_args_list[0][1]["link"] == "/verification"
+    # Deep-links the submission rather than the queue: the reviewer should
+    # not have to find the row the notification is about.
+    assert mock_create.call_args_list[0][1]["link"] == "/verification?request=req-uuid"
     # Only the reviewer with an email address gets mail
     mock_email.assert_awaited_once()
     assert mock_email.call_args[0][0] == "admin@example.com"
@@ -1343,3 +1345,49 @@ async def test_get_visible_verified_item_ids_kind_filter(mock_li, mock_vim):
 
     assert result == {"kb-1"}
     assert mock_li.find.call_args[0][0] == {"verified": True, "kind": "knowledge_base"}
+
+
+# ---------------------------------------------------------------------------
+# A submission notification names one submission — link to it
+# ---------------------------------------------------------------------------
+
+class TestVerificationSubmittedDeepLink:
+    """A reviewer clicking through from a notification should land on the
+    submission, not on a queue they then have to search. That is the moment
+    they have the least context about which item the mail was for, and it gets
+    worse as the queue grows. The approval flow already links to /reviews/{uuid}.
+    """
+
+    def test_email_button_targets_the_submission(self):
+        from app.services.email_service import verification_submitted_email
+
+        _subject, html = verification_submitted_email(
+            reviewer_name="Dana",
+            submitter_name="Sam",
+            item_kind="knowledge_base",
+            item_name="Uniform Guidance",
+            summary=None,
+            frontend_url="https://vandalizer.example.edu",
+            request_uuid="req-abc123",
+        )
+
+        assert "/verification?request=req-abc123" in html
+        assert "Open Submission" in html
+
+    def test_email_falls_back_to_the_queue_without_a_uuid(self):
+        """The parameter is optional, so an older caller still produces a
+        working link rather than one pointing at ?request=None."""
+        from app.services.email_service import verification_submitted_email
+
+        _subject, html = verification_submitted_email(
+            reviewer_name="Dana",
+            submitter_name="Sam",
+            item_kind="knowledge_base",
+            item_name="Uniform Guidance",
+            summary=None,
+            frontend_url="https://vandalizer.example.edu",
+        )
+
+        assert 'href="https://vandalizer.example.edu/verification"' in html
+        assert "request=" not in html
+        assert "Open Queue" in html

--- a/frontend/src/components/library/VerificationQueue.tsx
+++ b/frontend/src/components/library/VerificationQueue.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { useNavigate } from '@tanstack/react-router'
 import { ShieldCheck, Clock, Search, ChevronDown, ChevronRight, Tag, FileText, ExternalLink, Pin, Wrench, UserCheck } from 'lucide-react'
 import { listVerificationQueue, myVerificationRequests, updateVerificationStatus, listCollections } from '../../api/library'
@@ -60,7 +60,7 @@ function ListDetail({ label, items }: { label: string; items?: string[] }) {
   )
 }
 
-export function VerificationQueue() {
+export function VerificationQueue({ focusRequestUuid }: { focusRequestUuid?: string } = {}) {
   const navigate = useNavigate()
   const { user } = useAuth()
   const [view, setView] = useState<QueueView>('pending')
@@ -103,6 +103,26 @@ export function VerificationQueue() {
   useEffect(() => {
     refresh()
   }, [refresh])
+
+  // A notification names one submission, so open it rather than dropping the
+  // reviewer on a queue to search — which is the moment they have the least
+  // context about which row the mail was for, and gets worse as the queue
+  // grows. Runs once the row exists; if the request is not in the current view
+  // (already decided, say) nothing happens and the plain queue is shown.
+  const focusedRef = useRef<string | null>(null)
+  useEffect(() => {
+    if (!focusRequestUuid || loading) return
+    if (focusedRef.current === focusRequestUuid) return
+    if (!requests.some(r => r.uuid === focusRequestUuid)) return
+    focusedRef.current = focusRequestUuid
+    setExpandedId(focusRequestUuid)
+    // Let the expanded body render before scrolling to it.
+    requestAnimationFrame(() => {
+      document
+        .querySelector(`[data-request-uuid="${focusRequestUuid}"]`)
+        ?.scrollIntoView({ block: 'center', behavior: 'smooth' })
+    })
+  }, [focusRequestUuid, loading, requests])
 
   const handleAction = async (uuid: string, action: 'approved' | 'rejected' | 'in_review' | 'returned') => {
     const oIds = action === 'approved' && reviewOrgIds.length > 0 ? reviewOrgIds : undefined
@@ -254,6 +274,7 @@ export function VerificationQueue() {
             return (
               <div
                 key={req.id}
+                data-request-uuid={req.uuid}
                 className="border border-gray-200 rounded-lg bg-white"
               >
                 <div className="p-4">

--- a/frontend/src/pages/Verification.tsx
+++ b/frontend/src/pages/Verification.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { useSearch } from '@tanstack/react-router'
 import { ShieldCheck, BookOpen, FolderOpen, Users, Pin } from 'lucide-react'
 import { PageLayout } from '../components/layout/PageLayout'
 import { VerificationQueue } from '../components/library/VerificationQueue'
@@ -20,6 +21,9 @@ const TABS: { key: Tab; label: string; icon: typeof ShieldCheck; adminOnly?: boo
 
 export default function Verification() {
   const { user } = useAuth()
+  const search = useSearch({ strict: false }) as { request?: string }
+  // A notification links to the submission it is about, so open on the queue
+  // with that row in view rather than making the reviewer find it.
   const [activeTab, setActiveTab] = useState<Tab>('queue')
 
   if (!user?.is_examiner) {
@@ -80,7 +84,7 @@ export default function Verification() {
 
         {/* Content */}
         <div style={{ flex: 1, padding: '20px 32px', minWidth: 0 }}>
-          {activeTab === 'queue' && <VerificationQueue />}
+          {activeTab === 'queue' && <VerificationQueue focusRequestUuid={search.request} />}
           {activeTab === 'catalog' && <VerifiedCatalog />}
           {activeTab === 'coverage' && <CatalogCoverageTab />}
           {activeTab === 'collections' && <CollectionsManager />}

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -279,6 +279,12 @@ const automationRoute = createRoute({
 const verificationRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/verification',
+  // ?request=<uuid> deep-links a notification to the submission it is about,
+  // the way ?ticket= does on /support. Anything unrecognized falls back to the
+  // plain queue.
+  validateSearch: (search: Record<string, unknown>): { request?: string } => ({
+    request: (typeof search.request === 'string' && search.request) || undefined,
+  }),
   component: () => (
     <ProtectedRoute>
       <Verification />


### PR DESCRIPTION
Closes #646.

## The gap

The "New submission awaiting review" notification and its email both pointed at `{frontend_url}/verification` — the queue, not the submission. A reviewer clicking through had to find the right row themselves, which is worst at exactly this moment (they have the least context about which item the mail was for) and gets worse as the queue grows.

#637 already fixed the harder half of this journey — reviewers outside the submitter's team used to get "Workflow not found" on arrival, because reviewer eligibility is global while item access was team-scoped. So the link now lands somewhere useful; it just lands one level too high.

## The change

`/verification` accepts a `?request=<uuid>` search param, in the same shape `/support` already uses for `?ticket=`. `VerificationQueue` expands that row and scrolls it into view once the list has loaded.

Deliberately forgiving:

- A uuid **not in the current view** (already decided, filtered out) is ignored and the plain queue renders — a stale link degrades rather than erroring.
- The email's `request_uuid` is **optional**; without it the button keeps its old href and reads "Open Queue". Nothing breaks if a caller omits it.
- The default queue view is `pending` with no status filter, so a freshly-submitted request is in the default list — the deep link doesn't have to fight the filters.

## Rendered link

```
with uuid:  https://…/verification?request=req-abc123   "Open Submission"
without:    https://…/verification                      "Open Queue"
```

## Tests

Two new tests on the email builder (deep link, and the no-uuid fallback); the first fails against the code as it stood. One existing test asserted `link == "/verification"` and now pins the new value.

Backend: `test_verification_service.py` + `test_verification_routes.py` — 75 passed. Frontend verified with `npm run typecheck` (`tsc -b`) and `npm run build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
