### PR TITLE
fix(extraction): raise on failure instead of returning empty results

### DIFF
--- a/backend/app/services/extraction_engine.py
+++ b/backend/app/services/extraction_engine.py
@@ -84,6 +84,17 @@ def _resolve_prompt(variant: str | None, source_label: str) -> str:
     return fn(source_label)
 
 
+class ExtractionError(RuntimeError):
+    """An extraction attempt failed — LLM/provider error or unparseable output.
+
+    Raised instead of returning an empty result so callers mark the run as
+    FAILED. An empty list from the engine must mean "the model found nothing",
+    never "the call died": swallowing errors into ``[]`` produced runs marked
+    "completed" with every field null — a crash rendered as "not in document",
+    which is the most dangerous possible misreport for this product.
+    """
+
+
 class ExtractionEngine:
     """Synchronous extraction engine. Thread-safe for use in Celery workers."""
 
@@ -472,18 +483,28 @@ class ExtractionEngine:
         # not the document — rely on pass 1's quotes instead.
         p2_capture = capture_sources and p2_content is content
 
-        if p2_structured:
-            final = self._extract_structured(
-                p2_content, keys, p2_model,
-                thinking_override=p2_thinking,
-                draft_hint=draft_hint,
-                allow_fallback=False,
-                meta_map=meta_map,
-                prompt_variant=prompt_variant,
-                capture_sources=p2_capture,
-            )
-        else:
-            final = self._extract_fallback_json(p2_content, keys, p2_model, thinking_override=p2_thinking, meta_map=meta_map, prompt_variant=prompt_variant, capture_sources=p2_capture)
+        # A pass-2 failure degrades to the pass-1 draft (logged) rather than
+        # failing the document — the draft is a complete extraction, and
+        # refinement is best-effort. A pass-1 failure above still propagates:
+        # with no draft there is nothing honest to return.
+        try:
+            if p2_structured:
+                final = self._extract_structured(
+                    p2_content, keys, p2_model,
+                    thinking_override=p2_thinking,
+                    draft_hint=draft_hint,
+                    allow_fallback=False,
+                    meta_map=meta_map,
+                    prompt_variant=prompt_variant,
+                    capture_sources=p2_capture,
+                )
+            else:
+                final = self._extract_fallback_json(p2_content, keys, p2_model, thinking_override=p2_thinking, meta_map=meta_map, prompt_variant=prompt_variant, capture_sources=p2_capture)
+        except ExtractionError as e:
+            if not draft:
+                raise
+            logger.warning("Two-pass refinement failed (%s); returning pass-1 draft", e)
+            final = []
 
         if capture_sources and final and draft:
             self._backfill_sources(final, draft)
@@ -548,28 +569,49 @@ class ExtractionEngine:
     # ------------------------------------------------------------------
 
     def _extract_with_consensus(self, content: ExtractionContent, keys: list[str], model_name: str, config: dict, meta_map: dict[str, dict] | None = None, capture_sources: bool = False) -> list:
+        # A minority of failed replicates degrades to voting among the
+        # successes (logged); ALL replicates failing raises — a total failure
+        # must never come back as an empty "nothing found" result.
         with ThreadPoolExecutor(max_workers=2) as executor:
             future_1 = executor.submit(self._dispatch_extraction, content, keys, model_name, config, meta_map, capture_sources)
             future_2 = executor.submit(self._dispatch_extraction, content, keys, model_name, config, meta_map, capture_sources)
-            result_1 = future_1.result()
-            result_2 = future_2.result()
+            results: list = []
+            errors: list[ExtractionError] = []
+            for future in (future_1, future_2):
+                try:
+                    results.append(future.result())
+                except ExtractionError as e:
+                    errors.append(e)
+        if not results:
+            raise errors[0]
+        if errors:
+            logger.warning(
+                "%d of 2 consensus replicates failed (%s); voting among the rest",
+                len(errors), errors[0],
+            )
 
-        # Quotes legitimately vary between replicates, so the source sidecar
-        # must not participate in the agreement check or the vote.
-        norm_1 = self._strip_sources(self._normalize_to_dict(result_1))
-        norm_2 = self._strip_sources(self._normalize_to_dict(result_2))
+        if len(results) == 2:
+            result_1, result_2 = results
+            # Quotes legitimately vary between replicates, so the source
+            # sidecar must not participate in the agreement check or the vote.
+            norm_1 = self._strip_sources(self._normalize_to_dict(result_1))
+            norm_2 = self._strip_sources(self._normalize_to_dict(result_2))
+            if norm_1 == norm_2:
+                return result_1 if result_1 else result_2
 
-        if norm_1 == norm_2:
-            return result_1 if result_1 else result_2
+        try:
+            results.append(self._dispatch_extraction(content, keys, model_name, config, meta_map, capture_sources))
+        except ExtractionError as e:
+            if len(results) < 2:
+                raise
+            logger.warning("Consensus tiebreak replicate failed (%s); voting among 2", e)
 
-        result_3 = self._dispatch_extraction(content, keys, model_name, config, meta_map, capture_sources)
-        norm_3 = self._strip_sources(self._normalize_to_dict(result_3))
-
-        consensus = self._majority_vote(keys, [norm_1, norm_2, norm_3])
+        norms = [self._strip_sources(self._normalize_to_dict(r)) for r in results]
+        consensus = self._majority_vote(keys, norms)
         if capture_sources:
             sidecar = self._sidecar_for_consensus(
-                consensus, [norm_1, norm_2, norm_3],
-                [self._normalize_to_dict(r) for r in (result_1, result_2, result_3)],
+                consensus, norms,
+                [self._normalize_to_dict(r) for r in results],
             )
             if sidecar:
                 consensus[SOURCE_KEY] = sidecar
@@ -916,9 +958,15 @@ class ExtractionEngine:
             if ("output validation" in error_msg or "retries" in error_msg.lower()
                     or "validation error" in error_msg.lower()):
                 if allow_fallback:
+                    logger.warning(
+                        "Structured extraction failed (%s); retrying via JSON fallback",
+                        error_msg,
+                    )
                     return self._extract_fallback_json(content, keys, model_name, thinking_override=thinking_override, meta_map=meta_map, prompt_variant=prompt_variant, capture_sources=capture_sources)
-                return []
-            return []
+                logger.exception("Structured extraction failed with no fallback allowed")
+                raise ExtractionError(f"Structured extraction failed: {error_msg}") from e
+            logger.exception("Extraction LLM call failed")
+            raise ExtractionError(f"Extraction failed: {error_msg}") from e
 
     @staticmethod
     def _attach_source_quotes(entities: list, sources: list) -> None:
@@ -1016,8 +1064,17 @@ class ExtractionEngine:
                 elif isinstance(parsed, list):
                     return parsed
                 return []
-            except json.JSONDecodeError:
-                return []
+            except json.JSONDecodeError as e:
+                logger.error(
+                    "Fallback extraction returned unparseable JSON (%d chars): %s",
+                    len(output or ""), e,
+                )
+                raise ExtractionError(
+                    "Model returned unparseable output in JSON-fallback extraction"
+                ) from e
 
-        except Exception:
-            return []
+        except ExtractionError:
+            raise
+        except Exception as e:
+            logger.exception("Fallback extraction LLM call failed")
+            raise ExtractionError(f"Extraction failed: {e}") from e

--- a/backend/tests/test_extraction_engine_core.py
+++ b/backend/tests/test_extraction_engine_core.py
@@ -10,7 +10,7 @@ from unittest.mock import MagicMock, patch, PropertyMock
 
 import pytest
 
-from app.services.extraction_engine import ExtractionEngine
+from app.services.extraction_engine import ExtractionEngine, ExtractionError
 
 
 def _make_mock_agent_result(output, request_tokens=10, response_tokens=5):
@@ -401,22 +401,24 @@ class TestFallbackExtraction:
         assert result[0]["Name"] == "Alice"
 
     @patch("app.services.extraction_engine.create_chat_agent")
-    def test_fallback_handles_invalid_json(self, mock_create_agent):
+    def test_fallback_raises_on_invalid_json(self, mock_create_agent):
+        """Unparseable model output raises — it must never read as "nothing found"."""
         mock_agent = MagicMock()
         mock_agent.run_sync.return_value = _make_mock_agent_result("not json at all")
         mock_create_agent.return_value = mock_agent
 
         engine = ExtractionEngine(system_config_doc={})
-        result = engine._extract_fallback_json("text", ["Name"], "gpt-4o")
-        assert result == []
+        with pytest.raises(ExtractionError):
+            engine._extract_fallback_json("text", ["Name"], "gpt-4o")
 
     @patch("app.services.extraction_engine.create_chat_agent")
-    def test_fallback_handles_exception(self, mock_create_agent):
+    def test_fallback_raises_on_exception(self, mock_create_agent):
+        """A dead LLM call raises so callers mark the run FAILED, not completed."""
         mock_create_agent.side_effect = RuntimeError("LLM down")
 
         engine = ExtractionEngine(system_config_doc={})
-        result = engine._extract_fallback_json("text", ["Name"], "gpt-4o")
-        assert result == []
+        with pytest.raises(ExtractionError):
+            engine._extract_fallback_json("text", ["Name"], "gpt-4o")
 
     @patch("app.services.extraction_engine.create_chat_agent")
     def test_fallback_list_response(self, mock_create_agent):
@@ -457,16 +459,17 @@ class TestStructuredExtractionErrors:
 
     @patch("app.services.extraction_engine.Agent")
     @patch("app.services.extraction_engine.get_agent_model")
-    def test_non_validation_error_returns_empty(self, mock_get_model, mock_agent_cls):
-        """Non-validation errors return empty list."""
+    def test_non_validation_error_raises(self, mock_get_model, mock_agent_cls):
+        """Provider/network errors raise so the run is marked FAILED — an
+        empty result must mean "nothing found", never "the call died"."""
         mock_get_model.return_value = MagicMock()
         mock_agent = MagicMock()
         mock_agent.run_sync.side_effect = ConnectionError("network error")
         mock_agent_cls.return_value = mock_agent
 
         engine = ExtractionEngine(system_config_doc={})
-        result = engine._extract_structured("text", ["Name"], "gpt-4o")
-        assert result == []
+        with pytest.raises(ExtractionError, match="network error"):
+            engine._extract_structured("text", ["Name"], "gpt-4o")
 
     @patch("app.services.extraction_engine.Agent")
     @patch("app.services.extraction_engine.get_agent_model")
@@ -489,15 +492,75 @@ class TestStructuredExtractionErrors:
     @patch("app.services.extraction_engine.Agent")
     @patch("app.services.extraction_engine.get_agent_model")
     def test_fallback_disabled(self, mock_get_model, mock_agent_cls):
-        """When allow_fallback=False, validation errors return empty."""
+        """When allow_fallback=False, validation errors raise instead of
+        silently shipping an empty result."""
         mock_get_model.return_value = MagicMock()
         mock_agent = MagicMock()
         mock_agent.run_sync.side_effect = Exception("output validation failed")
         mock_agent_cls.return_value = mock_agent
 
         engine = ExtractionEngine(system_config_doc={})
-        result = engine._extract_structured("text", ["Name"], "gpt-4o", allow_fallback=False)
-        assert result == []
+        with pytest.raises(ExtractionError):
+            engine._extract_structured("text", ["Name"], "gpt-4o", allow_fallback=False)
+
+
+# ---------------------------------------------------------------------------
+# Failure-degradation semantics
+# ---------------------------------------------------------------------------
+
+class TestFailureDegradation:
+    def test_two_pass_falls_back_to_draft_when_pass2_fails(self):
+        """A pass-2 refinement failure ships the pass-1 draft, not a crash."""
+        engine = ExtractionEngine(system_config_doc={})
+        draft = [{"Name": "Alice"}]
+
+        def fake_extract(content, keys, model, **kwargs):
+            if kwargs.get("allow_fallback") is False:  # pass 2
+                raise ExtractionError("pass 2 died")
+            return deepcopy(draft)
+
+        with patch.object(engine, "_extract_structured", side_effect=fake_extract):
+            result = engine._execute_two_pass(
+                "text", ["Name"], "gpt-4o",
+                pass_1_cfg={"structured": True},
+                pass_2_cfg={"structured": True},
+            )
+        assert result == draft
+
+    def test_two_pass_raises_when_pass1_fails(self):
+        """No draft, no dishonest empty result — pass-1 failure propagates."""
+        engine = ExtractionEngine(system_config_doc={})
+        with patch.object(
+            engine, "_extract_structured", side_effect=ExtractionError("pass 1 died"),
+        ):
+            with pytest.raises(ExtractionError):
+                engine._execute_two_pass(
+                    "text", ["Name"], "gpt-4o",
+                    pass_1_cfg={"structured": True},
+                    pass_2_cfg={"structured": True},
+                )
+
+    def test_consensus_raises_when_all_replicates_fail(self):
+        engine = ExtractionEngine(system_config_doc={})
+        with patch.object(
+            engine, "_dispatch_extraction", side_effect=ExtractionError("down"),
+        ):
+            with pytest.raises(ExtractionError):
+                engine._extract_with_consensus("text", ["Name"], "gpt-4o", {})
+
+    def test_consensus_survives_one_failed_replicate(self):
+        engine = ExtractionEngine(system_config_doc={})
+        calls = {"n": 0}
+
+        def fake_dispatch(*args, **kwargs):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise ExtractionError("replicate 1 died")
+            return [{"Name": "Alice"}]
+
+        with patch.object(engine, "_dispatch_extraction", side_effect=fake_dispatch):
+            result = engine._extract_with_consensus("text", ["Name"], "gpt-4o", {})
+        assert result and result[0]["Name"] == "Alice"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

The extraction engine swallowed every exception into an unlogged empty list (`extraction_engine.py` `_extract_structured`/`_extract_fallback_json`). Downstream, `normalize_results` filled the expected keys with `None` and the run was marked **"completed"** — an LLM provider timeout at 2am produced a green-checkmarked run whose every field read "not found", bypassing the entire failure-notification architecture. A crash rendered as "not in document" is the most dangerous possible misreport for a research-administration tool.

## Change

- New typed `ExtractionError`, raised (and logged at the throw site) on provider errors, unparseable fallback output, and validation failure with fallback disabled.
- **Deliberate degradations, both logged:** a pass-2 refinement failure falls back to the complete pass-1 draft; consensus voting tolerates a minority of failed replicates. A pass-1 failure or all replicates failing raises.
- Callers already handle a raise honestly (verified each): Celery tasks mark the run failed + notify (`extraction_tasks`, document-automation, `passive_tasks`), the workflow task-level handler marks the `WorkflowResult` "error" and rings the bell, run-sync fails the activity, and the tuning/quality-monitor loops isolate per-config / per-item failures.
- Also fixes measurement integrity: validation runs previously scored a dead LLM call as 0%-accuracy answers — corrupting scores and able to trigger false regression alerts. Now the validation run fails visibly instead.

## Tests

- Updated the 4 tests that pinned the old swallow behavior to assert the raising contract.
- New `TestFailureDegradation`: pass-2→draft fallback, pass-1 raise, consensus all-fail raise, consensus minority-fail survival.
- Full unit suite + extraction/workflow neighborhood green; `ruff check app/` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)