### PR TITLE
fix(chat): record the documents a turn was asked against

### DIFF
--- a/backend/app/models/chat.py
+++ b/backend/app/models/chat.py
@@ -22,12 +22,38 @@ class ChatRole(str, Enum):
     ASSISTANT = "assistant"
 
 
+# A selection can expand to a lot of documents — folder expansion alone allows
+# 500 per folder — and this is written on every turn. Past this the record says
+# so rather than growing without bound.
+MAX_RECORDED_SOURCE_DOCUMENTS = 500
+
+
+def _cap_source_documents(docs: Optional[list[dict]]) -> Optional[list[dict]]:
+    """Bound what one turn records, saying so rather than silently dropping."""
+    if not docs:
+        return None
+    if len(docs) <= MAX_RECORDED_SOURCE_DOCUMENTS:
+        return docs
+    kept = docs[:MAX_RECORDED_SOURCE_DOCUMENTS]
+    return [*kept, {"truncated": len(docs) - MAX_RECORDED_SOURCE_DOCUMENTS}]
+
+
 class ChatMessage(Document):
     role: ChatRole
     message: str
     thinking: Optional[str] = None
     thinking_duration: Optional[float] = None
     citations: Optional[list[dict]] = None
+    # The documents in scope when this turn was asked: ``{uuid, title}`` each,
+    # plus ``{"truncated": n}`` as a final entry if the selection was larger
+    # than we record.
+    #
+    # Titles are stored alongside the uuids deliberately. The point of the
+    # record is to be readable later, and a uuid stops resolving the moment the
+    # document is deleted — which is exactly when someone wants to know what an
+    # old answer was based on. Both are already in hand when the router
+    # authorizes the selection, so this costs no extra lookups.
+    source_documents: Optional[list[dict]] = None
     created_at: datetime.datetime = Field(default_factory=datetime.datetime.now)
 
     class Settings:
@@ -41,6 +67,8 @@ class ChatMessage(Document):
             d["thinking_duration"] = self.thinking_duration
         if self.citations:
             d["citations"] = self.citations
+        if self.source_documents:
+            d["source_documents"] = self.source_documents
         return d
 
     def to_model_message(self) -> ModelMessage:
@@ -129,6 +157,7 @@ class ChatConversation(Document):
         thinking: Optional[str] = None,
         thinking_duration: Optional[float] = None,
         citations: Optional[list[dict]] = None,
+        source_documents: Optional[list[dict]] = None,
     ) -> ChatMessage:
         msg = ChatMessage(
             role=role,
@@ -136,6 +165,7 @@ class ChatConversation(Document):
             thinking=thinking or None,
             thinking_duration=thinking_duration,
             citations=citations or None,
+            source_documents=_cap_source_documents(source_documents),
         )
         await msg.insert()
         self.messages.append(msg.id)

--- a/backend/app/routers/chat.py
+++ b/backend/app/routers/chat.py
@@ -71,6 +71,10 @@ async def chat(
     team_access = await access_control.get_team_access_context(user)
 
     authorized_document_uuids: list[str] = []
+    # Captured as we authorize, so recording the turn's scope costs no extra
+    # lookups. Titles go in alongside the uuids because a uuid stops resolving
+    # once the document is deleted, which is when the record matters most.
+    source_documents: list[dict] = []
     for doc_uuid in document_uuids:
         doc = await access_control.get_authorized_document(
             doc_uuid,
@@ -81,6 +85,7 @@ async def chat(
         if not doc:
             raise HTTPException(status_code=404, detail=f"Document not found: {doc_uuid}")
         authorized_document_uuids.append(doc.uuid)
+        source_documents.append({"uuid": doc.uuid, "title": doc.title or doc.uuid})
     document_uuids = authorized_document_uuids
 
     # The KB scope passed to retrieval. A project scope overrides it with the
@@ -144,6 +149,9 @@ async def chat(
                 ):
                     document_uuids.append(doc.uuid)
                     existing.add(doc.uuid)
+                    source_documents.append(
+                        {"uuid": doc.uuid, "title": doc.title or doc.uuid},
+                    )
 
     activity: Optional[ActivityEvent] = None
     conversation: Optional[ChatConversation] = None
@@ -204,8 +212,17 @@ async def chat(
     if not conversation:
         raise HTTPException(status_code=500, detail="Failed to create conversation")
 
-    # Save user message
-    await conversation.add_message(ChatRole.USER, message)
+    # Save user message, with the scope it was asked against.
+    #
+    # A KB-grounded answer already recorded what it drew on (``citations`` on
+    # the assistant turn), while a direct-document answer recorded nothing —
+    # even though the fully resolved, authorized set is right here. Without it
+    # a saved conversation cannot say which documents produced which answer,
+    # and continuing a conversation across a changed selection (which is
+    # deliberate and useful) leaves no trace of the change.
+    await conversation.add_message(
+        ChatRole.USER, message, source_documents=source_documents or None,
+    )
 
     async def generate():
         try:

--- a/backend/tests/test_chat_routes.py
+++ b/backend/tests/test_chat_routes.py
@@ -599,3 +599,77 @@ class TestChatRemoveAttachments:
 
         assert resp.status_code == 200
         assert resp.json()["success"] is True
+
+
+class TestChatRecordsItsDocumentScope:
+    """The user turn is written with the documents it was asked against.
+
+    A KB-grounded answer already recorded its sources on the assistant turn;
+    a direct-document answer recorded nothing, even though the fully resolved,
+    authorized set is in hand at that moment.
+    """
+
+    @pytest.mark.asyncio
+    async def test_the_selected_documents_are_stored_with_the_question(self, client):
+        from types import SimpleNamespace
+
+        user = _make_user("user1")
+        cookies, headers = _auth("user1")
+
+        conversation = MagicMock()
+        conversation.uuid = "conv-1"
+        conversation.add_message = AsyncMock()
+        conversation.insert = AsyncMock()
+        conversation.save = AsyncMock()
+        conversation.generate_title = MagicMock()
+
+        docs = {
+            "d1": SimpleNamespace(uuid="d1", title="Proposal A.pdf"),
+            "d2": SimpleNamespace(uuid="d2", title="Proposal B.pdf"),
+        }
+
+        async def fake_authorized_document(doc_uuid, *a, **kw):
+            return docs.get(doc_uuid)
+
+        activity = MagicMock()
+        activity.id = "act-1"
+        activity.save = AsyncMock()
+
+        with patch("app.dependencies.decode_token", return_value={"sub": "user1", "type": "access"}), \
+             patch("app.dependencies.User") as MockUser, \
+             patch("app.routers.chat.access_control.get_team_access_context", new_callable=AsyncMock), \
+             patch("app.routers.chat.access_control.get_authorized_document",
+                   new=AsyncMock(side_effect=fake_authorized_document)), \
+             patch("app.routers.chat.ChatConversation", return_value=conversation) as MockConv, \
+             patch("app.routers.chat.activity_service.activity_start",
+                   new=AsyncMock(return_value=activity)), \
+             patch("app.routers.chat.chat_stream") as mock_stream:
+            MockUser.find_one = AsyncMock(return_value=user)
+            MockConv.find_one = AsyncMock(return_value=conversation)
+
+            async def _empty(*a, **kw):
+                if False:
+                    yield ""
+            mock_stream.side_effect = _empty
+
+            resp = await client.post(
+                "/api/chat",
+                json={
+                    "message": "What is the budget?",
+                    "document_uuids": ["d1", "d2"],
+                    "conversation_uuid": "conv-1",
+                },
+                cookies=cookies,
+                headers=headers,
+            )
+            assert resp.status_code == 200
+            # StreamingResponse: the body has to be consumed for the generator
+            # (and the message write before it) to run.
+            _ = resp.text
+
+        conversation.add_message.assert_awaited()
+        kwargs = conversation.add_message.await_args.kwargs
+        assert kwargs["source_documents"] == [
+            {"uuid": "d1", "title": "Proposal A.pdf"},
+            {"uuid": "d2", "title": "Proposal B.pdf"},
+        ]

--- a/backend/tests/test_chat_source_scope.py
+++ b/backend/tests/test_chat_source_scope.py
@@ -1,0 +1,147 @@
+"""A stored turn should record the documents it was asked against.
+
+A KB-grounded answer already recorded what it drew on — `citations` on the
+assistant turn — while a direct-document answer recorded nothing, even though
+the router has the fully resolved, authorized set in hand when it writes the
+user turn. Without it a saved conversation cannot say which document produced
+which answer, and continuing a conversation across a changed selection (which
+is deliberate and useful) leaves no trace of the change.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.models.chat import (
+    MAX_RECORDED_SOURCE_DOCUMENTS,
+    ChatMessage,
+    ChatRole,
+    _cap_source_documents,
+)
+
+
+def _doc(uuid: str, title: str) -> dict:
+    return {"uuid": uuid, "title": title}
+
+
+class TestRecordedScope:
+    def test_a_turn_serializes_the_scope_it_was_asked_against(self):
+        msg = ChatMessage.model_construct(
+            role=ChatRole.USER,
+            message="What is the budget?",
+            thinking=None,
+            thinking_duration=None,
+            citations=None,
+            source_documents=[_doc("d1", "Proposal A.pdf")],
+        )
+        assert msg.to_dict()["source_documents"] == [_doc("d1", "Proposal A.pdf")]
+
+    def test_a_turn_without_a_scope_says_nothing(self):
+        """Attachment notices and KB-only turns have no document scope; the key
+        should be absent rather than an empty list, so old messages and new ones
+        look the same to a reader."""
+        msg = ChatMessage.model_construct(
+            role=ChatRole.USER, message="hello", thinking=None,
+            thinking_duration=None, citations=None, source_documents=None,
+        )
+        assert "source_documents" not in msg.to_dict()
+
+    def test_the_title_is_kept_beside_the_uuid(self):
+        """The point of the record is to be readable later, and a uuid stops
+        resolving the moment the document is deleted — which is exactly when
+        someone wants to know what an old answer was based on."""
+        msg = ChatMessage.model_construct(
+            role=ChatRole.USER,
+            message="q",
+            thinking=None,
+            thinking_duration=None,
+            citations=None,
+            source_documents=[_doc("d1", "Proposal A.pdf")],
+        )
+        recorded = msg.to_dict()["source_documents"][0]
+        assert recorded["title"] == "Proposal A.pdf"
+        assert recorded["uuid"] == "d1"
+
+
+class TestScopeIsBounded:
+    def test_a_small_selection_is_recorded_whole(self):
+        docs = [_doc(f"d{i}", f"Doc {i}") for i in range(3)]
+        assert _cap_source_documents(docs) == docs
+
+    def test_nothing_becomes_none_rather_than_an_empty_list(self):
+        assert _cap_source_documents([]) is None
+        assert _cap_source_documents(None) is None
+
+    def test_an_oversized_selection_says_how_much_it_left_out(self):
+        """Folder expansion alone allows 500 documents per folder, and this is
+        written on every turn — so it is bounded, and says so rather than
+        silently dropping the tail."""
+        docs = [
+            _doc(f"d{i}", f"Doc {i}")
+            for i in range(MAX_RECORDED_SOURCE_DOCUMENTS + 7)
+        ]
+        capped = _cap_source_documents(docs)
+
+        assert len(capped) == MAX_RECORDED_SOURCE_DOCUMENTS + 1
+        assert capped[:MAX_RECORDED_SOURCE_DOCUMENTS] == docs[:MAX_RECORDED_SOURCE_DOCUMENTS]
+        assert capped[-1] == {"truncated": 7}
+
+    def test_exactly_at_the_cap_is_not_marked_truncated(self):
+        docs = [
+            _doc(f"d{i}", f"Doc {i}")
+            for i in range(MAX_RECORDED_SOURCE_DOCUMENTS)
+        ]
+        capped = _cap_source_documents(docs)
+        assert len(capped) == MAX_RECORDED_SOURCE_DOCUMENTS
+        assert all("truncated" not in d for d in capped)
+
+
+class TestAddMessageThreadsItThrough:
+    @pytest.mark.asyncio
+    async def test_the_scope_reaches_the_stored_message(self, monkeypatch):
+        created = await _add(monkeypatch, [_doc("d1", "Proposal A.pdf")])
+        assert created.source_documents == [_doc("d1", "Proposal A.pdf")]
+
+    @pytest.mark.asyncio
+    async def test_an_oversized_selection_is_capped_on_the_way_in(self, monkeypatch):
+        """The cap belongs on the write, not on every caller."""
+        too_many = [
+            _doc(f"d{i}", f"Doc {i}")
+            for i in range(MAX_RECORDED_SOURCE_DOCUMENTS + 3)
+        ]
+        created = await _add(monkeypatch, too_many)
+        assert created.source_documents[-1] == {"truncated": 3}
+
+
+async def _add(monkeypatch, source_documents):
+    """Run add_message with the DB writes stubbed, returning the stored message."""
+    from app.models import chat as chat_model
+
+    created: list[ChatMessage] = []
+
+    async def fake_insert(self):
+        created.append(self)
+        self.id = "msg-1"
+
+    async def fake_save(self):
+        return self
+
+    monkeypatch.setattr(chat_model.ChatMessage, "insert", fake_insert)
+    monkeypatch.setattr(chat_model.ChatConversation, "save", fake_save)
+    # Construct without Beanie's collection machinery, which these tests do not
+    # stand up; the field plumbing is what is under test.
+    monkeypatch.setattr(
+        chat_model, "ChatMessage",
+        type("_M", (), {
+            "__init__": lambda self, **kw: self.__dict__.update(kw),
+            "insert": fake_insert,
+        }),
+    )
+
+    conversation = chat_model.ChatConversation.model_construct(
+        uuid="c-1", user_id="u1", title="t", messages=[],
+    )
+    await conversation.add_message(
+        ChatRole.USER, "q", source_documents=source_documents,
+    )
+    return created[0]

--- a/frontend/src/types/chat.ts
+++ b/frontend/src/types/chat.ts
@@ -4,6 +4,19 @@ export interface ChatMessage {
   thinking?: string
   thinking_duration?: number
   citations?: Citation[]
+  /** Documents in scope when this turn was asked — `{uuid, title}` each, with
+   *  a final `{truncated: n}` when the selection was larger than is recorded.
+   *  Present on user turns; assistant turns carry `citations` instead. */
+  source_documents?: SourceDocument[]
+}
+
+/** A document that was attached when a question was asked. The title is stored
+ *  with the uuid so the record stays readable after the document is deleted. */
+export interface SourceDocument {
+  uuid?: string
+  title?: string
+  /** How many further documents were in scope but not recorded. */
+  truncated?: number
 }
 
 export interface FileAttachment {


### PR DESCRIPTION
Closes #607.

## The asymmetry

A KB-grounded answer recorded what it drew on:

```python
citations=kb_sources or None    # assistant turn
```

A **direct-document** answer recorded nothing — even though the router has the fully resolved, authorized set in hand at the moment it writes the user turn:

```python
await conversation.add_message(ChatRole.USER, message)   # scope discarded
```

So a saved conversation couldn't say which document produced which answer, and continuing a conversation across a changed selection — which the issue rightly calls deliberate and useful — left no trace of the change.

## The change

`ChatMessage` gains `source_documents`, written on the **user turn**: that's where the scope is chosen and where the router already has it. The assistant turn keeps `citations`, which is what it *drew on*. Read as a pair, they answer all three of the issue's questions — what was attached, what grounded the answer, and whether the set changed between turns.

**Titles are stored beside the uuids on purpose.** The record exists to be readable later, and a uuid stops resolving the moment the document is deleted — which is exactly when someone wants to know what an old answer was based on. Both are already in hand as the router authorizes the selection and expands folders, so this costs **no extra lookups**.

**The list is bounded.** Folder expansion alone allows 500 documents per folder, and this is written on every turn — so past a cap the record says how many it left out (`{"truncated": n}`) rather than growing without bound. The cap is applied on the write rather than asked of every caller.

**Attachment notices are left alone.** `"File attached: …"` turns carry no document scope, and the key stays absent rather than becoming an empty list, so an old message and a new one look the same to a reader.

## Scope

Per the issue, this does **not** reset a conversation when the selection changes. It only records what each turn used.

The frontend type is added so the record isn't invisible to consumers, but no UI is built on it here.

## Tests

Ten new. The router one fails against the code as it stood — it drives `POST /api/chat` with two selected documents and asserts the stored turn carries both, with titles.

The rest cover serialization, the absent-key case, the cap boundary (at, over, and the truncation marker), and that `add_message` threads and caps it.

`ruff check app/` clean. Full backend suite: **3688 passed**, 165 skipped. Frontend `tsc -b` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
