### PR TITLE
fix(extraction): record whether a source quote supports its value

### DIFF
--- a/backend/app/services/extraction_engine.py
+++ b/backend/app/services/extraction_engine.py
@@ -544,6 +544,12 @@ class ExtractionEngine:
                 if field not in entity or field in sidecar:
                     continue
                 if not _same_value(entity.get(field), draft_value):
+                    # Withhold the quote, but leave an entry behind. Dropping
+                    # the field entirely makes the UI render it unmarked —
+                    # the state that looks cleanest — so a revised value would
+                    # lose both its badge and its warning, and would vanish
+                    # from the value-support distribution instead of counting.
+                    sidecar[field] = {"quote": None, "dropped_reason": "value_changed"}
                     continue
                 sidecar[field] = src
 

--- a/backend/app/services/extraction_engine.py
+++ b/backend/app/services/extraction_engine.py
@@ -17,7 +17,11 @@ from pydantic import BaseModel, ConfigDict, Field, create_model, model_validator
 from pydantic_ai import Agent, BinaryContent, NativeOutput
 
 from app.models.system_config import DEFAULT_EXTRACTION_CONFIG, _deep_merge
-from app.services.extraction_sources import SOURCE_KEY, resolve_entity_sources
+from app.services.extraction_sources import (
+    SOURCE_KEY,
+    resolve_entity_sources,
+    same_value as _same_value,
+)
 from app.services.llm_service import (
     build_thinking_model_settings,
     create_chat_agent,
@@ -202,7 +206,7 @@ class ExtractionEngine:
                     self._resolve_sources(
                         doc_results,
                         texts[idx] if idx < len(texts) else "",
-                        (doc_metadata or []), idx,
+                        (doc_metadata or []), idx, meta_map,
                     )
                 all_results.extend(doc_results)
             return all_results
@@ -222,15 +226,18 @@ class ExtractionEngine:
                 capture_sources=capture_sources,
             )
             if doc_results and capture_sources:
-                self._resolve_sources(doc_results, doc_text, (doc_metadata or []), idx)
+                self._resolve_sources(doc_results, doc_text, (doc_metadata or []), idx, meta_map)
             all_results.extend(doc_results)
 
         return all_results
 
     @staticmethod
-    def _resolve_sources(entities: list, doc_text: str, doc_metadata: list[dict], idx: int) -> None:
+    def _resolve_sources(
+        entities: list, doc_text: str, doc_metadata: list[dict], idx: int,
+        field_meta: dict[str, dict] | None = None,
+    ) -> None:
         meta = doc_metadata[idx] if idx < len(doc_metadata) else {}
-        resolve_entity_sources(entities, doc_text or "", meta or {})
+        resolve_entity_sources(entities, doc_text or "", meta or {}, field_meta)
 
     def build_from_documents(self, doc_texts: list[str], model: str) -> dict | None:
         """Generate extraction entities from document text using LLM."""
@@ -512,21 +519,33 @@ class ExtractionEngine:
 
     @staticmethod
     def _backfill_sources(final: list, draft: list) -> None:
-        """Fill final entities' missing per-field quotes from the draft pass."""
-        draft_sources: dict = {}
+        """Fill final entities' missing per-field quotes from the draft pass.
+
+        Only when pass 2 kept pass 1's value for that field. Pass 2 routinely
+        *changes* values, and the draft's quote supports the draft's value —
+        copying it onto a changed value attaches a passage that contradicts
+        what is displayed, then the quote verifies (it is real document text)
+        and the field earns a source badge pointing at evidence against
+        itself. Values are compared after the same normalization used for
+        source matching, so formatting-only differences still backfill.
+        """
+        draft_entries: dict = {}
         for entity in draft:
             if isinstance(entity, dict) and isinstance(entity.get(SOURCE_KEY), dict):
                 for field, src in entity[SOURCE_KEY].items():
-                    draft_sources.setdefault(field, src)
-        if not draft_sources:
+                    draft_entries.setdefault(field, (entity.get(field), src))
+        if not draft_entries:
             return
         for entity in final:
             if not isinstance(entity, dict):
                 continue
             sidecar = entity.setdefault(SOURCE_KEY, {})
-            for field, src in draft_sources.items():
-                if field in entity and field not in sidecar:
-                    sidecar[field] = src
+            for field, (draft_value, src) in draft_entries.items():
+                if field not in entity or field in sidecar:
+                    continue
+                if not _same_value(entity.get(field), draft_value):
+                    continue
+                sidecar[field] = src
 
     @staticmethod
     def _format_draft_as_text(draft: dict, keys: list[str]) -> str:

--- a/backend/app/services/extraction_sources.py
+++ b/backend/app/services/extraction_sources.py
@@ -151,8 +151,19 @@ _NOT_FOUND_VARIANTS = frozenset({
     "no information", "no entry", "missing", "empty", "blank",
 })
 
-_CURRENCY_CHARS = "$€£¥%"
-_NUMBER_IN_TEXT_RE = re.compile(r"[-+]?\d[\d,]*(?:\.\d+)?")
+_CURRENCY_CHARS = "$€£¥"
+# Comma groups only in thousands position: `[\d,]*` swallowed "1,2,3" as one
+# token, which then parsed as 123 and "supported" a value of 123 with a quote
+# listing sections 1, 2 and 3.
+_NUMBER_IN_TEXT_RE = re.compile(
+    r"[-+]?\d{1,3}(?:,\d{3})+(?:\.\d+)?|[-+]?\d+(?:\.\d+)?"
+)
+
+# A quote is a passage, not a document. Past this the value question is not
+# worth asking, and asking it is not free: the date scan below backtracks
+# quadratically on long space-free text (OCR that lost its spaces, or a
+# degenerate model response), and the quote is model-controlled.
+_MAX_QUOTE_CHARS = 4000
 
 _MONTHS = "jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec"
 _DATE_IN_TEXT_RE = re.compile(
@@ -189,13 +200,67 @@ def _as_number(text: str) -> Optional[float]:
         return None
 
 
-def _numbers_in(text: str) -> set[float]:
-    out: set[float] = set()
+def _number_with_pct(text: str) -> Optional[tuple[float, bool]]:
+    """Parse a whole string as (number, is_percent).
+
+    A percentage is not the same quantity as the bare number: "$50" must not
+    be certified by a quote that says "50% of MTDC", so the unit travels with
+    the value instead of being stripped away.
+    """
+    s = text.strip()
+    pct = s.endswith("%")
+    if pct:
+        s = s[:-1]
+    n = _as_number(s)
+    return None if n is None else (n, pct)
+
+
+def _numbers_in(text: str) -> set[tuple[float, bool]]:
+    out: set[tuple[float, bool]] = set()
     for m in _NUMBER_IN_TEXT_RE.finditer(text):
         n = _as_number(m.group())
         if n is not None:
-            out.add(n)
+            out.add((n, text[m.end():m.end() + 1] == "%"))
     return out
+
+
+def _match_boundaries_ok(quote: str, start: int, end: int, *, numeric: bool) -> bool:
+    """Is the match at ``[start, end)`` a whole value rather than a fragment?
+
+    Without this the literal check is a bare substring test, so a quote saying
+    5000000 "supports" a value of 500000, $500,000.99 supports $500,000, and
+    "John Smithson" supports "John Smith" — over-claiming in exactly the
+    direction the value check exists to catch.
+    """
+    before = quote[start - 1] if start > 0 else ""
+    after = quote[end] if end < len(quote) else ""
+    if numeric:
+        # A digit or a group/decimal separator on either side means the match
+        # is a slice of a longer number. A trailing "." or "," only counts as
+        # part of the number when a digit follows it, so ordinary sentence
+        # punctuation still ends a value cleanly.
+        if before.isdigit() or before in ".,":
+            return False
+        if after.isdigit():
+            return False
+        if after in ".," and end + 1 < len(quote) and quote[end + 1].isdigit():
+            return False
+        return True
+    return not (before.isalnum() or after.isalnum())
+
+
+def _literal_match(norm_value: str, norm_quote: str, *, numeric: bool) -> bool:
+    """Whether *norm_value* occurs in *norm_quote* as a whole value.
+
+    Scans every occurrence: the first may be a fragment ("500,000" inside
+    "1,500,000") while a later one is genuine.
+    """
+    idx = norm_quote.find(norm_value)
+    while idx != -1:
+        if _match_boundaries_ok(norm_quote, idx, idx + len(norm_value), numeric=numeric):
+            return True
+        idx = norm_quote.find(norm_value, idx + 1)
+    return False
 
 
 def _as_date(text: str) -> Optional[date]:
@@ -234,7 +299,7 @@ def same_value(a, b) -> bool:
     if norm_a == norm_b:
         return True
 
-    num_a, num_b = _as_number(a_str), _as_number(b_str)
+    num_a, num_b = _number_with_pct(a_str), _number_with_pct(b_str)
     if num_a is not None and num_b is not None:
         return num_a == num_b
 
@@ -256,20 +321,30 @@ def value_supported_by_quote(
     rather than a span of it. ``method`` records how the answer was reached so
     the distribution can be measured before any of this drives a badge.
 
-    Deliberately strict: only literal, numeric, and date equivalence count.
+    Deliberately strict: only literal, numeric, and date equivalence count,
+    and a literal match must sit on value boundaries — a digit or separator
+    beside a number, or an alphanumeric beside a name, means the match is a
+    fragment of something else and does not count.
     A multi-part value assembled from a sentence ("Jane Smith, Chemistry")
     reads as unsupported. That is the conservative direction for a field that
     is recorded but not yet surfaced — if measurement shows it dominates, a
     partial-coverage rule can be added with evidence behind it.
 
-    Two known weaknesses to read the measured distribution against. Very short
-    values ("1", "A") match almost any passage by coincidence, so their
-    ``True`` carries little evidence. And a value that is a judgment about the
+    Three known weaknesses to read the measured distribution against. Very
+    short values ("1", "A") match almost any passage by coincidence, so their
+    ``True`` carries little evidence. A value that is a judgment about the
     passage rather than a span of it ("Yes" for "cost sharing is required")
-    reads as unsupported unless the field declares ``enum_values``.
+    reads as unsupported unless the field declares ``enum_values``. And the
+    check asks only whether the value appears *somewhere* in the passage, not
+    whether the passage assigns it to this field: a "Direct Costs" value is
+    supported by a quote that labels that same figure as indirect, and a year
+    (2024) by a dollar amount ($2,024). Reading a ``True`` as "the quote says
+    this field is this value" therefore over-reads it.
     """
     if not quote or not quote.strip():
         return None, "no_quote"
+    if len(quote) > _MAX_QUOTE_CHARS:
+        return None, "quote_too_long"
     if _is_not_found(value):
         return None, "empty_value"
     if enum_field:
@@ -286,10 +361,10 @@ def value_supported_by_quote(
     if not norm_value:
         return None, "empty_value"
 
-    if norm_value in norm_quote:
+    num = _number_with_pct(value_str)
+    if _literal_match(norm_value, norm_quote, numeric=num is not None):
         return True, "literal"
 
-    num = _as_number(value_str)
     if num is not None and num in _numbers_in(quote):
         return True, "numeric"
 
@@ -362,6 +437,13 @@ def resolve_entity_sources(
                     entity.get(field), quote,
                     enum_field=bool(meta.get("enum_values")),
                 )
+            elif isinstance(src, dict) and src.get("dropped_reason") == "value_changed":
+                # Pass 2 revised the value, so pass 1's quote was withheld
+                # rather than failing to locate. Kept as an entry (not dropped)
+                # so the UI renders "no source found" instead of nothing, and
+                # so these fields are counted rather than vanishing from the
+                # distribution.
+                supported, method = None, "value_changed_in_refinement"
             else:
                 supported, method = None, "quote_not_located"
             sidecar[field] = {

--- a/backend/app/services/extraction_sources.py
+++ b/backend/app/services/extraction_sources.py
@@ -10,9 +10,21 @@ A passage that cannot be located in the document — even after unicode
 normalization — is marked ``verified: False``, which the frontend surfaces
 as "no source found": both a traceability gap and a hallucination signal.
 
+``verified`` answers only "does this passage exist in the document?". It says
+nothing about whether the passage supports the value shown beside it: a model
+that hallucinates an award amount and returns any real sentence from the
+budget section earns a located quote. ``value_supported`` answers the second,
+load-bearing question — is the extracted value actually present in the
+passage — and is recorded separately so the two claims never get conflated.
+
 Pure string/offset logic only; no DB or LLM access, safe to import anywhere.
+That purity is why the number/date parsing below is duplicated here in
+miniature rather than imported from ``extraction_validation_service``, which
+pulls in the engine, Beanie documents, and system config.
 """
 
+import re
+from datetime import date, datetime
 from typing import Optional
 
 # Reserved sidecar key on entity dicts: {field_name: source dict}. Every
@@ -125,18 +137,196 @@ def _doc_for_offset(offset: int, doc_spans: list[dict]) -> Optional[dict]:
     return None
 
 
-def resolve_entity_sources(entities: list, doc_text: str, doc_meta: dict) -> None:
+# ---------------------------------------------------------------------------
+# Value support: is the extracted value actually present in its quote?
+# ---------------------------------------------------------------------------
+
+# Kept in sync with extraction_validation_service._NOT_FOUND_VARIANTS. A
+# sentinel has no value to support, so it is never counted either way.
+_NOT_FOUND_VARIANTS = frozenset({
+    "", "n/a", "na", "n.a.", "not found", "not available",
+    "not applicable", "none", "null", "nil", "unknown", "-", "--", "---",
+    "nan", "no data", "no value", "not provided", "not specified",
+    "not present", "not stated", "not mentioned", "not given",
+    "no information", "no entry", "missing", "empty", "blank",
+})
+
+_CURRENCY_CHARS = "$€£¥%"
+_NUMBER_IN_TEXT_RE = re.compile(r"[-+]?\d[\d,]*(?:\.\d+)?")
+
+_MONTHS = "jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec"
+_DATE_IN_TEXT_RE = re.compile(
+    r"\d{4}-\d{1,2}-\d{1,2}"
+    r"|\d{1,2}[/-]\d{1,2}[/-]\d{2,4}"
+    rf"|(?:{_MONTHS})[a-z]*\.?\s+\d{{1,2}},?\s+\d{{4}}"
+    rf"|\d{{1,2}}\s+(?:{_MONTHS})[a-z]*\.?,?\s+\d{{4}}",
+    re.IGNORECASE,
+)
+_DATE_FORMATS = (
+    "%Y-%m-%d", "%m/%d/%Y", "%m/%d/%y", "%m-%d-%Y", "%m-%d-%y",
+    "%B %d, %Y", "%B %d %Y", "%b %d, %Y", "%b %d %Y",
+    "%d %B %Y", "%d %b %Y", "%d %B, %Y", "%d %b, %Y",
+)
+
+
+def _is_not_found(value) -> bool:
+    if value is None:
+        return True
+    return str(value).strip().lower() in _NOT_FOUND_VARIANTS
+
+
+def _as_number(text: str) -> Optional[float]:
+    """Parse a whole string as a number, tolerating currency/percent/commas."""
+    cleaned = text.strip()
+    for ch in _CURRENCY_CHARS:
+        cleaned = cleaned.replace(ch, "")
+    cleaned = cleaned.replace(",", "").replace(" ", "")
+    if not cleaned:
+        return None
+    try:
+        return float(cleaned)
+    except ValueError:
+        return None
+
+
+def _numbers_in(text: str) -> set[float]:
+    out: set[float] = set()
+    for m in _NUMBER_IN_TEXT_RE.finditer(text):
+        n = _as_number(m.group())
+        if n is not None:
+            out.add(n)
+    return out
+
+
+def _as_date(text: str) -> Optional[date]:
+    s = text.strip().rstrip(".,").replace(".", "")
+    for fmt in _DATE_FORMATS:
+        try:
+            return datetime.strptime(s, fmt).date()
+        except ValueError:
+            continue
+    return None
+
+
+def _dates_in(text: str) -> set[date]:
+    out: set[date] = set()
+    for m in _DATE_IN_TEXT_RE.finditer(text):
+        d = _as_date(m.group())
+        if d is not None:
+            out.add(d)
+    return out
+
+
+def same_value(a, b) -> bool:
+    """Whether two extracted values are the same value.
+
+    Formatting-tolerant in the same directions as the quote matcher: unicode
+    folding, then numeric and date equivalence. Used to decide whether a
+    quote captured for one pass's value may be carried onto another's.
+    """
+    a_nf, b_nf = _is_not_found(a), _is_not_found(b)
+    if a_nf or b_nf:
+        return a_nf and b_nf
+
+    a_str, b_str = str(a).strip(), str(b).strip()
+    norm_a, _ = normalize_with_map(a_str)
+    norm_b, _ = normalize_with_map(b_str)
+    if norm_a == norm_b:
+        return True
+
+    num_a, num_b = _as_number(a_str), _as_number(b_str)
+    if num_a is not None and num_b is not None:
+        return num_a == num_b
+
+    date_a, date_b = _as_date(a_str), _as_date(b_str)
+    if date_a is not None and date_b is not None:
+        return date_a == date_b
+
+    return False
+
+
+def value_supported_by_quote(
+    value, quote: Optional[str], *, enum_field: bool = False,
+) -> tuple[Optional[bool], str]:
+    """Is *value* actually supported by *quote*?
+
+    Returns ``(supported, method)``. ``supported`` is None when the question
+    does not apply — there is no quote, the value is a "not found" sentinel,
+    or the field is an enum whose allowed values are a mapping of the prose
+    rather than a span of it. ``method`` records how the answer was reached so
+    the distribution can be measured before any of this drives a badge.
+
+    Deliberately strict: only literal, numeric, and date equivalence count.
+    A multi-part value assembled from a sentence ("Jane Smith, Chemistry")
+    reads as unsupported. That is the conservative direction for a field that
+    is recorded but not yet surfaced — if measurement shows it dominates, a
+    partial-coverage rule can be added with evidence behind it.
+
+    Two known weaknesses to read the measured distribution against. Very short
+    values ("1", "A") match almost any passage by coincidence, so their
+    ``True`` carries little evidence. And a value that is a judgment about the
+    passage rather than a span of it ("Yes" for "cost sharing is required")
+    reads as unsupported unless the field declares ``enum_values``.
+    """
+    if not quote or not quote.strip():
+        return None, "no_quote"
+    if _is_not_found(value):
+        return None, "empty_value"
+    if enum_field:
+        return None, "enum_field"
+    if not isinstance(value, (str, int, float)) or isinstance(value, bool):
+        # Lists/dicts/bools have no verbatim form to look for. Counting them
+        # unsupported would load the measurement with a class that carries no
+        # hallucination signal.
+        return None, "non_scalar_value"
+
+    value_str = str(value).strip()
+    norm_value, _ = normalize_with_map(value_str)
+    norm_quote, _ = normalize_with_map(quote)
+    if not norm_value:
+        return None, "empty_value"
+
+    if norm_value in norm_quote:
+        return True, "literal"
+
+    num = _as_number(value_str)
+    if num is not None and num in _numbers_in(quote):
+        return True, "numeric"
+
+    dt = _as_date(value_str)
+    if dt is not None and dt in _dates_in(quote):
+        return True, "date"
+
+    return False, "no_match"
+
+
+def resolve_entity_sources(
+    entities: list,
+    doc_text: str,
+    doc_meta: dict,
+    field_meta: Optional[dict] = None,
+) -> None:
     """Verify and locate each entity's raw source quotes, in place.
 
     The engine attaches ``entity[SOURCE_KEY] = {field: {"quote": str}}``.
     This fills each entry out to::
 
-        {"quote", "page", "document_uuid", "document_title", "verified"}
+        {"quote", "page", "document_uuid", "document_title", "verified",
+         "value_supported", "value_support_method"}
+
+    ``verified`` is unchanged: the quote was located in the document.
+    ``value_supported`` is the separate, stronger claim that the value shown
+    to the user actually appears in that quote (None when the check does not
+    apply — see :func:`value_supported_by_quote`). Keeping them apart is
+    deliberate: today's UI treats a located quote as proof of the value, and
+    collapsing the two here would bake that error in permanently.
 
     *doc_meta* carries ``uuid``, ``title``, ``text_markers``, and (for
     combined-context runs over a merged text) optional ``doc_spans`` —
     ``[{"start", "end", "uuid", "title"}]`` — used to attribute an offset to
-    the document that contributed it.
+    the document that contributed it. *field_meta* is the engine's per-field
+    metadata map (``{key: {"enum_values", "is_optional"}}``), used to skip the
+    value check on enum fields.
     """
     markers = doc_meta.get("text_markers") or []
     doc_spans = doc_meta.get("doc_spans") or []
@@ -163,12 +353,25 @@ def resolve_entity_sources(entities: list, doc_text: str, doc_meta: dict) -> Non
             page_marker = (
                 page_marker_for_offset(offset, markers) if offset is not None else None
             )
+            # Only ask whether the value is supported once the quote is known
+            # to exist — a fabricated passage that happens to contain the
+            # value proves nothing, so an unlocated quote stays unassessed.
+            meta = (field_meta or {}).get(field) or {}
+            if offset is not None:
+                supported, method = value_supported_by_quote(
+                    entity.get(field), quote,
+                    enum_field=bool(meta.get("enum_values")),
+                )
+            else:
+                supported, method = None, "quote_not_located"
             sidecar[field] = {
                 "quote": quote,
                 "page": page_marker.get("value") if page_marker else None,
                 "document_uuid": doc_uuid,
                 "document_title": doc_title,
                 "verified": offset is not None,
+                "value_supported": supported,
+                "value_support_method": method,
             }
             # Set only when true, so sidecars for measured pages keep the shape
             # they have always had and existing results stay comparable.

--- a/backend/tests/test_extraction_sources.py
+++ b/backend/tests/test_extraction_sources.py
@@ -13,6 +13,7 @@ from app.services.extraction_sources import (
     normalize_with_map,
     page_for_offset,
     resolve_entity_sources,
+    same_value,
 )
 from app.tasks.extraction_tasks import normalize_results
 
@@ -138,10 +139,18 @@ class TestPageResolution:
             "document_uuid": "U1",
             "document_title": "T&C",
             "verified": True,
+            # "Yes" is a judgment about the passage, not a span of it, so the
+            # literal check reads it as unsupported. Declaring the field's
+            # enum_values (see TestValueSupport) is what marks such fields
+            # unassessable instead — the reason value_supported is recorded
+            # and measured before it is allowed to drive any badge.
+            "value_supported": False,
+            "value_support_method": "no_match",
         }
         missing = entities[0][SOURCE_KEY]["Award Number"]
         assert missing["verified"] is False
         assert missing["page"] is None
+        assert missing["value_supported"] is None
 
     def test_resolve_combined_doc_spans(self):
         doc = "first document text" + "\n\n---\n\n" + "second document text"
@@ -295,3 +304,177 @@ class TestExtractWithCaptureSources:
         assert results == [{"A": "1"}]
         system_prompt = mock_agent_cls.call_args.kwargs.get("system_prompt", "")
         assert "'sources'" not in system_prompt
+
+
+# ---------------------------------------------------------------------------
+# Value support: does the quote actually contain the value it is attached to?
+# ---------------------------------------------------------------------------
+
+class TestValueSupport:
+    def test_real_quote_does_not_vouch_for_a_hallucinated_value(self):
+        """The defect this check exists for.
+
+        A model invents an award amount and returns a genuine sentence from
+        the budget section as its supporting passage. The quote verifies —
+        it is real document text — and today that alone lights the source
+        badge. ``value_supported`` must say False.
+        """
+        doc_text = "The budget narrative describes personnel and travel costs in detail."
+        entities = [{
+            "Award Amount": "$500,000",
+            SOURCE_KEY: {"Award Amount": {"quote": doc_text}},
+        }]
+        resolve_entity_sources(entities, doc_text, {})
+        src = entities[0][SOURCE_KEY]["Award Amount"]
+        assert src["verified"] is True
+        assert src["value_supported"] is False
+        assert src["value_support_method"] == "no_match"
+
+    def test_literal_value_in_quote_is_supported(self):
+        doc_text = "Proposals are due March 1, 2026 at 5:00 PM local time."
+        entities = [{
+            "Deadline": "March 1, 2026",
+            SOURCE_KEY: {"Deadline": {"quote": doc_text}},
+        }]
+        resolve_entity_sources(entities, doc_text, {})
+        src = entities[0][SOURCE_KEY]["Deadline"]
+        assert (src["value_supported"], src["value_support_method"]) == (True, "literal")
+
+    def test_currency_formatting_still_counts_as_supported(self):
+        doc_text = "Equipment costs total 61,100 in year one."
+        entities = [{
+            "Equipment": "$61,100",
+            SOURCE_KEY: {"Equipment": {"quote": doc_text}},
+        }]
+        resolve_entity_sources(entities, doc_text, {})
+        src = entities[0][SOURCE_KEY]["Equipment"]
+        assert (src["value_supported"], src["value_support_method"]) == (True, "numeric")
+
+    def test_reformatted_date_still_counts_as_supported(self):
+        doc_text = "Applications close 3/1/2026 without exception."
+        entities = [{
+            "Deadline": "March 1, 2026",
+            SOURCE_KEY: {"Deadline": {"quote": doc_text}},
+        }]
+        resolve_entity_sources(entities, doc_text, {})
+        src = entities[0][SOURCE_KEY]["Deadline"]
+        assert (src["value_supported"], src["value_support_method"]) == (True, "date")
+
+    def test_wrong_number_is_not_supported(self):
+        doc_text = "Equipment costs total $61,100 in year one."
+        entities = [{
+            "Equipment": "$16,100",
+            SOURCE_KEY: {"Equipment": {"quote": doc_text}},
+        }]
+        resolve_entity_sources(entities, doc_text, {})
+        assert entities[0][SOURCE_KEY]["Equipment"]["value_supported"] is False
+
+    def test_enum_field_is_not_assessed(self):
+        """An enum value is a mapping of the prose, not a span of it —
+        flagging it would train users to ignore the signal."""
+        doc_text = "Cost sharing is required for this competition."
+        entities = [{
+            "Cost Share": "yes",
+            SOURCE_KEY: {"Cost Share": {"quote": doc_text}},
+        }]
+        resolve_entity_sources(
+            entities, doc_text, {}, {"Cost Share": {"enum_values": ["yes", "no"]}},
+        )
+        src = entities[0][SOURCE_KEY]["Cost Share"]
+        assert src["value_supported"] is None
+        assert src["value_support_method"] == "enum_field"
+
+    def test_not_found_sentinel_is_not_assessed(self):
+        doc_text = "Nothing relevant here at all."
+        entities = [{
+            "Missing": "N/A",
+            SOURCE_KEY: {"Missing": {"quote": doc_text}},
+        }]
+        resolve_entity_sources(entities, doc_text, {})
+        src = entities[0][SOURCE_KEY]["Missing"]
+        assert src["value_supported"] is None
+        assert src["value_support_method"] == "empty_value"
+
+    def test_unlocated_quote_is_not_assessed(self):
+        """A fabricated passage containing the value proves nothing, so the
+        value question is not even asked until the quote itself verifies."""
+        entities = [{
+            "Amount": "$500,000",
+            SOURCE_KEY: {"Amount": {"quote": "The award totals $500,000."}},
+        }]
+        resolve_entity_sources(entities, "Unrelated document text.", {})
+        src = entities[0][SOURCE_KEY]["Amount"]
+        assert src["verified"] is False
+        assert src["value_supported"] is None
+        assert src["value_support_method"] == "quote_not_located"
+
+    def test_verified_semantics_are_unchanged(self):
+        """Phase 1 records the new signal without redefining the old one."""
+        doc_text = "The budget narrative describes personnel costs."
+        entities = [{
+            "Amount": "$500,000",
+            SOURCE_KEY: {"Amount": {"quote": doc_text}},
+        }]
+        resolve_entity_sources(entities, doc_text, {})
+        assert entities[0][SOURCE_KEY]["Amount"]["verified"] is True
+
+
+class TestBackfillGuard:
+    def test_changed_value_does_not_inherit_the_drafts_quote(self):
+        """Pass 2 moved the deadline; pass 1's quote supports the old one.
+
+        Copying it would attach a real, verifiable passage that contradicts
+        the displayed value — a source badge pointing at evidence against
+        itself.
+        """
+        final = [{"Deadline": "April 1"}]
+        draft = [{
+            "Deadline": "March 1",
+            SOURCE_KEY: {"Deadline": {"quote": "Proposals are due March 1."}},
+        }]
+        ExtractionEngine._backfill_sources(final, draft)
+        assert "Deadline" not in final[0].get(SOURCE_KEY, {})
+
+    def test_unchanged_value_still_inherits_the_quote(self):
+        final = [{"Deadline": "March 1"}]
+        draft = [{
+            "Deadline": "March 1",
+            SOURCE_KEY: {"Deadline": {"quote": "Proposals are due March 1."}},
+        }]
+        ExtractionEngine._backfill_sources(final, draft)
+        assert final[0][SOURCE_KEY]["Deadline"]["quote"] == "Proposals are due March 1."
+
+    def test_reformatted_value_still_inherits_the_quote(self):
+        """Formatting-only differences are the same value, not a new one."""
+        final = [{"Amount": "61100"}]
+        draft = [{
+            "Amount": "$61,100",
+            SOURCE_KEY: {"Amount": {"quote": "Equipment totals $61,100."}},
+        }]
+        ExtractionEngine._backfill_sources(final, draft)
+        assert final[0][SOURCE_KEY]["Amount"]["quote"] == "Equipment totals $61,100."
+
+
+class TestSameValue:
+    def test_equivalences(self):
+        assert same_value("March 1, 2026", "3/1/2026")
+        assert same_value("$61,100", "61100")
+        assert same_value(" Alice ", "alice")
+        assert same_value(None, "N/A")  # both sentinels
+
+    def test_differences(self):
+        assert not same_value("March 1", "April 1")
+        assert not same_value("$61,100", "$16,100")
+        assert not same_value("Alice", "Bob")
+        assert not same_value(None, "Alice")  # sentinel vs real value
+
+    def test_non_scalar_value_is_not_assessed(self):
+        doc_text = "Personnel include Alice and Bob."
+        entities = [{
+            "People": ["Alice", "Bob"],
+            SOURCE_KEY: {"People": {"quote": doc_text}},
+        }]
+        resolve_entity_sources(entities, doc_text, {})
+        src = entities[0][SOURCE_KEY]["People"]
+        assert src["value_supported"] is None
+        assert src["value_support_method"] == "non_scalar_value"

--- a/backend/tests/test_extraction_sources.py
+++ b/backend/tests/test_extraction_sources.py
@@ -6,14 +6,18 @@ sidecar plumbing (capture, merge, draft, consensus, filtering).
 
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from app.services.extraction_engine import ExtractionEngine
 from app.services.extraction_sources import (
     SOURCE_KEY,
+    _numbers_in,
     find_quote_offset,
     normalize_with_map,
     page_for_offset,
     resolve_entity_sources,
     same_value,
+    value_supported_by_quote,
 )
 from app.tasks.extraction_tasks import normalize_results
 
@@ -425,7 +429,9 @@ class TestBackfillGuard:
 
         Copying it would attach a real, verifiable passage that contradicts
         the displayed value — a source badge pointing at evidence against
-        itself.
+        itself. The quote is withheld, but an entry is left behind: dropping
+        the field entirely renders it unmarked, which is the state that looks
+        cleanest, so the least trustworthy value would lose its warning too.
         """
         final = [{"Deadline": "April 1"}]
         draft = [{
@@ -433,7 +439,26 @@ class TestBackfillGuard:
             SOURCE_KEY: {"Deadline": {"quote": "Proposals are due March 1."}},
         }]
         ExtractionEngine._backfill_sources(final, draft)
-        assert "Deadline" not in final[0].get(SOURCE_KEY, {})
+        entry = final[0][SOURCE_KEY]["Deadline"]
+        assert entry["quote"] is None
+        assert entry["dropped_reason"] == "value_changed"
+
+    def test_withheld_quote_resolves_to_an_unverified_entry(self):
+        """End to end: the withheld entry must survive resolution as a
+        present-but-unverified source, which is what makes the UI render
+        "no source found" rather than nothing at all."""
+        final = [{"Deadline": "April 1"}]
+        draft = [{
+            "Deadline": "March 1",
+            SOURCE_KEY: {"Deadline": {"quote": "Proposals are due March 1."}},
+        }]
+        ExtractionEngine._backfill_sources(final, draft)
+        resolve_entity_sources(final, "Proposals are due March 1.", {})
+        entry = final[0][SOURCE_KEY]["Deadline"]
+        assert entry["verified"] is False
+        assert entry["quote"] is None
+        assert entry["value_supported"] is None
+        assert entry["value_support_method"] == "value_changed_in_refinement"
 
     def test_unchanged_value_still_inherits_the_quote(self):
         final = [{"Deadline": "March 1"}]
@@ -478,3 +503,74 @@ class TestSameValue:
         src = entities[0][SOURCE_KEY]["People"]
         assert src["value_supported"] is None
         assert src["value_support_method"] == "non_scalar_value"
+
+
+class TestLiteralMatchBoundaries:
+    """A substring is not a value.
+
+    Every case here returned True before boundaries were required — the
+    over-claiming direction, on the field the whole feature exists for.
+    """
+
+    @pytest.mark.parametrize("value,quote", [
+        ("500000", "The total award is 5000000 dollars over five years."),
+        ("1,500,000", "The ceiling is $11,500,000 across all awards."),
+        ("$500,000", "The obligated total is $500,000.99 as of today."),
+        ("61100", "Account code 561100 covers equipment purchases."),
+        ("2026", "See https://grants.gov/opportunity/12026 for details."),
+        ("John Smith", "The contact is John Smithson, Director of Research."),
+        ("Cole", "Nicole Smith serves as principal investigator."),
+        ("Ann", "The award was announced on the agency web site."),
+    ])
+    def test_fragment_of_a_larger_token_is_not_support(self, value, quote):
+        assert value_supported_by_quote(value, quote) == (False, "no_match")
+
+    @pytest.mark.parametrize("value,quote,method", [
+        ("$500,000", "The award is $500,000.", "literal"),
+        ("500,000", "Totals: $1,500,000 overall and 500,000 in year two.", "literal"),
+        ("March 1, 2026", "Proposals are due March 1, 2026 at 5:00 PM.", "literal"),
+        ("$61,100", "Equipment costs total 61,100 in year one.", "numeric"),
+        ("March 1, 2026", "Applications close 3/1/2026 without exception.", "date"),
+        ("Jane Smith", "Contact Jane Smith, Director.", "literal"),
+    ])
+    def test_real_support_still_counts(self, value, quote, method):
+        """Sentence punctuation, a genuine second occurrence, and formatting
+        differences must all still resolve as supported."""
+        assert value_supported_by_quote(value, quote) == (True, method)
+
+
+class TestNumberParsing:
+    def test_percent_is_a_different_quantity_than_the_bare_number(self):
+        assert value_supported_by_quote("$50", "The negotiated F&A rate is 50% of MTDC.") == (
+            False, "no_match",
+        )
+
+    def test_a_percentage_is_supported_by_its_own_percentage(self):
+        assert value_supported_by_quote("26%", "The negotiated rate is 26% of MTDC.") == (
+            True, "literal",
+        )
+
+    def test_comma_separated_list_is_not_one_number(self):
+        """`[\\d,]*` read "1,2,3" as a single 123."""
+        assert _numbers_in("Sections 1,2,3 of the policy apply.") == {
+            (1.0, False), (2.0, False), (3.0, False),
+        }
+        assert value_supported_by_quote("123", "Sections 1,2,3 of the policy apply.") == (
+            False, "no_match",
+        )
+
+    def test_thousands_groups_still_parse(self):
+        assert _numbers_in("Equipment totals $61,100 this year.") == {(61100.0, False)}
+
+
+class TestQuoteLengthCap:
+    def test_oversized_quote_is_not_assessed(self):
+        """The quote is model-controlled and the date scan backtracks
+        quadratically on space-free text; a passage this long is pathological,
+        so it is excluded rather than measured."""
+        supported, method = value_supported_by_quote("3/1/2026", "May" * 4000)
+        assert (supported, method) == (None, "quote_too_long")
+
+    def test_a_normal_passage_is_still_assessed(self):
+        quote = "Proposals are due March 1, 2026. " + ("Boilerplate text. " * 50)
+        assert value_supported_by_quote("March 1, 2026", quote)[0] is True

--- a/frontend/src/api/extractions.ts
+++ b/frontend/src/api/extractions.ts
@@ -103,6 +103,19 @@ export interface ExtractionFieldSource {
   document_uuid: string | null
   document_title: string | null
   verified: boolean
+  /**
+   * Whether the extracted value actually appears in `quote` — the stronger
+   * claim `verified` does not make. `null` when the check does not apply (no
+   * located quote, a "not found" value, or an enum field whose value is a
+   * mapping of the prose rather than a span of it); absent on results
+   * extracted before this was recorded.
+   *
+   * Recorded but not yet surfaced: the badge still keys off `verified` until
+   * the true/false distribution across real extractions is known.
+   */
+  value_supported?: boolean | null
+  /** How `value_supported` was decided, for measuring that distribution. */
+  value_support_method?: string
 }
 
 export type ExtractionSourceMap = Record<string, ExtractionFieldSource>


### PR DESCRIPTION
Phase 1 of tightening the per-field source badge. Ships the correctness work and the unambiguous bug fix; deliberately does **not** change what the badge shows yet.

## Problem

`verified` on a field's source sidecar attests only that the quoted passage exists in the document (`extraction_sources.py`, `verified = offset is not None`). It says nothing about whether that passage supports the value shown beside it.

So: a model invents an award amount, returns any genuine sentence from the budget section as its supporting quote, the quote is found, and the field renders with a page badge and click-to-highlight — the strongest trust signal the product has, earned by a hallucination. For a grants office acting on an extracted dollar amount or deadline, that is the failure that matters most.

## What this changes

**Adds the missing check as a separate signal.** `resolve_entity_sources` now records `value_supported` and `value_support_method` per field — does the extracted value actually appear in its quote — via three deterministic paths:

| path | catches |
|---|---|
| literal | verbatim copy, after the existing unicode folding |
| numeric | `$61,100` in the value vs `61,100` in the prose |
| date | `March 1, 2026` vs `3/1/2026` |

No LLM, no new dependencies. The number/date parsers are written locally rather than imported from `extraction_validation_service` so the module keeps its documented pure-string contract (importing it would pull in the engine, Beanie documents, and system config, and invert the dependency direction).

**`verified` is unchanged, and no UI keys off the new field.** That is the point of shipping it this way — see below.

**Fixes `_backfill_sources` outright.** It copied pass 1's quote onto pass 2's value without checking the value survived refinement. Pass 2 routinely *changes* values, so a field could display "April 1" beside a real, verifiable passage reading "…due March 1…" — a source badge pointing at evidence against itself. Backfill now requires the values to match, formatting-tolerantly, so a reformatted-but-identical value still gets its source.

## Why the badge doesn't move in this PR

Nobody knows what fraction of real fields would flip from green to amber. That number decides the design, and guessing it wrong is worse than the current too-generous badge: if amber appears on half the fields of a correct extraction, users learn to ignore amber within a week and the signal is spent.

The check therefore returns **not applicable** rather than `false` for the classes that would load the measurement with non-hallucinations — enum fields (the value maps the prose rather than quoting it), "not found" sentinels, non-scalar values, and quotes that were never located in the first place (a fabricated passage containing the value proves nothing).

**To measure once this has been running:** the sidecar is persisted in `activity_event.result_snapshot.sources` for run-sync extractions. Group by `value_support_method` to get the distribution — `no_match` is the population that would turn amber, and `enum_field` / `empty_value` / `non_scalar_value` are the ones correctly excluded. A high `no_match` rate concentrated in a few templates most likely means those templates have judgment fields missing `enum_values`, which is a metadata fix, not a badge design problem.

Two known weaknesses are documented in the docstring so the distribution is read correctly: very short values (`"1"`) match almost any passage coincidentally, and a judgment value (`"Yes"` for "cost sharing is required") reads as unsupported unless the field declares `enum_values`. An existing test in this file is exactly that second case, and I left it asserting `false` with a comment rather than papering over it — it is the clearest illustration of why measurement comes before the badge.

## Follow-ups (not in this PR)

- **Phase 2:** measure the distribution.
- **Phase 3:** redefine what earns the strong badge, and give the sidecar's four real states two visual tiers (rely on it / check it yourself). That pass should also fix the related defect the audit found: a field where the model returned *no* quote at all currently renders completely unmarked, so the most uncertain state looks the cleanest.

## Tests

New `TestValueSupport`, `TestBackfillGuard`, `TestSameValue` in `tests/test_extraction_sources.py`, including the headline case — hallucinated `$500,000` paired with a genuine budget sentence now yields `verified: True, value_supported: False` — plus currency/date equivalence, the not-applicable classes, and both backfill directions.

Locally: `test_extraction_sources.py` (38) and `test_extraction_engine_core.py` (46) pass, `ruff check app/` clean. Only that one test file references the sidecar anywhere in the suite. The full suite is left to CI here — this machine is currently saturated by another job and local full-suite runs were taking >10min.

🤖 Generated with [Claude Code](https://claude.com/claude-code)