### PR TITLE
fix(tasks): make TRANSIENT_EXCEPTIONS match real transient failures

### DIFF
--- a/backend/app/tasks/__init__.py
+++ b/backend/app/tasks/__init__.py
@@ -15,11 +15,49 @@ logger = logging.getLogger(__name__)
 
 # Transient exceptions that are safe to retry with backoff.
 # Permanent errors (ValueError, KeyError, TypeError, etc.) should NOT be retried.
-TRANSIENT_EXCEPTIONS = (
-    ConnectionError,
-    TimeoutError,
-    OSError,
-)
+#
+# The builtins alone are not enough: the failures that actually occur in
+# production raise library exception types that do NOT inherit from them —
+# httpx timeouts/transport errors (httpx.HTTPError → Exception), pymongo
+# AutoReconnect (PyMongoError → Exception), redis connection errors
+# (RedisError → Exception) — so ``autoretry_for=TRANSIENT_EXCEPTIONS``
+# silently never fired for the most common blips. Each library is added
+# under an import guard so a missing optional dependency can't break task
+# module import.
+#
+# LLM-call errors are deliberately NOT here: pydantic-ai's ``ModelAPIError``
+# is transient but its subclass ``ModelHTTPError`` (an HTTP *status* error —
+# a 4xx won't improve on retry) is not, and an ``except autoretry_for``
+# clause cannot express that exclusion. Tasks that make LLM calls handle it
+# per-task with the catch/re-raise pattern in
+# ``kb_validation_tasks.generate_test_queries_task``.
+def _transient_exceptions() -> tuple[type[BaseException], ...]:
+    excs: list[type[BaseException]] = [ConnectionError, TimeoutError, OSError]
+    try:
+        import httpx
+
+        # TransportError covers ConnectError, ReadTimeout, WriteError, etc.
+        # HTTPStatusError is intentionally excluded (4xx/5xx responses).
+        excs.append(httpx.TransportError)
+    except ImportError:  # pragma: no cover
+        pass
+    try:
+        from pymongo.errors import AutoReconnect
+
+        excs.append(AutoReconnect)
+    except ImportError:  # pragma: no cover
+        pass
+    try:
+        from redis.exceptions import ConnectionError as RedisConnectionError
+        from redis.exceptions import TimeoutError as RedisTimeoutError
+
+        excs.extend([RedisConnectionError, RedisTimeoutError])
+    except ImportError:  # pragma: no cover
+        pass
+    return tuple(excs)
+
+
+TRANSIENT_EXCEPTIONS = _transient_exceptions()
 
 
 def run_task_async(coro: "Coroutine[Any, Any, Any]") -> Any:

--- a/backend/tests/test_transient_exceptions.py
+++ b/backend/tests/test_transient_exceptions.py
@@ -1,0 +1,67 @@
+"""TRANSIENT_EXCEPTIONS must match the transient errors that actually occur.
+
+The tuple is used as ``autoretry_for`` across the Celery task layer. The
+original builtins-only tuple (ConnectionError, TimeoutError, OSError) never
+matched httpx, pymongo, or redis failures — none of which inherit from the
+builtins — so the retry decorators effectively never fired for the most
+common production blips.
+"""
+
+import httpx
+import pytest
+from pymongo.errors import AutoReconnect
+from redis.exceptions import ConnectionError as RedisConnectionError
+from redis.exceptions import TimeoutError as RedisTimeoutError
+
+from app.tasks import TRANSIENT_EXCEPTIONS
+
+
+@pytest.mark.parametrize(
+    "exc_type",
+    [
+        # builtins (the original tuple)
+        ConnectionError,
+        TimeoutError,
+        OSError,
+        # httpx transport-level failures
+        httpx.ConnectError,
+        httpx.ConnectTimeout,
+        httpx.ReadTimeout,
+        httpx.WriteError,
+        httpx.RemoteProtocolError,
+        # database / broker blips
+        AutoReconnect,
+        RedisConnectionError,
+        RedisTimeoutError,
+    ],
+)
+def test_transient_error_is_retryable(exc_type):
+    assert issubclass(exc_type, TRANSIENT_EXCEPTIONS)
+
+
+@pytest.mark.parametrize(
+    "exc_type",
+    [
+        # Permanent errors must never be auto-retried.
+        ValueError,
+        KeyError,
+        TypeError,
+        # An HTTP *status* error (4xx/5xx response arrived) is not a
+        # transport failure — a 404 won't improve on retry.
+        httpx.HTTPStatusError,
+        # LLM-call errors are handled per-task (ModelHTTPError exclusion),
+        # never via the shared tuple.
+    ],
+)
+def test_permanent_error_is_not_retryable(exc_type):
+    assert not issubclass(exc_type, TRANSIENT_EXCEPTIONS)
+
+
+def test_pydantic_ai_errors_stay_out_of_the_shared_tuple():
+    """ModelAPIError retry needs a ModelHTTPError exclusion that a plain
+    ``except autoretry_for`` clause cannot express — see
+    kb_validation_tasks.generate_test_queries_task for the per-task pattern."""
+    from pydantic_ai.exceptions import ModelAPIError, ModelHTTPError
+
+    assert not issubclass(ModelAPIError, TRANSIENT_EXCEPTIONS)
+    assert not issubclass(ModelHTTPError, TRANSIENT_EXCEPTIONS)


### PR DESCRIPTION
## Problem

`TRANSIENT_EXCEPTIONS` was builtins-only (`ConnectionError`, `TimeoutError`, `OSError`). The transient failures production actually raises — httpx timeouts/transport errors, pymongo `AutoReconnect`, redis connection errors — inherit from none of them, so every `autoretry_for=TRANSIENT_EXCEPTIONS` decorator across the task layer was effectively decorative: an HTTP hiccup or a Mongo election failed the task on the first attempt.

## Change

Extends the tuple with `httpx.TransportError`, `pymongo.errors.AutoReconnect`, and redis `ConnectionError`/`TimeoutError`, each under an import guard.

Deliberately **excluded**:
- `httpx.HTTPStatusError` — a 4xx/5xx response arrived; retrying a 404 doesn't help.
- pydantic-ai `ModelAPIError` — transient, but its subclass `ModelHTTPError` must not be retried, and an `except autoretry_for` clause can't express that exclusion. LLM tasks keep the per-task pattern already documented in `kb_validation_tasks.generate_test_queries_task`.

Note: with these errors now retryable, failure notifications fire on the *final* attempt per the existing `is_final_attempt` contract — previously they fired on attempt 1 because nothing ever retried.

## Tests

New `tests/test_transient_exceptions.py` pins retryable vs non-retryable classes, including the ModelAPIError exclusion rationale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)