### PR TITLE
fix(scripts): make the orphan cleanup safe to interrupt and to run alongside a user

### DIFF
--- a/backend/scripts/adopt_orphaned_workflows.py
+++ b/backend/scripts/adopt_orphaned_workflows.py
@@ -160,9 +160,15 @@ async def adopt(dry_run: bool = False, only_user: str | None = None) -> dict[str
     skipped_referenced = 0
     by_owner: dict[str, int] = defaultdict(int)
     lib_cache: dict[str, Library] = {}
-    # Batch the appends so each owner's library is written once, not once per
-    # orphan — some accounts have hundreds.
-    pending: dict[str, list[PydanticObjectId]] = defaultdict(list)
+
+    # Phase 1 — scan only, writing nothing.
+    #
+    # Writing inside the cursor loop held it open across every insert, so a
+    # ten-minute cursor expiry, a crash or a Ctrl-C left behind LibraryItem rows
+    # that no library referenced: invisible, and re-running inserted a second
+    # set rather than reusing them, so each attempt added more. Collecting the
+    # orphans first closes the cursor before anything is written.
+    orphans_by_owner: dict[str, list[Workflow]] = defaultdict(list)
 
     query = {"user_id": only_user} if only_user else {}
     async for wf in Workflow.find(query):
@@ -177,27 +183,36 @@ async def adopt(dry_run: bool = False, only_user: str | None = None) -> dict[str
         by_owner[owner] += 1
         adopted += 1
         print(f"  orphan: {wf.name!r}  id={wf.id}  owner={owner}")
-        if dry_run:
-            continue
+        orphans_by_owner[owner].append(wf)
 
-        lib = await _personal_library(owner, lib_cache)
-        li = LibraryItem(
-            item_id=wf.id,
-            kind=LibraryItemKind.WORKFLOW,
-            added_by_user_id=owner,
-            verified=bool(wf.verified),
-            created_at=wf.created_at,
-        )
-        await li.insert()
-        pending[owner].append(li.id)
-
+    # Phase 2 — write, one owner at a time.
     if not dry_run:
         now = datetime.datetime.now(datetime.timezone.utc)
-        for owner, item_ids in pending.items():
-            lib = lib_cache[owner]
-            lib.items.extend(item_ids)
-            lib.updated_at = now
-            await lib.save()
+        for owner, workflows in orphans_by_owner.items():
+            lib = await _personal_library(owner, lib_cache)
+            item_ids: list[PydanticObjectId] = []
+            for wf in workflows:
+                li = LibraryItem(
+                    item_id=wf.id,
+                    kind=LibraryItemKind.WORKFLOW,
+                    added_by_user_id=owner,
+                    verified=bool(wf.verified),
+                    created_at=wf.created_at,
+                )
+                await li.insert()
+                item_ids.append(li.id)
+
+            # $push rather than save(). save() writes the whole items array from
+            # the snapshot read when the library was first fetched, so anything
+            # the owner bookmarked while the script ran would be overwritten
+            # away — creating a fresh orphan of exactly the kind this repairs.
+            await Library.get_motor_collection().update_one(
+                {"_id": lib.id},
+                {
+                    "$push": {"items": {"$each": item_ids}},
+                    "$set": {"updated_at": now},
+                },
+            )
 
     return {
         "scanned": scanned,

--- a/backend/tests/test_adopt_orphaned_workflows.py
+++ b/backend/tests/test_adopt_orphaned_workflows.py
@@ -7,7 +7,9 @@ workflows that were reachable all along, too strict and the names stay blocked.
 """
 
 from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
 
+import pytest
 from beanie import PydanticObjectId
 
 from scripts.adopt_orphaned_workflows import (
@@ -97,3 +99,122 @@ class TestIsOrphan:
 
         assert is_orphan(wf, set(), {wf.id}) is True
         assert is_orphan(wf, set(), {str(wf.id)}) is False
+
+
+# ---------------------------------------------------------------------------
+# adopt(): the run must be safe to interrupt, and safe to run concurrently
+# ---------------------------------------------------------------------------
+
+class _Cursor:
+    """An async cursor that records whether it has been fully consumed."""
+
+    def __init__(self, items):
+        self._items = list(items)
+        self.exhausted = False
+
+    def __aiter__(self):
+        async def gen():
+            for it in self._items:
+                yield it
+            self.exhausted = True
+        return gen()
+
+
+def _wf(name, wid, owner="alice"):
+    return SimpleNamespace(
+        id=PydanticObjectId(),
+        name=name,
+        user_id=owner,
+        created_by_user_id=owner,
+        verified=False,
+        created_at=None,
+    )
+
+
+async def _run_adopt(monkeypatch, workflows, *, dry_run=False):
+    """Drive adopt() against stand-in models, returning what it wrote."""
+    import scripts.adopt_orphaned_workflows as mod
+
+    cursor = _Cursor(workflows)
+    inserted_during_scan: list[bool] = []
+    updates: list[tuple] = []
+
+    monkeypatch.setattr(mod, "AsyncIOMotorClient", lambda *a, **k: {"db": MagicMock()})
+    monkeypatch.setattr(mod, "init_beanie", AsyncMock())
+    monkeypatch.setattr(mod, "Settings", lambda: SimpleNamespace(mongo_host="", mongo_db="db"))
+    monkeypatch.setattr(mod, "_fetch_bookmarked", AsyncMock(return_value=set()))
+    monkeypatch.setattr(mod, "_fetch_referenced", AsyncMock(return_value=set()))
+
+    workflow_cls = MagicMock()
+    workflow_cls.find = MagicMock(return_value=cursor)
+    monkeypatch.setattr(mod, "Workflow", workflow_cls)
+
+    class _LibraryItem:
+        def __init__(self, **kw):
+            self.id = PydanticObjectId()
+            self.__dict__.update(kw)
+
+        async def insert(self):
+            # Records whether the scan cursor was still open at write time.
+            inserted_during_scan.append(not cursor.exhausted)
+
+    monkeypatch.setattr(mod, "LibraryItem", _LibraryItem)
+
+    coll = MagicMock()
+    coll.update_one = AsyncMock(side_effect=lambda q, u: updates.append((q, u)))
+    library_cls = MagicMock()
+    library_cls.get_motor_collection = MagicMock(return_value=coll)
+    monkeypatch.setattr(mod, "Library", library_cls)
+    monkeypatch.setattr(
+        mod, "_personal_library",
+        AsyncMock(side_effect=lambda owner, cache: SimpleNamespace(id=f"lib-{owner}")),
+    )
+
+    stats = await mod.adopt(dry_run=dry_run)
+    return stats, inserted_during_scan, updates
+
+
+@pytest.mark.asyncio
+async def test_nothing_is_written_while_the_scan_cursor_is_open(monkeypatch):
+    """Writing inside the cursor loop held it open across every insert.
+
+    A ten-minute cursor expiry, a crash, or a Ctrl-C then left LibraryItem rows
+    that no library referenced — invisible, and re-running inserted a second set
+    rather than reusing them, so every attempt added more garbage. That is
+    precisely the state this script exists to repair.
+    """
+    stats, inserted_during_scan, _updates = await _run_adopt(
+        monkeypatch, [_wf("A", 1), _wf("B", 2)],
+    )
+
+    assert stats["adopted"] == 2
+    assert inserted_during_scan and not any(inserted_during_scan), (
+        "a LibraryItem was inserted while the scan cursor was still open"
+    )
+
+
+@pytest.mark.asyncio
+async def test_the_library_is_appended_to_rather_than_overwritten(monkeypatch):
+    """lib.items.extend(...) + save() writes the whole array from a snapshot
+    read when the library was first fetched, so a bookmark the owner made while
+    the script ran was silently overwritten away — creating a fresh orphan of
+    exactly the kind being repaired."""
+    _stats, _during, updates = await _run_adopt(monkeypatch, [_wf("A", 1)])
+
+    assert len(updates) == 1
+    _query, update = updates[0]
+    assert "$push" in update, "the whole items array was rewritten"
+    assert "$each" in update["$push"]["items"]
+    assert "items" not in update.get("$set", {}), (
+        "items was $set, which clobbers concurrent bookmarks"
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_dry_run_writes_nothing_at_all(monkeypatch):
+    stats, inserted, updates = await _run_adopt(
+        monkeypatch, [_wf("A", 1)], dry_run=True,
+    )
+    assert stats["adopted"] == 1
+    assert inserted == []
+    assert updates == []


### PR DESCRIPTION
Addresses the **first** finding of #673. The other two (team-library bookmarking, unused pagination metadata) are untouched — see the bottom.

## 1. An interrupted run stranded rows

`LibraryItem` rows were inserted inside the scan's `async for`, but `Library.items` was only written after the whole scan completed. That held the cursor open across every write, so:

- a ten-minute cursor expiry, a crash, or a Ctrl-C left every already-inserted `LibraryItem` with **no library referencing it** — invisible;
- and re-running inserted a *second* set rather than reusing them, so each attempt added more garbage.

That is precisely the state this script exists to repair, and its own docstring defines as "not a bookmark".

**Fix:** the scan now collects orphans and writes nothing, so the cursor is closed before the first insert. Writes run one owner at a time, bounding what an interruption can strand to a single owner's batch.

## 2. A concurrent bookmark was overwritten away

The append was:

```python
lib.items.extend(item_ids)
await lib.save()
```

Beanie's `save()` writes the **whole** `items` array from the snapshot read when the library was first fetched — minutes earlier on a large collection. A user who bookmarked something while the script ran had that bookmark silently overwritten, creating a fresh orphan of exactly the kind being repaired.

**Fix:** `$push` with `$each`, so concurrent bookmarks survive.

## Tests

Three new; **two fail against the code as it stood**. The first asserts the property rather than the implementation — no `LibraryItem` may be inserted while the scan cursor is still open — using a stand-in cursor that records when it was exhausted.

`adopt()` had no coverage before this; the existing nine tests all exercise the pure helpers.

## Not in this PR

- **Team-scoped copies land in the duplicator's personal library.** `duplicate_workflow` and `import_workflow` receive `team_id`, but `ensure_bookmark` always targets `get_or_create_personal_library`. Routing to the team library is a behaviour decision about where a team copy belongs, not a repair.
- **The pagination metadata still has no consumers.** `total`/`hasMore` are returned and ignored by all four callers, so a picker past the limit truncates silently. Wiring it up is UI work with its own design question (a "showing N of M" affordance, a search box, or both).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
