### PR TITLE
fix(budget): size a request in the ruler of the model being offered it

### DIFF
--- a/backend/app/services/context_budget.py
+++ b/backend/app/services/context_budget.py
@@ -63,20 +63,25 @@ DEFAULT_TOKENIZER_CACHE_ROOT = "/hf-cache"
 
 
 @lru_cache(maxsize=1)
-def _settings_tokenizer_cache_root() -> str:
-    """The deployment-wide cache root, or "" when it cannot be read.
+def _settings_tokenizer_cache_root() -> str | None:
+    """The deployment-wide cache root, or None when settings cannot be read.
+
+    None means "no answer", not "no root". Settings already carries the default,
+    so an empty string here is an operator explicitly turning discovery off —
+    collapsing the two made ``TOKENIZER_CACHE_ROOT=`` fall through to the
+    hardcoded default and quietly ignore the opt-out.
 
     Cached because this is consulted on every token count. Deliberately
-    forgiving: a settings failure must degrade to the default, not take down
-    the budget planner and with it chat.
+    forgiving: a settings failure degrades to the default rather than taking
+    down the budget planner and with it chat.
     """
     try:
         from app.config import Settings
 
-        return Settings().tokenizer_cache_root or ""
+        return Settings().tokenizer_cache_root
     except Exception:  # pragma: no cover - defensive
         logger.debug("could not read tokenizer_cache_root from settings")
-        return ""
+        return None
 
 # Tokens a request costs beyond the text it carries.
 #
@@ -182,8 +187,12 @@ def _find_vocabulary(model_name: str, cache_root: str) -> Optional[str]:
 
     "Qwen/Qwen3-VL-8B-Instruct" lives at
     ``<root>/hub/models--Qwen--Qwen3-VL-8B-Instruct/snapshots/<rev>/``.
-    Newest snapshot wins, so a re-pulled model is picked up without config
-    changes.
+    Newest snapshot wins at the time of lookup.
+
+    Note the lookup is cached on ``(model_name, cache_root)``, and the loader on
+    the resolved path, so a model re-pulled while the process is running keeps
+    serving the snapshot found first. Picking up a new one needs a restart —
+    which is worth knowing before relying on "newest wins" operationally.
     """
     if not model_name or not cache_root:
         return None
@@ -220,11 +229,14 @@ def resolve_exact_tokenizer(model_name: str, model_config: Optional[dict] = None
     if explicit:
         return _load_tokenizer(str(explicit))
 
-    root = (
-        cfg.get("tokenizer_cache_root")
-        or _settings_tokenizer_cache_root()
-        or DEFAULT_TOKENIZER_CACHE_ROOT
-    )
+    root = cfg.get("tokenizer_cache_root")
+    if root is None:
+        settings_root = _settings_tokenizer_cache_root()
+        root = settings_root if settings_root is not None else DEFAULT_TOKENIZER_CACHE_ROOT
+    if not root:
+        # Explicitly emptied, at either level: discovery is off. Falling back to
+        # the default here is what made the opt-out unreachable.
+        return None
     path = _find_vocabulary(model_name or "", str(root))
     return _load_tokenizer(path) if path else None
 
@@ -268,18 +280,29 @@ def token_safety_margin(
     Returns 1.0 for OpenAI models, where the count is exact and inflating it
     would only trigger premature routing.
 
-    An explicit ``token_safety_margin`` on the model config wins for any model,
-    so a deployment can tune against its own measurements. A configured value
-    below 1.0 is refused — that re-creates the original bug by configuration,
-    leaving the planner optimistic in the direction that hard-fails.
+    An explicit ``token_safety_margin`` on the model config wins for any model
+    whose count is an *estimate*, so a deployment can tune against its own
+    measurements. A configured value below 1.0 is refused — that re-creates the
+    original bug by configuration, leaving the planner optimistic in the
+    direction that hard-fails.
+
+    Exactness beats a configured margin. The guidance for a model with no local
+    vocabulary is to set this value; when that deployment later mounts its model
+    cache, those models start counting exactly and the configured number becomes
+    a stale second correction applied on top of a figure that needs none —
+    inflating every budget, and making every trim over-aggressive by the same
+    factor through ``raw_usable``. ``stored_count_margin`` still honours the
+    configured value: it corrects a tiktoken figure taken at ingestion, which is
+    not the same question.
     """
+    # An exact count needs no correction. Inflating it would only route early.
+    if resolve_exact_tokenizer(model_name, model_config) is not None:
+        return 1.0
+
     configured = _configured_margin(model_name, model_config)
     if configured is not None:
         return configured
 
-    # An exact count needs no correction. Inflating it would only route early.
-    if resolve_exact_tokenizer(model_name, model_config) is not None:
-        return 1.0
     if _is_openai_model(model_name):
         return 1.0
     _warn_estimated_once(model_name or "<unnamed>")

--- a/backend/app/services/model_routing.py
+++ b/backend/app/services/model_routing.py
@@ -17,7 +17,7 @@ the user's behalf.
 from dataclasses import dataclass
 from typing import Optional
 
-from app.services.context_budget import input_budget_for
+from app.services.context_budget import input_budget_for, token_safety_margin
 
 # Lower is stricter. An unlabelled model is treated as *less* protected than
 # one explicitly marked internal: `privacy` has never been enforced anywhere in
@@ -44,6 +44,35 @@ class RoutingDecision:
     model_name: str
     switched: bool
     reason: str
+
+
+def _sized_for(
+    input_tokens: int,
+    current_name: str, current_config: Optional[dict],
+    other_name: str, other_config: Optional[dict],
+) -> int:
+    """``input_tokens`` restated in *other*'s units, never smaller.
+
+    The caller measures the request once, with the model the user is on. That
+    number carries *that* model's safety margin — 1.0 where the count is exact
+    (a local vocabulary, or OpenAI), 1.20 where it is an estimate. Comparing it
+    against another model's budget silently mixes rulers: a request measured
+    exactly looks like it fits a model whose own count would come out 20%
+    higher, the router switches, and that model rejects it. That is the
+    "estimate reads low, so we fail" failure the margin exists to prevent,
+    relocated to the routing boundary.
+
+    Re-measuring per candidate would mean re-tokenizing the whole prompt for
+    each one, so the margin is rescaled instead. Where the two models tokenize
+    differently the rescale is approximate — which is why it only ever rounds
+    *up*: over-stating routes a request early, which costs the user nothing but
+    a larger model, while under-stating hard-fails the request outright.
+    """
+    current_margin = token_safety_margin(current_name, current_config)
+    other_margin = token_safety_margin(other_name, other_config)
+    if other_margin <= current_margin or current_margin <= 0:
+        return input_tokens
+    return int(input_tokens / current_margin * other_margin)
 
 
 def choose_document_model(
@@ -78,7 +107,10 @@ def choose_document_model(
         return stay
 
     candidate_budget = input_budget_for(candidate_name, candidate_config)
-    if input_tokens > candidate_budget:
+    candidate_tokens = _sized_for(
+        input_tokens, current_name, current_config, candidate_name, candidate_config,
+    )
+    if candidate_tokens > candidate_budget:
         return RoutingDecision(
             current_name,
             False,
@@ -130,7 +162,8 @@ def suggest_document_model(
         if m.get("name")
         and m.get("name") != current_name
         and _privacy_rank(m) <= current_rank
-        and input_tokens <= input_budget_for(m.get("name", ""), m)
+        and _sized_for(input_tokens, current_name, current_config, m.get("name", ""), m)
+        <= input_budget_for(m.get("name", ""), m)
     ]
     if not fits:
         return None

--- a/backend/tests/test_context_budget.py
+++ b/backend/tests/test_context_budget.py
@@ -746,3 +746,84 @@ def test_a_tokenizer_that_cannot_encode_is_treated_as_absent(tmp_path, monkeypat
     assert cb.token_safety_margin("Fake/Broken", cfg) > 1.0, (
         "the margin stayed at 1.0 for a model whose count is not exact"
     )
+
+
+# ---------------------------------------------------------------------------
+# Configuration: what wins, and how discovery is turned off
+# ---------------------------------------------------------------------------
+
+
+def test_an_exact_count_is_not_multiplied_by_a_stale_configured_margin(tmp_path, monkeypatch):
+    """The guidance for a model with no local vocabulary is to configure a
+    margin. When that deployment later mounts its model cache — the headline
+    feature — those models start counting exactly, and the configured number
+    becomes a second correction applied to a figure that needs none: every
+    budget inflated, and every trim over-aggressive by the same factor through
+    raw_usable.
+    """
+    from app.services import context_budget as cb
+
+    _write_tokenizer(tmp_path, "Fake--Exact", dict(_MINIMAL_VOCAB, truncation=None, padding=None))
+    cb._find_vocabulary.cache_clear()
+    cb._load_tokenizer.cache_clear()
+
+    cfg = {"tokenizer_cache_root": str(tmp_path), "token_safety_margin": 1.35}
+    assert cb.token_safety_margin("Fake/Exact", cfg) == 1.0, (
+        "a configured margin was applied on top of an exact count"
+    )
+
+
+def test_a_configured_margin_still_wins_for_an_estimated_model(tmp_path):
+    """The setting is not ignored — it is the whole point for models whose
+    count is an estimate."""
+    from app.services import context_budget as cb
+
+    cfg = {"tokenizer_cache_root": str(tmp_path), "token_safety_margin": 1.35}
+    assert cb.token_safety_margin("some/hosted-model", cfg) == 1.35
+
+
+def test_an_emptied_cache_root_turns_discovery_off(tmp_path, monkeypatch):
+    """`TOKENIZER_CACHE_ROOT=` is how an operator opts out. Collapsing "unset"
+    and "set to empty" made it fall through to the hardcoded /hf-cache and
+    quietly ignore them.
+    """
+    from app.services import context_budget as cb
+
+    _write_tokenizer(tmp_path, "Fake--Findable", dict(_MINIMAL_VOCAB, truncation=None, padding=None))
+    cb._find_vocabulary.cache_clear()
+    cb._load_tokenizer.cache_clear()
+    cb._settings_tokenizer_cache_root.cache_clear()
+
+    # The default root has to be findable for this to discriminate: otherwise
+    # an ignored opt-out and an honoured one both return None, for different
+    # reasons, and the test proves nothing.
+    monkeypatch.setattr(cb, "DEFAULT_TOKENIZER_CACHE_ROOT", str(tmp_path))
+
+    # Present when the root points at it...
+    assert cb.resolve_exact_tokenizer(
+        "Fake/Findable", {"tokenizer_cache_root": str(tmp_path)},
+    ) is not None
+
+    # ...and gone when the operator empties the root, rather than silently
+    # falling through to the default and loading it anyway.
+    assert cb.resolve_exact_tokenizer(
+        "Fake/Findable", {"tokenizer_cache_root": ""},
+    ) is None
+
+    monkeypatch.setattr(cb, "_settings_tokenizer_cache_root", lambda: "")
+    assert cb.resolve_exact_tokenizer("Fake/Findable", {}) is None
+
+
+def test_an_unreadable_settings_object_still_falls_back_to_the_default(tmp_path, monkeypatch):
+    """None means "no answer" and must not be mistaken for "no root"."""
+    from app.services import context_budget as cb
+
+    _write_tokenizer(tmp_path, "Fake--Defaulted", dict(_MINIMAL_VOCAB, truncation=None, padding=None))
+    cb._find_vocabulary.cache_clear()
+    cb._load_tokenizer.cache_clear()
+    monkeypatch.setattr(cb, "DEFAULT_TOKENIZER_CACHE_ROOT", str(tmp_path))
+    monkeypatch.setattr(cb, "_settings_tokenizer_cache_root", lambda: None)
+
+    # Falls back to the default and finds it, rather than reading the failure
+    # as an operator opt-out.
+    assert cb.resolve_exact_tokenizer("Fake/Defaulted", {}) is not None

--- a/backend/tests/test_model_routing.py
+++ b/backend/tests/test_model_routing.py
@@ -202,3 +202,82 @@ class TestSuggestingAModel:
         assert suggest_document_model(
             current_name="small", current_config=SMALL, models=[], input_tokens=41213,
         ) is None
+
+
+class TestSizingAgainstTheCandidate:
+    """The request is measured once, with the model the user is on.
+
+    That number carries *that* model's safety margin — 1.0 where the count is
+    exact (a local vocabulary, or OpenAI), 1.20 where it is an estimate.
+    Comparing it against another model's budget mixes rulers: a request
+    measured exactly looks like it fits a model whose own count comes out 20%
+    higher, the router switches, and the model rejects the request. That is the
+    "estimate reads low, so we hard-fail" failure the margin exists to prevent,
+    relocated to the routing boundary.
+    """
+
+    def test_an_exact_count_is_inflated_before_it_is_offered_to_an_estimated_model(self):
+        # gpt-4o counts exactly (margin 1.0). The candidate has no local
+        # vocabulary, so its own count would run ~20% higher.
+        current = _model("gpt-4o", 32768)
+        candidate = _model("some-hosted-model", 100_000)
+
+        # Sized on the current model's ruler this sits just inside the
+        # candidate's budget; on the candidate's own ruler it does not.
+        tokens = 88_000
+
+        d = choose_document_model(
+            current_name="gpt-4o",
+            current_config=current,
+            candidate_name="some-hosted-model",
+            candidate_config=candidate,
+            input_tokens=tokens,
+        )
+        assert d.switched is False, (
+            "routed to a model that would have rejected the request"
+        )
+        assert "does not fit" in d.reason
+
+    def test_a_request_that_genuinely_fits_still_routes(self):
+        current = _model("gpt-4o", 32768)
+        candidate = _model("some-hosted-model", 262_144)
+        d = choose_document_model(
+            current_name="gpt-4o",
+            current_config=current,
+            candidate_name="some-hosted-model",
+            candidate_config=candidate,
+            input_tokens=41_213,
+        )
+        assert d.switched is True
+        assert d.model_name == "some-hosted-model"
+
+    def test_a_stricter_candidate_ruler_never_shrinks_the_estimate(self):
+        # Reverse direction: current is estimated (1.20), candidate exact (1.0).
+        # Rescaling down would make the request look smaller than measured, so
+        # the number is left alone — over-stating costs a bigger model, while
+        # under-stating hard-fails.
+        current = _model("some-hosted-model", 32768)
+        candidate = _model("gpt-4o", 50_000)
+        d = choose_document_model(
+            current_name="some-hosted-model",
+            current_config=current,
+            candidate_name="gpt-4o",
+            candidate_config=candidate,
+            input_tokens=45_000,
+        )
+        # 45k already exceeds gpt-4o's usable budget; it must not be scaled down
+        # into fitting.
+        assert d.switched is False
+
+    def test_the_suggestion_list_uses_each_candidate_ruler(self):
+        current = _model("gpt-4o", 32768)
+        estimated = _model("hosted-a", 100_000)
+        suggestion = suggest_document_model(
+            current_name="gpt-4o",
+            current_config=current,
+            models=[estimated],
+            input_tokens=88_000,
+        )
+        assert suggestion is None, (
+            "offered a model whose own count would not fit the request"
+        )


### PR DESCRIPTION
Closes #666.

## The main bug: routing mixes rulers

The request is measured **once**, with the model the user is on:

```python
requested_input_tokens = estimate_input_tokens(..., model_config=model_config)
```

That number carries *that* model's safety margin — `1.0` where the count is exact (a local vocabulary, or OpenAI), `1.20` where it's an estimate. Both `choose_document_model` and `suggest_document_model` then compare it against **another** model's budget.

So when the current model counts exactly and the candidate has no local vocabulary, the router sees an uninflated number fit the candidate, switches, and the candidate rejects the request. That's the same "estimate reads low, so we hard-fail" failure the margin exists to prevent — relocated to the routing boundary, which is exactly where #648 left it.

### The fix, and why it rescales rather than re-measures

Re-measuring per candidate means re-tokenizing the whole prompt for every model considered. So the margin is rescaled instead — and only ever **upward**:

```python
if other_margin <= current_margin: return input_tokens
return int(input_tokens / current_margin * other_margin)
```

Where two models tokenize differently the rescale is approximate. The asymmetry isn't: over-stating routes a request early, which costs the user a larger model; under-stating fails the request outright. Rounding up is the only safe direction, and it's the direction the margin already encodes.

## Three config gaps in the same area

**An exact count is no longer multiplied by a configured margin.** The guidance for a model with no local vocabulary is to set `token_safety_margin`. When that deployment later mounts its model cache — the headline feature of #648 — those models start counting exactly and the configured number becomes a stale *second* correction on a figure that needs none: every budget inflated, and every trim over-aggressive by the same factor through `raw_usable`.

It still applies to estimated models, which is its whole point. `stored_count_margin` is untouched — that corrects a tiktoken figure taken at ingestion, a different question.

**`TOKENIZER_CACHE_ROOT=` now turns discovery off.** "Unset" and "set to empty" were collapsed to the same empty string, which fell through to the hardcoded `/hf-cache`, so the operator's explicit opt-out was ignored. A `None` from the settings read means "no answer" and still falls back to the default.

**`_find_vocabulary`'s docstring** claimed a re-pulled model is picked up without config changes; the `lru_cache` on it and on the loader prevent that until a restart. Replaced with what actually happens.

## Tests

Eight new; **four fail against the code as it stood**.

Worth noting one: my first version of the opt-out test passed both fixed and unfixed, because nothing is mounted at the default root either way — an ignored opt-out and an honoured one both returned `None`, for different reasons. It now points the default root at the fixture so it actually discriminates.

`ruff check app/` clean. Full backend suite: **3648 passed**, 165 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
