### PR TITLE
fix(reviews): key the approval wait on the review, and bound the reaper exemption

### DIFF
--- a/backend/app/routers/reviews.py
+++ b/backend/app/routers/reviews.py
@@ -6,6 +6,7 @@ assigned reviewer / workflow manager — not the global admin flag.
 """
 
 import datetime
+import logging
 from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -23,6 +24,8 @@ from app.models.document import SmartDocument
 from app.models.user import User
 from app.models.workflow import Workflow, WorkflowResult
 from app.services import access_control, approval_service, audit_service
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
@@ -110,10 +113,31 @@ async def _approval_full(a: ApprovalRequest) -> dict:
 
 
 async def _can_view_approval(approval: ApprovalRequest, user: User) -> bool:
-    """User can see this review if assigned, or if they manage the workflow."""
+    """User can see this review if assigned, if they ran it, or if they manage
+    the workflow.
+
+    Viewing is not deciding — :func:`_can_decide_approval` is a strictly
+    narrower check, so nothing here grants the right to approve or reject.
+    """
     if user.user_id in (approval.assigned_to_user_ids or []):
         return True
     if user.user_id == approval.requester_user_id:
+        return True
+    # The person who actually ran the workflow. requester_user_id is the
+    # workflow's *owner*, which is often someone else: a team member running a
+    # shared workflow, or a share-link recipient. Their own activity row links
+    # straight here, so without this they follow a link from their own run and
+    # get "Review not found" — having also lost the previous behaviour, where
+    # clicking that row opened the workflow.
+    try:
+        result = await WorkflowResult.get(approval.workflow_result_id)
+    except Exception:  # pragma: no cover - defensive
+        logger.warning(
+            "Could not load run %s while checking review visibility",
+            approval.workflow_result_id, exc_info=True,
+        )
+        result = None
+    if result is not None and result.user_id == user.user_id:
         return True
     # Workflow manage rights (covers team admins on team-scoped workflows)
     workflow = await access_control.get_authorized_workflow(
@@ -301,6 +325,7 @@ async def reject_review(
     # activity so the rail shows a rejected run instead of one still spinning.
     await approval_service.end_approval_wait(
         approval.workflow_result_id,
+        approval_uuid=approval.uuid,
         error=(
             f"Rejected by reviewer: {body.comments}" if body.comments
             else "Rejected by reviewer."

--- a/backend/app/services/approval_service.py
+++ b/backend/app/services/approval_service.py
@@ -164,6 +164,7 @@ def detect_artifact_kind(value) -> str:
 async def end_approval_wait(
     workflow_result_id: PydanticObjectId,
     *,
+    approval_uuid: str | None = None,
     error: str = "",
 ) -> None:
     """Take a run's activity out of its approval wait, closing it if it ended.
@@ -175,15 +176,37 @@ async def end_approval_wait(
     about: it was left at "running" and only the reaper ever closed it. Passing
     ``error`` closes the row too, so the rail agrees with the WorkflowResult.
 
+    Two things make a batch different, and both are handled here.
+
+    A batch shares one ActivityEvent across every document
+    (``run_workflow_batch`` hands the same ``activity_id`` to all of them), and
+    ``_pause_for_approval`` overwrites ``workflow_result`` on each pause. So
+    matching on ``workflow_result`` finds the row only for whichever document
+    paused last, and misses entirely for the others — leaving the marker in
+    place, and with it a row the reaper will never touch. Matching on the
+    approval's own uuid finds exactly the row that is waiting on *this* review,
+    for a batch and a single run alike.
+
+    And one document's rejection is not the batch's failure. Where several runs
+    share a row, the wait is ended without closing it, so the documents still
+    running keep their row; the ``WorkflowResult`` for the rejected one is
+    already marked by the caller.
+
     Never raises: a review decision must not fail because a bookkeeping write
     on the activity did.
     """
     from app.models.activity import ActivityEvent, ActivityStatus
 
-    update: dict = {"$unset": {"meta_summary.pending_review_uuid": ""}}
     now = datetime.datetime.now(datetime.timezone.utc)
+    update: dict = {"$unset": {"meta_summary.pending_review_uuid": ""}}
     set_ops: dict = {"last_updated_at": now}
-    if error:
+
+    try:
+        shared_with_a_batch = await _is_batch_run(workflow_result_id)
+    except Exception:  # pragma: no cover - defensive
+        shared_with_a_batch = False
+
+    if error and not shared_with_a_batch:
         set_ops.update({
             "status": ActivityStatus.FAILED.value,
             "finished_at": now,
@@ -191,14 +214,28 @@ async def end_approval_wait(
         })
     update["$set"] = set_ops
 
+    # Prefer the approval's own uuid; fall back to the run for callers that
+    # have no approval in hand.
+    query: dict = (
+        {"meta_summary.pending_review_uuid": approval_uuid}
+        if approval_uuid
+        else {"workflow_result": workflow_result_id}
+    )
+
     try:
-        await ActivityEvent.get_motor_collection().update_one(
-            {"workflow_result": workflow_result_id}, update,
-        )
+        await ActivityEvent.get_motor_collection().update_one(query, update)
     except Exception:
         logger.exception(
             "Could not end approval wait on activity for result %s", workflow_result_id,
         )
+
+
+async def _is_batch_run(workflow_result_id: PydanticObjectId) -> bool:
+    """True when this run is one document of a batch sharing an activity row."""
+    from app.models.workflow import WorkflowResult
+
+    result = await WorkflowResult.get(workflow_result_id)
+    return bool(result and result.batch_id)
 
 
 async def expire_overdue_approvals() -> dict:
@@ -252,6 +289,7 @@ async def expire_overdue_approvals() -> dict:
                 await result.save()
             await end_approval_wait(
                 approval.workflow_result_id,
+                approval_uuid=approval.uuid,
                 error="Auto-rejected: review deadline passed.",
             )
             counts["rejected"] += 1
@@ -310,6 +348,7 @@ async def expire_overdue_approvals() -> dict:
             await approval.save()
             await end_approval_wait(
                 approval.workflow_result_id,
+                approval_uuid=approval.uuid,
                 error="Review deadline passed with no decision — run is still paused.",
             )
             counts["expired"] += 1

--- a/backend/app/tasks/activity_tasks.py
+++ b/backend/app/tasks/activity_tasks.py
@@ -343,8 +343,43 @@ def reap_stale_running_task(self) -> None:
         },
     )
 
-    if result.modified_count:
+    # A row parked on a review is exempt from the sweep above, but only while
+    # that review is actually pending. approve_review returns as soon as the
+    # resume task is dispatched, and the marker is cleared deep inside that
+    # task — after guards that raise on "Approval not found", "is not approved"
+    # and "Workflow or result not found". If the workflows worker is down when
+    # the message is sent, the message is lost, or any guard trips, the marker
+    # stays and the row sits at "running" forever: precisely the condition this
+    # reaper exists to catch, made unreachable by its own exemption.
+    pending_uuids = [
+        a["uuid"]
+        for a in db.approval_request.find({"status": "pending"}, {"uuid": 1})
+        if a.get("uuid")
+    ]
+    orphaned = db.activity_event.update_many(
+        {
+            "status": {"$in": ["running", "queued"]},
+            "last_updated_at": {"$lt": cutoff},
+            # Carries a marker, but not one of a review still awaiting a decision.
+            "meta_summary.pending_review_uuid": {"$nin": [None, *pending_uuids]},
+        },
+        {
+            "$set": {
+                "status": "failed",
+                "finished_at": now,
+                "last_updated_at": now,
+                "error": (
+                    "Timed out — the review this run was waiting on is no "
+                    "longer pending and the run never resumed."
+                ),
+            },
+            "$unset": {"meta_summary.pending_review_uuid": ""},
+        },
+    )
+
+    if result.modified_count or orphaned.modified_count:
         logger.info(
-            "Reaped %d stale activity events (threshold=%d min)",
-            result.modified_count, threshold_minutes,
+            "Reaped %d stale activity events and %d parked on a decided review "
+            "(threshold=%d min)",
+            result.modified_count, orphaned.modified_count, threshold_minutes,
         )

--- a/backend/tests/test_activity_tasks.py
+++ b/backend/tests/test_activity_tasks.py
@@ -62,23 +62,63 @@ class TestReapStaleRunning:
     mark every review left overnight as a timeout and fail the run's activity.
     """
 
-    def _reap(self):
+    def _reap(self, pending_uuids=()):
+        """Run the task and return (elapsed_time_query, decided_review_query)."""
         import app.tasks.activity_tasks as at
 
         db = MagicMock()
         db.activity_event.update_many.return_value = MagicMock(modified_count=0)
+        db.approval_request.find.return_value = [{"uuid": u} for u in pending_uuids]
         with patch.object(at, "_get_db", return_value=db), \
              patch.object(at, "_resolve_stale_threshold_minutes", return_value=30):
             at.reap_stale_running_task()
-        return db.activity_event.update_many.call_args[0][0]
+        calls = db.activity_event.update_many.call_args_list
+        assert len(calls) == 2, f"expected two sweeps, got {len(calls)}"
+        return calls[0][0][0], calls[1][0][0]
 
     def test_skips_runs_awaiting_approval(self):
-        query = self._reap()
+        elapsed, _ = self._reap()
         # `None` matches both a null field and a missing one, so ordinary
         # activities (which never carry the key) stay in scope.
-        assert query["meta_summary.pending_review_uuid"] is None
+        assert elapsed["meta_summary.pending_review_uuid"] is None
 
     def test_still_targets_stuck_running_events(self):
-        query = self._reap()
-        assert query["status"] == {"$in": ["running", "queued"]}
-        assert "$lt" in query["last_updated_at"]
+        elapsed, _ = self._reap()
+        assert elapsed["status"] == {"$in": ["running", "queued"]}
+        assert "$lt" in elapsed["last_updated_at"]
+
+    def test_a_row_parked_on_a_decided_review_is_still_reaped(self):
+        """The exemption was unbounded. approve_review returns as soon as the
+        resume task is dispatched, and the marker is cleared deep inside that
+        task, after guards that raise. A lost message or a tripped guard left
+        the row at "running" forever — the exact condition the reaper exists to
+        catch, made unreachable by its own exemption.
+        """
+        _elapsed, decided = self._reap(pending_uuids=["still-waiting"])
+
+        # Reaps rows carrying a marker that is not one of the pending reviews.
+        assert decided["meta_summary.pending_review_uuid"]["$nin"] == [
+            None, "still-waiting",
+        ]
+        assert decided["status"] == {"$in": ["running", "queued"]}
+        assert "$lt" in decided["last_updated_at"]
+
+    def test_a_row_parked_on_a_review_still_awaiting_a_decision_is_left_alone(self):
+        _elapsed, decided = self._reap(pending_uuids=["a", "b"])
+        excluded = decided["meta_summary.pending_review_uuid"]["$nin"]
+        assert "a" in excluded and "b" in excluded
+
+    def test_the_decided_sweep_clears_the_marker_it_reaps(self):
+        """Otherwise the row stays exempt from the first sweep forever."""
+        import app.tasks.activity_tasks as at
+
+        db = MagicMock()
+        db.activity_event.update_many.return_value = MagicMock(modified_count=0)
+        db.approval_request.find.return_value = []
+        with patch.object(at, "_get_db", return_value=db), \
+             patch.object(at, "_resolve_stale_threshold_minutes", return_value=30):
+            at.reap_stale_running_task()
+
+        update = db.activity_event.update_many.call_args_list[1][0][1]
+        assert update["$unset"] == {"meta_summary.pending_review_uuid": ""}
+        assert update["$set"]["status"] == "failed"

--- a/backend/tests/test_reviews_routes.py
+++ b/backend/tests/test_reviews_routes.py
@@ -2,6 +2,7 @@
 
 import datetime
 import secrets
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -150,6 +151,7 @@ class TestReviewAuthorization:
         with patch("app.dependencies.decode_token", return_value={"sub": "randomuser", "type": "access"}), \
              patch("app.dependencies.User") as MockUser, \
              patch("app.routers.reviews.ApprovalRequest") as MockApproval, \
+             patch("app.routers.reviews.WorkflowResult") as MockResult, \
              patch(
                  "app.routers.reviews.access_control.get_authorized_workflow",
                  new_callable=AsyncMock,
@@ -157,6 +159,73 @@ class TestReviewAuthorization:
              ):
             MockUser.find_one = AsyncMock(return_value=user)
             MockApproval.find_one = AsyncMock(return_value=approval)
+            # Somebody else's run, so the "you ran this" path does not apply.
+            MockResult.get = AsyncMock(return_value=SimpleNamespace(user_id="someone-else"))
+
+            resp = await client.get(
+                f"/api/reviews/{approval.uuid}",
+                cookies=cookies,
+                headers=headers,
+            )
+        assert resp.status_code == 404
+
+
+    async def test_the_person_who_ran_it_can_view_their_own_review(self, client):
+        """requester_user_id is the workflow's *owner*, which is often someone
+        else — a team member running a shared workflow, or a share-link
+        recipient. Their own activity row links straight here, so they followed
+        a link from their own run and got "Review not found", having also lost
+        the previous behaviour where that row opened the workflow.
+
+        Viewing is not deciding: _can_decide_approval is a strictly narrower
+        check and is unaffected.
+        """
+        user = _make_user("runner")
+        approval = _make_approval(assigned=("reviewer1",))
+        approval.requester_user_id = "workflow-owner"
+        cookies, headers = _auth("runner")
+
+        with patch("app.dependencies.decode_token", return_value={"sub": "runner", "type": "access"}), \
+             patch("app.dependencies.User") as MockUser, \
+             patch("app.routers.reviews.ApprovalRequest") as MockApproval, \
+             patch("app.routers.reviews.WorkflowResult") as MockResult, \
+             patch("app.routers.reviews.User") as MockRouterUser, \
+             patch(
+                 "app.routers.reviews.access_control.get_authorized_workflow",
+                 new_callable=AsyncMock,
+                 return_value=None,
+             ):
+            MockUser.find_one = AsyncMock(return_value=user)
+            MockApproval.find_one = AsyncMock(return_value=approval)
+            # Only used to render the requester's display name.
+            MockRouterUser.find_one = AsyncMock(return_value=None)
+            MockResult.get = AsyncMock(return_value=SimpleNamespace(user_id="runner"))
+
+            resp = await client.get(
+                f"/api/reviews/{approval.uuid}",
+                cookies=cookies,
+                headers=headers,
+            )
+        assert resp.status_code == 200
+
+    async def test_a_failed_run_lookup_does_not_grant_access(self, client):
+        """An authorization check must fail closed."""
+        user = _make_user("randomuser")
+        approval = _make_approval(assigned=("reviewer1",))
+        cookies, headers = _auth("randomuser")
+
+        with patch("app.dependencies.decode_token", return_value={"sub": "randomuser", "type": "access"}), \
+             patch("app.dependencies.User") as MockUser, \
+             patch("app.routers.reviews.ApprovalRequest") as MockApproval, \
+             patch("app.routers.reviews.WorkflowResult") as MockResult, \
+             patch(
+                 "app.routers.reviews.access_control.get_authorized_workflow",
+                 new_callable=AsyncMock,
+                 return_value=None,
+             ):
+            MockUser.find_one = AsyncMock(return_value=user)
+            MockApproval.find_one = AsyncMock(return_value=approval)
+            MockResult.get = AsyncMock(side_effect=RuntimeError("mongo down"))
 
             resp = await client.get(
                 f"/api/reviews/{approval.uuid}",

--- a/backend/tests/test_workflow_approval_pause.py
+++ b/backend/tests/test_workflow_approval_pause.py
@@ -6,7 +6,9 @@ telling the rail, the run history, and the stale reaper that this run is parked
 on a person. Every path out of the wait has to clear it.
 """
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from types import SimpleNamespace
 
 import pytest
 from bson import ObjectId
@@ -121,6 +123,63 @@ class TestEndApprovalWait:
         assert update["$set"]["status"] == "failed"
         assert update["$set"]["error"] == "Rejected by reviewer."
         assert "finished_at" in update["$set"]
+
+    @pytest.mark.asyncio
+    async def test_it_targets_the_review_rather_than_the_run(self):
+        """A batch shares one ActivityEvent across every document, and
+        _pause_for_approval overwrites `workflow_result` on each pause. So
+        matching on the run found the row only for whichever document paused
+        last, and missed entirely for the others — leaving the marker behind,
+        and with it a row the reaper will never touch.
+        """
+        from app.services import approval_service
+
+        coll = MagicMock()
+        coll.update_one = _AsyncNoop()
+        with patch("app.models.activity.ActivityEvent.get_motor_collection", return_value=coll), \
+             patch("app.models.workflow.WorkflowResult.get", new=AsyncMock(return_value=None)):
+            await approval_service.end_approval_wait(ObjectId(), approval_uuid="rev-7")
+
+        query = coll.update_one.calls[0][0][0]
+        assert query == {"meta_summary.pending_review_uuid": "rev-7"}
+
+    @pytest.mark.asyncio
+    async def test_one_document_rejection_does_not_fail_the_whole_batch(self):
+        """The shared row represents the batch. Closing it because one document
+        was rejected would report every other document as failed while they are
+        still running."""
+        from app.services import approval_service
+
+        coll = MagicMock()
+        coll.update_one = _AsyncNoop()
+        batch_run = SimpleNamespace(batch_id="b-1")
+        with patch("app.models.activity.ActivityEvent.get_motor_collection", return_value=coll), \
+             patch("app.models.workflow.WorkflowResult.get", new=AsyncMock(return_value=batch_run)):
+            await approval_service.end_approval_wait(
+                ObjectId(), approval_uuid="rev-7", error="Rejected by reviewer.",
+            )
+
+        update = coll.update_one.calls[0][0][1]
+        # The wait ends...
+        assert update["$unset"] == {"meta_summary.pending_review_uuid": ""}
+        # ...but the row stays open for the documents still running.
+        assert "status" not in update["$set"]
+
+    @pytest.mark.asyncio
+    async def test_a_single_run_rejection_still_closes_its_row(self):
+        from app.services import approval_service
+
+        coll = MagicMock()
+        coll.update_one = _AsyncNoop()
+        single_run = SimpleNamespace(batch_id=None)
+        with patch("app.models.activity.ActivityEvent.get_motor_collection", return_value=coll), \
+             patch("app.models.workflow.WorkflowResult.get", new=AsyncMock(return_value=single_run)):
+            await approval_service.end_approval_wait(
+                ObjectId(), approval_uuid="rev-7", error="Rejected by reviewer.",
+            )
+
+        update = coll.update_one.calls[0][0][1]
+        assert update["$set"]["status"] == "failed"
 
     @pytest.mark.asyncio
     async def test_never_raises(self):


### PR DESCRIPTION
Closes #672. All three findings.

## 1. A batch shares one activity row, but approvals are per-result

`run_workflow_batch` hands the **same** `activity_id` to every document, and `_pause_for_approval` overwrites `workflow_result` on each pause. `end_approval_wait` matched on that field, so it found the row only for whichever document paused **last**, and missed entirely for the others — leaving the marker behind, and with it a row the stale reaper skips forever.

It now matches on the **approval's own uuid**, which identifies exactly the row waiting on that review — for a batch and a single run alike.

One document's rejection is also not the batch's failure. Where a run belongs to a batch the wait ends without closing the row, so the documents still running keep it; the rejected run's own `WorkflowResult` is already marked by the caller. A single run still closes its row exactly as before.

**Keeping one row per batch is deliberate** — it's what keeps the activity rail readable — so the fix is in the approval path rather than in how many rows a batch has.

## 2. The reaper exemption was unbounded

`approve_review` returns as soon as the resume task is dispatched, and the marker is cleared deep inside that task — *after* guards that raise on "Approval not found", "is not approved" and "Workflow or result not found".

So a worker that's down when the message is sent, a lost message, or any tripped guard left the row at `running` **forever**: precisely the condition the reaper exists to catch, made unreachable by its own exemption.

A second sweep reaps rows whose marker names a review that is no longer pending, and clears the marker as it goes so the row doesn't stay exempt from the first sweep.

## 3. The review was invisible to the person who ran it

`requester_user_id` is the workflow's **owner**, which is often someone else — a team member running a shared workflow, or a share-link recipient. Their own activity row links straight to the review, so they followed a link from their own run and got "Review not found" — having also lost the previous behaviour, where clicking that row opened the workflow.

Viewing now includes the runner. **Deciding is unchanged**: `_can_decide_approval` is a strictly narrower check and isn't touched. The run lookup fails closed, so a lookup error denies rather than grants.

## Tests

Nine new/updated tests fail against the code as it stood, covering: the query targets the review not the run; a batch rejection clears the wait without closing the row; a single run still closes its row; the decided-review sweep and what it excludes; the marker is cleared as it reaps; the runner can view their own review; and a failed lookup doesn't grant access.

`ruff check app/` clean. Full backend suite: **3662 passed**, 165 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
