### PR TITLE
perf(workflows): bundle a batch without stalling the worker

### DIFF
--- a/backend/app/routers/workflows.py
+++ b/backend/app/routers/workflows.py
@@ -7,10 +7,12 @@ import io
 import json
 import logging
 import re
+import tempfile
 import zipfile
 
 from beanie import PydanticObjectId
 from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, Request, UploadFile
+from fastapi.concurrency import run_in_threadpool
 from fastapi.responses import Response, StreamingResponse
 from pydantic import BaseModel
 
@@ -357,6 +359,16 @@ def _unique_member(member: str, seen: dict[str, int]) -> str:
             return candidate
 
 
+# Past this the request is refused with a clear message rather than quietly
+# spending minutes and gigabytes. Nothing caps batch size — a folder can expand
+# one arbitrarily — so an unbounded bundle is a worker-wide stall, not a slow
+# response.
+MAX_BATCH_DOWNLOAD_RUNS = 250
+
+# Below this the archive stays in memory; above it, it spills to a temp file.
+_ZIP_SPOOL_BYTES = 32 * 1024 * 1024
+
+
 def _session_base_filename(status: dict, session_id: str) -> str:
     """Build a filesystem-safe base name (no extension) unique per session.
 
@@ -545,34 +557,55 @@ async def download_batch_results(
     if format not in VALID_EXPORT_FORMATS:
         raise HTTPException(status_code=400, detail=f"Invalid format. Use one of: {sorted(VALID_EXPORT_FORMATS)}")
 
-    batch = await svc.get_batch_status(batch_id, user=user, share_token=share_token)
-    if not batch:
+    # One pair of queries for the whole batch. get_workflow_status costs a
+    # find_one plus a Workflow.get *per run*, so a 300-document batch was ~600
+    # sequential round trips inside one request.
+    completed = await svc.get_batch_completed_outputs(
+        batch_id, user=user, share_token=share_token,
+    )
+    if completed is None:
         raise HTTPException(status_code=404, detail="Batch not found")
-
-    completed = [it for it in batch["items"] if it["status"] == "completed"]
     if not completed:
         raise HTTPException(status_code=409, detail="No completed runs to download yet")
+    if len(completed) > MAX_BATCH_DOWNLOAD_RUNS:
+        raise HTTPException(
+            status_code=413,
+            detail=(
+                f"This batch has {len(completed)} completed runs; "
+                f"downloads are limited to {MAX_BATCH_DOWNLOAD_RUNS} at a time."
+            ),
+        )
 
-    zip_buf = io.BytesIO()
-    seen: dict[str, int] = {}
-    with zipfile.ZipFile(zip_buf, "w", zipfile.ZIP_DEFLATED) as zf:
-        for item in completed:
-            sid = item["session_id"]
-            status = await svc.get_workflow_status(sid, user=user, share_token=share_token)
-            if not status:
-                continue
-            content, _media_type, ext, explicit_name = _render_workflow_output(status, format, parse_structured)
-            base = _session_base_filename(status, sid)
-            if explicit_name:
-                # A step-supplied filename is static config, identical for every
-                # run in the batch, so on its own it says nothing about which
-                # document produced it. Prefix the per-run base so the bundle
-                # stays readable.
-                member = f"{base}-{_safe_zip_member(explicit_name)}"
-            else:
-                member = f"{base}.{ext}"
-            zf.writestr(_unique_member(member, seen), content)
-    zip_buf.seek(0)
+    def _build_zip():
+        """Render and compress every run.
+
+        Off the event loop: rendering to pdf/docx is CPU-bound, and doing it
+        inline stalled every other request the worker was serving for the
+        duration. Spooled so a large bundle spills to disk instead of being held
+        in memory in full.
+        """
+        buf = tempfile.SpooledTemporaryFile(max_size=_ZIP_SPOOL_BYTES)
+        seen: dict[str, int] = {}
+        with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+            for status in completed:
+                sid = status["session_id"]
+                content, _media_type, ext, explicit_name = _render_workflow_output(
+                    status, format, parse_structured,
+                )
+                base = _session_base_filename(status, sid)
+                if explicit_name:
+                    # A step-supplied filename is static config, identical for
+                    # every run in the batch, so on its own it says nothing about
+                    # which document produced it. Prefix the per-run base so the
+                    # bundle stays readable.
+                    member = f"{base}-{_safe_zip_member(explicit_name)}"
+                else:
+                    member = f"{base}.{ext}"
+                zf.writestr(_unique_member(member, seen), content)
+        buf.seek(0)
+        return buf
+
+    zip_buf = await run_in_threadpool(_build_zip)
 
     zip_name = "".join(c if c.isalnum() or c in " _-." else "_" for c in f"batch-{batch_id}").strip()
     return StreamingResponse(

--- a/backend/app/services/workflow_service.py
+++ b/backend/app/services/workflow_service.py
@@ -916,6 +916,62 @@ async def get_batch_status(
     }
 
 
+async def get_batch_completed_outputs(
+    batch_id: str, user: User | None = None, share_token: str | None = None
+) -> list[dict] | None:
+    """Every completed run in a batch, in the shape the download renderers want.
+
+    Two queries for the whole batch rather than two per run. ``get_workflow_status``
+    does a ``find_one`` plus a ``Workflow.get`` each time, so bundling a
+    300-document batch meant ~600 sequential round trips in one request; nothing
+    caps batch size, and a folder can expand one arbitrarily.
+
+    Authorization is unchanged in strength. Every run in a batch is created
+    against the same workflow, so authorizing that workflow once is what the
+    per-run check was doing N times — and any row that somehow points elsewhere
+    is dropped rather than trusted.
+
+    Returns ``None`` when the batch is unknown or the caller is not authorized
+    for it, matching :func:`get_batch_status`.
+    """
+    results = await WorkflowResult.find(
+        WorkflowResult.batch_id == batch_id,
+    ).to_list()
+    if not results:
+        return None
+
+    first = results[0]
+    if not first.workflow:
+        return None
+    workflow = await get_authorized_workflow(
+        str(first.workflow), user, share_token=share_token
+    ) if user is not None else await Workflow.get(first.workflow)
+    if not workflow:
+        return None
+
+    workflow_name = getattr(workflow, "name", None)
+    authorized_workflow_id = first.workflow
+
+    outputs: list[dict] = []
+    for r in results:
+        if r.status != "completed":
+            continue
+        if r.workflow != authorized_workflow_id:
+            # A batch is created against one workflow; anything else was not
+            # covered by the check above.
+            continue
+        outputs.append({
+            "session_id": r.session_id,
+            "status": r.status,
+            "final_output": r.final_output,
+            "steps_output": r.steps_output,
+            "output_step_names": r.output_step_names,
+            "workflow_name": workflow_name,
+            "document_title": r.document_title,
+        })
+    return outputs
+
+
 async def cancel_batch(
     batch_id: str, user: User, share_token: str | None = None
 ) -> dict | None:

--- a/backend/tests/test_workflow_routes_extended.py
+++ b/backend/tests/test_workflow_routes_extended.py
@@ -589,6 +589,14 @@ class TestDownloadBatchResults:
             ],
         }
 
+    def _outputs(self, item_statuses):
+        """What get_batch_completed_outputs returns: completed runs only, each
+        already carrying the fields the renderers read."""
+        return [
+            self._session_status(sid) | {"session_id": sid}
+            for sid, st in item_statuses if st == "completed"
+        ]
+
     def _session_status(self, sid):
         return {
             "status": "completed",
@@ -614,11 +622,8 @@ class TestDownloadBatchResults:
              patch("app.dependencies.User") as MockUser, \
              patch("app.routers.workflows.svc") as mock_svc:
             MockUser.find_one = AsyncMock(return_value=user)
-            mock_svc.get_batch_status = AsyncMock(
-                return_value=self._batch([("s1", "completed"), ("s2", "running"), ("s3", "completed")])
-            )
-            mock_svc.get_workflow_status = AsyncMock(
-                side_effect=lambda sid, **kw: self._session_status(sid)
+            mock_svc.get_batch_completed_outputs = AsyncMock(
+                return_value=self._outputs([("s1", "completed"), ("s2", "running"), ("s3", "completed")])
             )
 
             resp = await client.get(
@@ -661,10 +666,9 @@ class TestDownloadBatchResults:
              patch("app.dependencies.User") as MockUser, \
              patch("app.routers.workflows.svc") as mock_svc:
             MockUser.find_one = AsyncMock(return_value=user)
-            mock_svc.get_batch_status = AsyncMock(
-                return_value=self._batch([("s1", "completed")])
+            mock_svc.get_batch_completed_outputs = AsyncMock(
+                return_value=[evil_status("s1") | {"session_id": "s1"}]
             )
-            mock_svc.get_workflow_status = AsyncMock(side_effect=lambda sid, **kw: evil_status(sid))
 
             resp = await client.get(
                 "/api/workflows/batch-download?batch_id=b1&format=json",
@@ -709,12 +713,11 @@ class TestDownloadBatchResults:
              patch("app.dependencies.User") as MockUser, \
              patch("app.routers.workflows.svc") as mock_svc:
             MockUser.find_one = AsyncMock(return_value=user)
-            mock_svc.get_batch_status = AsyncMock(
-                return_value=self._batch([
-                    ("s1", "completed"), ("s2", "completed"), ("s3", "completed"),
-                ])
+            mock_svc.get_batch_completed_outputs = AsyncMock(
+                return_value=[
+                    same_name(sid) | {"session_id": sid} for sid in ("s1", "s2", "s3")
+                ]
             )
-            mock_svc.get_workflow_status = AsyncMock(side_effect=lambda sid, **kw: same_name(sid))
 
             resp = await client.get(
                 "/api/workflows/batch-download?batch_id=b1&format=json",
@@ -731,6 +734,62 @@ class TestDownloadBatchResults:
                 f"no member attributable to {sid} in {names}"
             )
 
+    async def test_the_bundle_costs_one_lookup_however_many_runs(self, client):
+        """get_workflow_status was called per run and does a find_one plus a
+        Workflow.get each time, so a 300-document batch meant ~600 sequential
+        round trips in a single request. Nothing caps batch size — a folder can
+        expand one arbitrarily.
+        """
+        import io as _io
+        import zipfile
+
+        user = _make_user()
+        cookies, headers = _auth()
+        many = [(f"s{i}", "completed") for i in range(40)]
+
+        with patch("app.dependencies.decode_token", return_value={"sub": "testuser", "type": "access"}), \
+             patch("app.dependencies.User") as MockUser, \
+             patch("app.routers.workflows.svc") as mock_svc:
+            MockUser.find_one = AsyncMock(return_value=user)
+            mock_svc.get_batch_completed_outputs = AsyncMock(
+                return_value=self._outputs(many)
+            )
+            mock_svc.get_workflow_status = AsyncMock()
+
+            resp = await client.get(
+                "/api/workflows/batch-download?batch_id=b1&format=json",
+                cookies=cookies, headers=headers,
+            )
+
+        assert resp.status_code == 200
+        assert len(zipfile.ZipFile(_io.BytesIO(resp.content)).namelist()) == 40
+        assert mock_svc.get_batch_completed_outputs.await_count == 1
+        mock_svc.get_workflow_status.assert_not_awaited()
+
+    async def test_an_oversized_batch_is_refused_with_a_reason(self, client):
+        """Better a clear refusal than minutes of CPU and a worker-wide stall."""
+        from app.routers.workflows import MAX_BATCH_DOWNLOAD_RUNS
+
+        user = _make_user()
+        cookies, headers = _auth()
+        too_many = [(f"s{i}", "completed") for i in range(MAX_BATCH_DOWNLOAD_RUNS + 1)]
+
+        with patch("app.dependencies.decode_token", return_value={"sub": "testuser", "type": "access"}), \
+             patch("app.dependencies.User") as MockUser, \
+             patch("app.routers.workflows.svc") as mock_svc:
+            MockUser.find_one = AsyncMock(return_value=user)
+            mock_svc.get_batch_completed_outputs = AsyncMock(
+                return_value=self._outputs(too_many)
+            )
+
+            resp = await client.get(
+                "/api/workflows/batch-download?batch_id=b1&format=json",
+                cookies=cookies, headers=headers,
+            )
+
+        assert resp.status_code == 413
+        assert str(MAX_BATCH_DOWNLOAD_RUNS) in resp.json()["detail"]
+
     async def test_no_completed_runs_returns_409(self, client):
         user = _make_user()
         cookies, headers = _auth()
@@ -739,9 +798,9 @@ class TestDownloadBatchResults:
              patch("app.dependencies.User") as MockUser, \
              patch("app.routers.workflows.svc") as mock_svc:
             MockUser.find_one = AsyncMock(return_value=user)
-            mock_svc.get_batch_status = AsyncMock(
-                return_value=self._batch([("s1", "running"), ("s2", "queued")])
-            )
+            # Empty list means "batch exists, nothing finished"; None would be
+            # "no such batch", which is the 404 case.
+            mock_svc.get_batch_completed_outputs = AsyncMock(return_value=[])
 
             resp = await client.get(
                 "/api/workflows/batch-download?batch_id=b1&format=json",
@@ -758,7 +817,7 @@ class TestDownloadBatchResults:
              patch("app.dependencies.User") as MockUser, \
              patch("app.routers.workflows.svc") as mock_svc:
             MockUser.find_one = AsyncMock(return_value=user)
-            mock_svc.get_batch_status = AsyncMock(return_value=None)
+            mock_svc.get_batch_completed_outputs = AsyncMock(return_value=None)
 
             resp = await client.get(
                 "/api/workflows/batch-download?batch_id=missing&format=json",


### PR DESCRIPTION
Closes #671.

## The problem

`download_batch_results` called `get_workflow_status` **once per completed run**, and that does a `find_one` plus a `Workflow.get` each time. A 300-document batch meant roughly **600 sequential round trips inside one request** — and nothing caps batch size, since `folder_uuids` can expand a batch to every document in a folder.

Two more costs on the same path: the whole ZIP was built in memory, and the render loop (CPU-bound for `pdf`/`docx`) ran **on the event loop**, stalling every other request that worker was serving for the duration. The failure mode is a worker-wide stall, not a slow response.

## The changes

**Two queries instead of 2N.** `get_batch_completed_outputs` fetches the batch's runs and the parent workflow once.

Authorization is **no weaker**. Every run in a batch is created against the same workflow, so authorizing that workflow once is exactly what the per-run check was doing N times — and any row whose `workflow` doesn't match the authorized one is dropped rather than trusted.

**Rendering moved off the event loop** via `run_in_threadpool`.

**The archive is spooled** (`SpooledTemporaryFile`), so a large bundle spills to disk rather than being held in memory whole.

**A cap, with a reason.** Past `MAX_BATCH_DOWNLOAD_RUNS` the request is refused with a 413 naming the limit. A clear refusal beats minutes of CPU and an unbounded allocation.

## Tests

Two new:

- the per-run lookup is gone however many runs there are (40 runs → one `get_batch_completed_outputs`, `get_workflow_status` never awaited)
- an oversized batch is refused with the limit in the message

The existing batch-download tests keep their intent — zip-slip, filename attribution, 409, 404 — with their mocks repointed at the new collaborator. One nuance worth noting in the harness: `None` now means "no such batch" (404) while `[]` means "batch exists, nothing finished" (409).

`ruff check app/` clean; 787 passed across the workflow/batch suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
