### PR TITLE
fix(chat): flip the citation menu when it would open past the panel edge

### DIFF
--- a/frontend/src/components/chat/ChatMessage.tsx
+++ b/frontend/src/components/chat/ChatMessage.tsx
@@ -84,6 +84,39 @@ interface Props {
   isStreaming?: boolean
 }
 
+/** The nearest ancestor that clips its contents horizontally.
+ *
+ * A container with `overflow-y: auto` computes `overflow-x` to `auto` too, per
+ * CSS — so the chat scroller clips sideways even though nothing asked it to,
+ * and `hide-scrollbar` removes the scrollbar that would otherwise let a reader
+ * reach what spilled out.
+ */
+function clippingAncestor(el: HTMLElement | null): HTMLElement | null {
+  let node = el?.parentElement ?? null
+  while (node && node !== document.body) {
+    const { overflowX, overflowY } = getComputedStyle(node)
+    if (overflowX !== 'visible' || overflowY !== 'visible') return node
+    node = node.parentElement
+  }
+  return null
+}
+
+/** Align the menu to the pill's right edge when left-aligning would overflow.
+ *
+ * Returns the alignment to use. Flipping is only worth it if the menu actually
+ * fits that way — otherwise it would be clipped on the other side instead, and
+ * left-aligned at least keeps the first item reachable.
+ */
+export function menuAlignmentFor(
+  pillLeft: number, pillRight: number, menuWidth: number,
+  containerLeft: number, containerRight: number,
+): 'left' | 'right' {
+  const fitsLeftAligned = pillLeft + menuWidth <= containerRight
+  if (fitsLeftAligned) return 'left'
+  const fitsRightAligned = pillRight - menuWidth >= containerLeft
+  return fitsRightAligned ? 'right' : 'left'
+}
+
 export function ChatMessage({ message, messageIndex, conversationUuid, streamingThinking, thinkingDuration, isStreaming: isStreamingProp }: Props) {
   const isUser = message.role === 'user'
   const [feedback, setFeedback] = useState<'up' | 'down' | null>(null)
@@ -95,6 +128,11 @@ export function ChatMessage({ message, messageIndex, conversationUuid, streaming
   const [openCitation, setOpenCitation] = useState<number | null>(null)
   // Citation whose Preview/Open chooser is showing (null = none).
   const [citationMenu, setCitationMenu] = useState<number | null>(null)
+  // The menu is absolutely positioned inside the chat scroller, which clips
+  // horizontally; in files mode the panel is ~half width, so the last pill on
+  // a row opens a menu that runs off the edge with no scrollbar to reach it.
+  const [menuAlign, setMenuAlign] = useState<'left' | 'right'>('left')
+  const menuRef = useRef<HTMLDivElement | null>(null)
   const contentRef = useRef<HTMLDivElement>(null)
   const citationsRef = useRef<HTMLDivElement>(null)
   const certPanel = useCertificationPanel()
@@ -181,6 +219,24 @@ export function ChatMessage({ message, messageIndex, conversationUuid, streaming
       document.removeEventListener('mousedown', onPointerDown)
       document.removeEventListener('keydown', onKeyDown)
     }
+  }, [citationMenu])
+
+  useEffect(() => {
+    if (citationMenu === null) {
+      setMenuAlign('left')
+      return
+    }
+    const menu = menuRef.current
+    const pill = menu?.parentElement
+    if (!menu || !pill) return
+    const container = clippingAncestor(menu)
+    const bounds = container?.getBoundingClientRect()
+    const left = bounds?.left ?? 0
+    const right = bounds?.right ?? document.documentElement.clientWidth
+    const pillRect = pill.getBoundingClientRect()
+    setMenuAlign(menuAlignmentFor(
+      pillRect.left, pillRect.right, menu.offsetWidth, left, right,
+    ))
   }, [citationMenu])
 
   const toggleCitationPreview = (index: number) => {
@@ -356,9 +412,11 @@ export function ChatMessage({ message, messageIndex, conversationUuid, streaming
                         {menuOpen && (
                           <div
                             role="menu"
+                            ref={menuRef}
                             aria-label={`Source: ${label}`}
                             style={{
-                              position: 'absolute', top: 'calc(100% + 4px)', left: 0,
+                              position: 'absolute', top: 'calc(100% + 4px)',
+                              ...(menuAlign === 'right' ? { right: 0 } : { left: 0 }),
                               zIndex: 30, minWidth: 150, padding: 4,
                               backgroundColor: '#fff', border: '1px solid #e5e7eb',
                               borderRadius: 8, boxShadow: '0 4px 12px rgba(0,0,0,0.12)',

--- a/frontend/src/components/chat/menuAlignment.test.ts
+++ b/frontend/src/components/chat/menuAlignment.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest'
+import { menuAlignmentFor } from './ChatMessage'
+
+// The citation menu is absolutely positioned inside the chat scroller. A
+// container with overflow-y: auto computes overflow-x to auto as well, and
+// `hide-scrollbar` removes the scrollbar that would let a reader reach what
+// spilled out — so a menu running past the right edge is simply unreachable.
+// In files mode the panel is roughly half width, which is when it bites.
+
+const MENU = 150
+
+describe('menuAlignmentFor', () => {
+  it('left-aligns a pill with room to spare', () => {
+    // container 0..800, pill at 100 — 150px menu ends at 250, well inside.
+    expect(menuAlignmentFor(100, 160, MENU, 0, 800)).toBe('left')
+  })
+
+  it('flips a pill near the right edge', () => {
+    // pill at 700..760 in an 800-wide panel: left-aligned the menu would end
+    // at 850, past the edge and unreachable.
+    expect(menuAlignmentFor(700, 760, MENU, 0, 800)).toBe('right')
+  })
+
+  it('treats exactly fitting as fitting', () => {
+    expect(menuAlignmentFor(650, 710, MENU, 0, 800)).toBe('left')
+  })
+
+  it('stays left when neither side fits, keeping the first item reachable', () => {
+    // A container narrower than the menu: flipping would clip the other edge
+    // instead, which is no better and hides the first item rather than the last.
+    expect(menuAlignmentFor(10, 60, MENU, 0, 100)).toBe('left')
+  })
+
+  it('respects a container that does not start at zero', () => {
+    // The panel is offset from the viewport in files mode.
+    expect(menuAlignmentFor(900, 960, MENU, 500, 1000)).toBe('right')
+    expect(menuAlignmentFor(520, 580, MENU, 500, 1000)).toBe('left')
+  })
+
+  it('still flips a pill sitting past the container edge', () => {
+    // Degenerate — pills cannot actually escape a vertically-scrolling
+    // container — but the answer should not get worse: right-aligning puts the
+    // menu at 1110..1260 rather than 1200..1350, i.e. nearer the container,
+    // not further out.
+    expect(menuAlignmentFor(1200, 1260, MENU, 0, 800)).toBe('right')
+  })
+})


### PR DESCRIPTION
Closes #665.

## The bug

The citation source menu is absolutely positioned and left-aligned to its pill:

```
position: absolute, top: calc(100% + 4px), left: 0, minWidth: 150
```

Its nearest clipping ancestor is the chat scroller (`flex-1 overflow-y-auto hide-scrollbar`). Per CSS, a container with `overflow-y: auto` computes `overflow-x` to `auto` too — so it clips horizontally even though nothing asked it to — and `hide-scrollbar` removes the scrollbar that would otherwise let a reader reach what spilled out.

In **files mode** the chat panel sits at roughly half width, citation pills wrap, and the last pill on a row opens a menu that runs off the right edge with no way to get to it.

## The fix

The menu measures itself against that clipping ancestor once it's in the DOM and right-aligns when left-aligning would overflow.

It only flips **if the menu actually fits that way**. Otherwise it stays left-aligned — clipping the other edge instead is no improvement, and it would hide the *first* item rather than the last.

The ancestor walk is what finds the clipping container, since the overflow doing the clipping isn't declared on any element deliberately — it's the computed side-effect of `overflow-y`.

## Tests

Six tests on the geometry, which is extracted as a pure `menuAlignmentFor` so it can be checked without the DOM: room to spare, near the right edge, exactly fitting, container narrower than the menu, a container offset from the viewport (files mode), and a degenerate pill past the edge.

## What I could not verify

The alignment arithmetic is tested and the existing chat suites pass (21 tests), but **the DOM measurement path itself is not covered** — that needs the app running with the panel at a narrow width. Worth a visual check at a few widths before merging:

- chat at full width — menus should be unchanged, left-aligned
- files mode (~50%) — the last pill on a wrapped row should open leftward and stay fully visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)
