### PR TITLE
fix(documents): stop ingesting reader crashes as content; surface errored docs

### DIFF
--- a/backend/app/services/document_readers.py
+++ b/backend/app/services/document_readers.py
@@ -13,6 +13,17 @@ from markitdown import MarkItDown
 
 logger = logging.getLogger(__name__)
 
+
+class DocumentReadError(RuntimeError):
+    """Text extraction failed for a document.
+
+    Raised instead of returning an error-message string as if it were the
+    document's text — a returned placeholder is indistinguishable from real
+    content downstream (it gets token-counted, chunked, and embedded), so a
+    crashed reader must fail the document visibly instead.
+    """
+
+
 MIN_PDF_TEXT_LENGTH = 100
 MAX_XLSX_COMMENT_LEN = 500
 
@@ -958,5 +969,13 @@ def extract_text_from_file(file_path: str, file_extension: str) -> str:
         return ""
 
     except Exception as e:
+        # Raise instead of returning an error string: a returned
+        # "[Error extracting content: …]" is non-empty, so it sailed past the
+        # empty-text guard, was token-counted, chunked, and embedded into
+        # ChromaDB as the document's entire content — the document showed as
+        # processed and chat answered confidently from a one-line error
+        # message. A reader crash must fail the document visibly.
         logger.error("Error extracting text from %s: %s", file_path, e)
-        return f"[Error extracting content: {e!s}]"
+        raise DocumentReadError(
+            f"Could not read this {file_extension or 'file'}: {e!s}"
+        ) from e

--- a/backend/app/services/document_service.py
+++ b/backend/app/services/document_service.py
@@ -117,6 +117,7 @@ async def list_contents(
                 "chromadb_ready": d.chromadb_ready,
                 "chunk_count": d.chunk_count,
                 "ingest_error": d.ingest_error,
+                "error_message": d.error_message,
                 "extraction_low_quality": is_extraction_low_quality(d),
             }
             for d in documents

--- a/backend/app/tasks/document_tasks.py
+++ b/backend/app/tasks/document_tasks.py
@@ -388,6 +388,13 @@ def perform_extraction_and_update(self, document_uuid: str, extension: str) -> s
                 "Document %s produced empty extracted text (ext=%s) — marking as error",
                 document_uuid, extension,
             )
+            message = (
+                "We couldn't extract any text from this document. "
+                "It may be blank, image-only, or encrypted, or our "
+                "OCR service may be temporarily unavailable. Try "
+                "retrying — if it keeps failing, re-upload or "
+                "contact support."
+            )
             db.smart_document.update_one(
                 {"uuid": document_uuid},
                 {
@@ -401,16 +408,14 @@ def perform_extraction_and_update(self, document_uuid: str, extension: str) -> s
                         # a previously-good document is reprocessed.
                         "num_pages": 0,
                         "task_status": "error",
-                        "error_message": (
-                            "We couldn't extract any text from this document. "
-                            "It may be blank, image-only, or encrypted, or our "
-                            "OCR service may be temporarily unavailable. Try "
-                            "retrying — if it keeps failing, re-upload or "
-                            "contact support."
-                        ),
+                        "error_message": message,
                     }
                 },
             )
+            # Every other terminal-error branch notifies; this one silently
+            # relied on the user noticing the row state — which the file list
+            # didn't render either. Same coalesced bell as the rest.
+            _notify_document_processing_failed(db, document_uuid, message)
             return ""
 
         update_fields: dict = {

--- a/backend/app/tasks/upload_validation_tasks.py
+++ b/backend/app/tasks/upload_validation_tasks.py
@@ -285,7 +285,18 @@ def perform_document_validation(
             else os.path.join(Settings().upload_dir, rel_or_abs)
         )
         ext = os.path.splitext(file_path)[1].lstrip(".")
-        text = extract_text_from_file(file_path, ext)
+        try:
+            text = extract_text_from_file(file_path, ext)
+        except Exception as e:
+            # The extraction task owns reporting read failures (it marks the
+            # document errored and notifies). For compliance validation a
+            # failed read just means nothing to validate: empty text produces
+            # zero chunks and the chord callback still runs, so the
+            # "validating" flag clears instead of stalling forever.
+            logger.warning(
+                "Validation text read failed for %s: %s", document_uuid, e,
+            )
+            text = ""
 
     compliance = settings["rules"]
     effective_chunk_size = chunk_size or settings["chunk_size"]

--- a/frontend/src/components/files/FileRow.tsx
+++ b/frontend/src/components/files/FileRow.tsx
@@ -90,6 +90,23 @@ export function FileRow({ doc, onClick, onContextMenu, selected, onToggleSelect,
             >
               <AlertTriangle className="h-4 w-4 text-red-500" />
             </span>
+          ) : doc.task_status === 'error' ? (
+            <span
+              className="shrink-0 mr-2.5 inline-flex items-center"
+              role="img"
+              aria-label={
+                doc.error_message
+                  ? `Text extraction failed: ${doc.error_message}`
+                  : 'Text extraction failed for this document — chat and extraction cannot read it. Try Retry extraction or re-upload it.'
+              }
+              title={
+                doc.error_message
+                  ? `Text extraction failed: ${doc.error_message}`
+                  : 'Text extraction failed for this document — chat and extraction cannot read it. Try Retry extraction or re-upload it.'
+              }
+            >
+              <AlertTriangle className="h-4 w-4 text-red-500" />
+            </span>
           ) : doc.ingest_error ? (
             <span
               className="shrink-0 mr-2.5 inline-flex items-center"

--- a/frontend/src/types/document.ts
+++ b/frontend/src/types/document.ts
@@ -21,6 +21,7 @@ export interface Document {
   chromadb_ready?: boolean
   chunk_count?: number
   ingest_error?: string | null
+  error_message?: string | null
   extraction_low_quality?: boolean
 }
 


### PR DESCRIPTION
## Problem

Three ways a failed ingest hid from the user:

1. `extract_text_from_file` returned `"[Error extracting content: …]"` as if it were the document's text. Being non-empty it passed the empty-text guard, was token-counted, chunked, and **embedded into ChromaDB as the document's entire content** — the document showed as processed and chat answered confidently from a one-line error message.
2. The empty-extracted-text branch marked `task_status "error"` but was the only terminal-error branch that skipped `_notify_document_processing_failed` — a scanned PDF with OCR down failed in complete silence.
3. The file list had no badge for `task_status === "error"` (only validation/ingest/low-quality states), so an errored document looked like a perfectly normal row until someone opened the viewer.

## Change

- `extract_text_from_file` raises a typed `DocumentReadError` (logged) instead of returning the placeholder; the extraction task's existing failure branch marks the document errored + notifies. The benign `FileNotFoundError` → `""` branch is unchanged. The compliance-validation task degrades to empty text on a read failure so its chord callback still runs and `validating` clears.
- The empty-text branch now sends the same coalesced failure notification as every other terminal-error branch.
- `FileRow` shows a red badge with the document's `error_message` for errored docs; the list serializer and `Document` type carry `error_message`.

## Tests

Backend document/reader/upload/ocr test set green (424 passed); `ruff check app/` clean; frontend `tsc -b` and eslint clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)