### PR TITLE
chore(deps): sync uv.lock's pdf-inspector requirement with the #729 bump

### DIFF
--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -3704,7 +3704,7 @@ requires-dist = [
     { name = "motor", specifier = ">=3.6,<4" },
     { name = "msal", specifier = ">=1.28,<2" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.10" },
-    { name = "pdf-inspector", specifier = ">=0.2,<1.15" },
+    { name = "pdf-inspector", specifier = ">=0.2,<1.18" },
     { name = "pip-audit", marker = "extra == 'dev'", specifier = ">=2.9,<3" },
     { name = "playwright", specifier = ">=1.49,<2" },
     { name = "prometheus-fastapi-instrumentator", specifier = ">=7.0,<9" },


### PR DESCRIPTION
## Summary
Dependabot's #729 widened `pdf-inspector` to `>=0.2,<1.18` in `backend/pyproject.toml` but did not update the matching `requires-dist` line in `backend/uv.lock`, so the lock is stale on `main` (`uv lock --check` fails there). CI's `uv sync --frozen` doesn't detect that, and every local non-frozen `uv` run rewrites the line and dirties the checkout — which is how it surfaced.

One-line metadata sync, no resolution change. `uv lock --check` passes on this branch.

## Test plan
- [x] `uv lock --check` — stale on `main`, up to date here
- [x] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
