### PR TITLE
fix(viewer): hedge the page when the passage cannot be matched

### DIFF
--- a/frontend/src/components/chat/ChatMessage.tsx
+++ b/frontend/src/components/chat/ChatMessage.tsx
@@ -210,6 +210,9 @@ export function ChatMessage({ message, messageIndex, conversationUuid, streaming
     viewDocument(citation.document_uuid, citation.document_title, {
       terms: anchor ? [anchor] : [],
       page: citation.page ?? null,
+      // Same reason as the extraction path: the chip says "p. ~N" for an
+      // interpolated page, so the viewer's fallback must not drop the hedge.
+      pageApproximate: citation.page_approximate ?? false,
     })
   }
 

--- a/frontend/src/components/files/DocumentViewer.tsx
+++ b/frontend/src/components/files/DocumentViewer.tsx
@@ -20,6 +20,9 @@ interface DocumentViewerProps {
   // to prefer matches on that page, and to still jump the viewer there when
   // the passage can't be text-matched at all.
   highlightPage?: number | null
+  /** The cited page was interpolated from OCR text, not read from the
+   *  document's structure — so the viewer must not state it as fact. */
+  highlightPageApproximate?: boolean
   onClearHighlights?: () => void
   processing?: boolean
   taskStatus?: string | null
@@ -117,7 +120,25 @@ function highlightHtmlSearch(root: HTMLElement, query: string): number {
   return count
 }
 
-export function DocumentViewer({ docUuid, highlightTerms = [], highlightPage = null, onClearHighlights, processing, taskStatus }: DocumentViewerProps) {
+/** What to say when the passage could not be found in the document.
+ *
+ * The page only gets stated as fact when it was *read* from the document's
+ * structure. When it was interpolated from OCR text it is an estimate, and
+ * this fallback fires hardest on exactly those documents — the quote came out
+ * of the OCR text while the search runs against the PDF's own text layer, so
+ * the two routinely disagree. Asserting the page here is the conflation the
+ * "p. ~N" notation exists to prevent.
+ */
+export function highlightMissLabel(
+  page: number | null | undefined, approximate: boolean,
+): string {
+  if (page == null) return 'not found in this document'
+  return approximate
+    ? `passage not matched — showing approximately page ${page}`
+    : `passage not matched — showing page ${page}`
+}
+
+export function DocumentViewer({ docUuid, highlightTerms = [], highlightPage = null, highlightPageApproximate = false, onClearHighlights, processing, taskStatus }: DocumentViewerProps) {
   const [zoom, setZoom] = useState(2) // index into ZOOM_LEVELS, default 100%
   const [isPdf, setIsPdf] = useState<boolean | null>(null) // null = loading
   const [isSpreadsheet, setIsSpreadsheet] = useState(false)
@@ -1194,9 +1215,7 @@ export function DocumentViewer({ docUuid, highlightTerms = [], highlightPage = n
                 </span>
               ) : (
                 <span style={{ marginLeft: 6, color: '#b45309', fontWeight: 500 }}>
-                  {effectivePage != null
-                    ? `passage not matched — showing page ${effectivePage}`
-                    : 'not found in this document'}
+                  {highlightMissLabel(effectivePage, highlightPageApproximate)}
                 </span>
               )}
             </div>

--- a/frontend/src/components/files/highlightMissLabel.test.ts
+++ b/frontend/src/components/files/highlightMissLabel.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest'
+import { highlightMissLabel } from './DocumentViewer'
+
+// #626 made every page *label* hedge when the number was interpolated from OCR
+// text ("p. ~12"). This is the one place that still stated such a page as fact,
+// and it is the worst place for it: the fallback fires when the passage could
+// not be matched, which happens disproportionately on scanned documents —
+// the quote came out of OCR text while the search runs against the PDF's own
+// text layer. #626's benchmark puts the interpolated page a median 6 pages off,
+// correct 4.5% of the time on a 68-page proposal.
+
+describe('highlightMissLabel', () => {
+  it('states a measured page plainly', () => {
+    expect(highlightMissLabel(12, false)).toBe('passage not matched — showing page 12')
+  })
+
+  it('hedges a page that was estimated from OCR text', () => {
+    expect(highlightMissLabel(12, true)).toBe(
+      'passage not matched — showing approximately page 12',
+    )
+  })
+
+  it('never asserts an estimated page as exact', () => {
+    const label = highlightMissLabel(234, true)
+    expect(label).toContain('approximately')
+    expect(label).not.toMatch(/showing page \d/)
+  })
+
+  it('says nothing about a page when there is none', () => {
+    expect(highlightMissLabel(null, false)).toBe('not found in this document')
+    expect(highlightMissLabel(undefined, true)).toBe('not found in this document')
+  })
+
+  it('treats page 0 as a real page rather than absent', () => {
+    // `if (!page)` would swallow it; the guard is an explicit null check.
+    expect(highlightMissLabel(0, false)).toBe('passage not matched — showing page 0')
+  })
+})

--- a/frontend/src/components/workspace/ExtractionEditorPanel.tsx
+++ b/frontend/src/components/workspace/ExtractionEditorPanel.tsx
@@ -334,13 +334,19 @@ export function ExtractionEditorPanel() {
 
     const src: ExtractionFieldSource | undefined = resultSources[field]
     if (src && src.verified && src.quote) {
-      const highlight = { terms: [src.quote], page: src.page ?? null }
+      const highlight = {
+        terms: [src.quote],
+        page: src.page ?? null,
+        // The badge the user just clicked already reads "p. ~12" when the page
+        // is interpolated; the viewer must not then assert it as fact.
+        pageApproximate: src.page_approximate ?? false,
+      }
       if (src.document_uuid) {
         // Routes through the open-document request so this works even when
         // the source document isn't the one currently in the viewer.
         viewDocument(src.document_uuid, src.document_title ?? 'Document', highlight)
       } else {
-        setHighlightTerms(highlight.terms, highlight.page)
+        setHighlightTerms(highlight.terms, highlight.page, highlight.pageApproximate)
       }
       return
     }

--- a/frontend/src/components/workspace/LeftPanel.tsx
+++ b/frontend/src/components/workspace/LeftPanel.tsx
@@ -14,7 +14,7 @@ import { addDocumentsToKB } from '../../api/knowledge'
 import type { Folder } from '../../types/document'
 
 export function LeftPanel() {
-  const { setSelectedDocUuids, setSelectedDocNames, setSelectedFolderUuids, highlightTerms, highlightPage, setHighlightTerms, setProcessingDoc, setSelectedDocsProcessing, viewDocumentRequest, clearViewDocumentRequest, focusChat, openWorkflow, activeProjectRootFolder, activeProjectTitle, activeProjectTeamId, workspaceMode, setOpenDocumentUuid } = useWorkspace()
+  const { setSelectedDocUuids, setSelectedDocNames, setSelectedFolderUuids, highlightTerms, highlightPage, highlightPageApproximate, setHighlightTerms, setProcessingDoc, setSelectedDocsProcessing, viewDocumentRequest, clearViewDocumentRequest, focusChat, openWorkflow, activeProjectRootFolder, activeProjectTitle, activeProjectTeamId, workspaceMode, setOpenDocumentUuid } = useWorkspace()
   const { toast } = useToast()
   // Folder targeted by the workflow / KB picker modals (null = closed).
   const [workflowPickerFolder, setWorkflowPickerFolder] = useState<Folder | null>(null)
@@ -115,7 +115,11 @@ export function LeftPanel() {
       setSelectedDocUuids([viewDocumentRequest.uuid])
       setSelectedDocNames({ [viewDocumentRequest.uuid]: viewDocumentRequest.title })
       if (viewDocumentRequest.highlight) {
-        setHighlightTerms(viewDocumentRequest.highlight.terms, viewDocumentRequest.highlight.page)
+        setHighlightTerms(
+          viewDocumentRequest.highlight.terms,
+          viewDocumentRequest.highlight.page,
+          viewDocumentRequest.highlight.pageApproximate,
+        )
       } else {
         setHighlightTerms([])
       }
@@ -327,6 +331,7 @@ export function LeftPanel() {
             docUuid={viewingDoc.uuid}
             highlightTerms={highlightTerms}
             highlightPage={highlightPage}
+            highlightPageApproximate={highlightPageApproximate}
             onClearHighlights={() => setHighlightTerms([])}
             processing={viewingDoc.processing}
             taskStatus={viewingDoc.taskStatus}

--- a/frontend/src/contexts/WorkspaceContext.tsx
+++ b/frontend/src/contexts/WorkspaceContext.tsx
@@ -12,7 +12,7 @@ export type WorkspaceMode = 'chat' | 'files' | 'automations' | 'knowledge' | 'pr
 export interface ViewDocumentRequest {
   uuid: string
   title: string
-  highlight?: { terms: string[]; page: number | null }
+  highlight?: { terms: string[]; page: number | null; pageApproximate?: boolean }
 }
 
 export interface PendingExtractionResults {
@@ -130,7 +130,14 @@ interface UIStateContextValue {
   // source tracking) — lets the viewer jump to the right page even when the
   // passage itself can't be text-matched.
   highlightPage: number | null
-  setHighlightTerms: (terms: string[], page?: number | null) => void
+  // True when that page was interpolated from OCR text rather than read from
+  // the document's own structure, so the viewer can hedge instead of asserting
+  // it. Travels with the page for the same reason the page travels with the
+  // terms: a stale flag on a new highlight would be worse than none.
+  highlightPageApproximate: boolean
+  setHighlightTerms: (
+    terms: string[], page?: number | null, pageApproximate?: boolean,
+  ) => void
   activitySignal: number
   bumpActivitySignal: () => void
   viewDocumentRequest: ViewDocumentRequest | null
@@ -259,11 +266,16 @@ export function WorkspaceProvider({ children }: { children: ReactNode }) {
   const [pendingChatMessage, setPendingChatMessage] = useState<PendingChatMessage | null>(null)
   const [highlightTerms, _setHighlightTerms] = useState<string[]>([])
   const [highlightPage, setHighlightPage] = useState<number | null>(null)
-  // Terms and their page hint always move together — a stale page from a
-  // previous highlight must never survive a new set/clear.
-  const setHighlightTerms = useCallback((terms: string[], page?: number | null) => {
+  const [highlightPageApproximate, setHighlightPageApproximate] = useState(false)
+  // Terms, their page hint and whether that page is an estimate always move
+  // together — a stale value from a previous highlight must never survive a
+  // new set/clear.
+  const setHighlightTerms = useCallback((
+    terms: string[], page?: number | null, pageApproximate?: boolean,
+  ) => {
     _setHighlightTerms(terms)
     setHighlightPage(page ?? null)
+    setHighlightPageApproximate(Boolean(pageApproximate))
   }, [])
   const [activitySignal, setActivitySignal] = useState(0)
   const [processingDoc, setProcessingDoc] = useState<{ title: string; status: string | null } | null>(null)
@@ -700,7 +712,7 @@ export function WorkspaceProvider({ children }: { children: ReactNode }) {
     selectedFolderUuids, setSelectedFolderUuids,
     railDocked, toggleRailDocked,
     panelSplit, setPanelSplit,
-    highlightTerms, highlightPage, setHighlightTerms,
+    highlightTerms, highlightPage, highlightPageApproximate, setHighlightTerms,
     activitySignal, bumpActivitySignal,
     viewDocumentRequest, viewDocument, clearViewDocumentRequest,
     openDocumentUuid, setOpenDocumentUuid,
@@ -708,7 +720,7 @@ export function WorkspaceProvider({ children }: { children: ReactNode }) {
     selectedDocUuids, selectedDocNames, selectedFolderUuids,
     railDocked, toggleRailDocked,
     panelSplit, setPanelSplit,
-    highlightTerms, highlightPage, setHighlightTerms,
+    highlightTerms, highlightPage, highlightPageApproximate, setHighlightTerms,
     activitySignal, bumpActivitySignal,
     viewDocumentRequest, viewDocument, clearViewDocumentRequest,
     openDocumentUuid,


### PR DESCRIPTION
Closes #667.

## The gap

#626 made every page **label** hedge when the number was interpolated from OCR text rather than read from the document's structure — `p. ~12`. The viewer's passage-not-found fallback was the one place still stating such a page as fact:

```
passage not matched — showing page 12
```

And it's the worst possible place for it. That fallback fires *disproportionately on scanned documents*: the quote came out of the OCR text while the search runs against the PDF's own text layer, so the two routinely disagree. #626's own benchmark puts the interpolated page a **median 6 pages off**, correct **4.5%** of the time on a 68-page proposal.

So the message asserted a page number at exactly the moment it was least likely to be right — immediately after the user clicked a badge that already read `p. ~12`.

## The change

The flag travels with the page it qualifies, the same way the page already travels with the terms:

`ViewDocumentRequest.highlight` → `setHighlightTerms(terms, page, pageApproximate)` → `LeftPanel` → `DocumentViewer`

The context setter clears all three together, so a stale flag can't survive a new highlight — the same invariant the page hint already had.

**Four call sites feed it**, not just the one in the issue:

- the extraction click-through
- its `else` branch, for when the document is already open (same bug)
- the chat citation path, which had the same gap and already carried `page_approximate`

## Result

```
measured page:   passage not matched — showing page 12
estimated page:  passage not matched — showing approximately page 12
no page at all:  not found in this document
```

## Tests

The message is extracted as `highlightMissLabel` so it can be tested without the DOM plumbing. Five tests, including that an estimated page never renders as `showing page N`, and that page `0` is treated as a real page rather than absent.

Verified with `npm run typecheck` (`tsc -b`) and `npm run build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
