### PR TITLE
fix(workflows): give a stopped batch run its own state

### DIFF
--- a/backend/app/services/workflow_service.py
+++ b/backend/app/services/workflow_service.py
@@ -909,6 +909,9 @@ async def get_batch_status(
         "total": total,
         "completed": completed,
         "failed": failed,
+        # Already computed above for the overall status, and the card needs it
+        # to say how much of a stopped batch actually ran.
+        "canceled": canceled,
         "items": items,
     }
 

--- a/backend/tests/test_workflow_service.py
+++ b/backend/tests/test_workflow_service.py
@@ -1457,3 +1457,33 @@ class TestCancelClearsTheReviewMarker:
         # Only the marker is dropped; the rest of meta_summary is untouched.
         assert act.meta_summary["kept"] == "yes"
         act.save.assert_awaited_once()
+
+
+class TestBatchStatusReportsCancelled:
+    @patch("app.services.workflow_service.WorkflowResult")
+    async def test_the_stopped_count_is_returned(self, mock_wr_cls):
+        """The count was computed to decide the overall status and then dropped,
+        so the card could say "3 of 20 completed" with no way to tell which of
+        the other 17 had actually run before the stop and which never started.
+        """
+        from app.services.workflow_service import get_batch_status
+
+        results = [
+            _make_result("s1", "completed"),
+            _make_result("s2", "canceled"),
+            _make_result("s3", "canceled"),
+            _make_result("s4", "queued"),
+        ]
+        mock_find = MagicMock()
+        mock_find.to_list = AsyncMock(return_value=results)
+        mock_wr_cls.find.return_value = mock_find
+
+        status = await get_batch_status("b1")
+
+        assert status["canceled"] == 2
+        assert status["completed"] == 1
+        assert status["total"] == 4
+        # Per-item status was always carried; it is what the row renders from.
+        assert [i["status"] for i in status["items"]] == [
+            "completed", "canceled", "canceled", "queued",
+        ]

--- a/frontend/src/api/workflows.ts
+++ b/frontend/src/api/workflows.ts
@@ -187,6 +187,9 @@ export interface BatchStatus {
   total: number
   completed: number
   failed: number
+  /** Runs stopped by the user. Optional so a client polling an older backend
+   *  still typechecks; treat absent as zero. */
+  canceled?: number
   items: BatchStatusItem[]
 }
 

--- a/frontend/src/components/workspace/WorkflowEditorPanel.tsx
+++ b/frontend/src/components/workspace/WorkflowEditorPanel.tsx
@@ -6,7 +6,7 @@ import {
   Bug, Search, Zap, Download, Package, CheckCircle, XCircle,
   MousePointerClick, PenTool, ClipboardCheck, Flag,
   ChevronDown, ChevronRight, ArrowUp, ArrowDown, GripVertical,
-  Circle, Hand, Keyboard, Sparkles, ShieldCheck, Type,
+  Circle, MinusCircle, Hand, Keyboard, Sparkles, ShieldCheck, Type,
   ArrowRight, Pause, TrendingUp, RefreshCw,
   Upload, Clock, Copy, Check, FolderInput, Link2, Info, AlertTriangle,
 } from 'lucide-react'
@@ -5528,6 +5528,9 @@ function BatchOutputCard({ batchId, batchStatus, running, runElapsed }: {
       <div style={{ fontSize: 13, color: '#6b7280', marginBottom: 8 }}>
         {batchStatus.completed} of {batchStatus.total} completed
         {batchStatus.failed > 0 && <span style={{ color: '#dc2626' }}> ({batchStatus.failed} failed)</span>}
+        {(batchStatus.canceled ?? 0) > 0 && (
+          <span style={{ color: '#b45309' }}> ({batchStatus.canceled} stopped)</span>
+        )}
         {running && <span> - {runElapsed}s elapsed</span>}
       </div>
 
@@ -5552,6 +5555,11 @@ function BatchOutputCard({ batchId, batchStatus, running, runElapsed }: {
           const itemDone = item.status === 'completed'
           const itemFailed = item.status === 'error' || item.status === 'failed'
           const itemRunning = item.status === 'running'
+          // Without its own state a stopped run falls through to the gray dot
+          // used for "queued", so a halted 20-document batch shows 17 identical
+          // dots and no way to tell which ones actually ran — which is the
+          // question someone asks immediately after pressing STOP.
+          const itemCanceled = item.status === 'canceled'
           const isExpanded = expandedIdx === idx
 
           return (
@@ -5567,13 +5575,14 @@ function BatchOutputCard({ batchId, batchStatus, running, runElapsed }: {
                 style={{
                   display: 'flex', alignItems: 'center', gap: 8, padding: '8px 12px',
                   cursor: itemDone ? 'pointer' : 'default',
-                  backgroundColor: itemDone ? '#f0fdf4' : itemFailed ? '#fef2f2' : '#fff',
+                  backgroundColor: itemDone ? '#f0fdf4' : itemFailed ? '#fef2f2' : itemCanceled ? '#fffbeb' : '#fff',
                 }}
               >
                 {itemDone && <CheckCircle style={{ width: 14, height: 14, color: '#16a34a', flexShrink: 0 }} />}
                 {itemFailed && <XCircle style={{ width: 14, height: 14, color: '#dc2626', flexShrink: 0 }} />}
                 {itemRunning && <Loader2 aria-hidden="true" style={{ width: 14, height: 14, color: '#6b7280', flexShrink: 0, animation: 'spin 1s linear infinite' }} />}
-                {!itemDone && !itemFailed && !itemRunning && <Circle style={{ width: 14, height: 14, color: '#d1d5db', flexShrink: 0 }} />}
+                {itemCanceled && <MinusCircle aria-label="Stopped" style={{ width: 14, height: 14, color: '#b45309', flexShrink: 0 }} />}
+                {!itemDone && !itemFailed && !itemRunning && !itemCanceled && <Circle style={{ width: 14, height: 14, color: '#d1d5db', flexShrink: 0 }} />}
                 <span style={{ fontSize: 13, color: '#374151', flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
                   {item.document_title || item.session_id}
                 </span>


### PR DESCRIPTION
Closes #670.

## The gap

`BatchOutputCard` gained an `isCanceled` **header** when batch cancellation shipped, but the **per-item** branch still classified on `completed` / `error|failed` / `running` only — so a canceled run fell through to the gray `Circle` used for `queued`.

Stopping a 20-document batch showed:

- header: "Batch Stopped"
- summary: "3 of 20 completed", a 15% bar
- and **17 identical gray dots**

with nothing to distinguish the runs that were actually going when you pressed STOP from the ones that never started. That's the first thing you want to know afterwards, because it decides what was already paid for and what still needs running.

## The change

The `canceled` count was already being computed in `get_batch_status` to decide the overall status, and then dropped — it's returned now. Per-item `status` was always on the wire, so the row only needed a branch for it.

- Canceled items get their own icon and an amber tint, matching the header's existing treatment.
- The summary gains a stopped count: `3 of 20 completed (17 stopped)`.

The new `canceled` field is **optional** on the client type, so a frontend polling an older backend still typechecks and just shows no stopped count.

## Tests

One new backend test pinning the returned count and the per-item statuses. Verified with `ruff check app/`, the workflow/batch backend suites (785 passed), and `npm run typecheck` (`tsc -b`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
