### PR TITLE
fix(library): say "Remove" instead of "Delete" for items you do not own

### DIFF
--- a/frontend/src/components/library/LibraryItemRow.tsx
+++ b/frontend/src/components/library/LibraryItemRow.tsx
@@ -53,6 +53,10 @@ export function LibraryItemRow({ item, scope, onPin, onFavorite, onClone, onShar
   const [menuPos, setMenuPos] = useState<{ top: number; left: number }>({ top: 0, left: 0 })
   const [flipUp, setFlipUp] = useState(false)
 
+  // The backend reports whether this user may delete the underlying object;
+  // without it, removal is bookmark-only.
+  const canDelete = item.can_delete_underlying === true
+
   const updateMenuPos = useCallback(() => {
     const btn = triggerRef.current
     if (!btn) return
@@ -535,10 +539,14 @@ export function LibraryItemRow({ item, scope, onPin, onFavorite, onClone, onShar
                     </>
                   )}
                   <div style={{ borderTop: '1px solid #e0e0e0', margin: '4px 0' }} />
+                  {/* Only owners can truly delete. For a bookmark of someone
+                      else's item (e.g. added from Explore) removal only drops
+                      the bookmark, so label it "Remove" — same as KB cards. */}
                   <MenuItem
                     icon={<Trash2 size={14} />}
-                    label="Delete"
-                    danger
+                    label={canDelete ? 'Delete' : 'Remove'}
+                    title={canDelete ? undefined : `Remove from library — the ${kindLabel.toLowerCase()} itself is kept by its owner`}
+                    danger={canDelete}
                     onClick={() => {
                       onRemove(item.id)
                       setMenuOpen(false)

--- a/frontend/src/components/workspace/LibraryTab.test.tsx
+++ b/frontend/src/components/workspace/LibraryTab.test.tsx
@@ -207,6 +207,14 @@ describe('LibraryTab delete flow', () => {
     expect(await screen.findByText('Delete permanently')).toBeTruthy()
   }
 
+  it('labels the menu action "Delete" only when the user owns the underlying item', async () => {
+    mockItems.current = [makeOwnedWorkflow()]
+    render(<LibraryTab />)
+    fireEvent.mouseOver(screen.getByText('NSF Proposal Extractor'))
+    fireEvent.click(await screen.findByLabelText('More actions'))
+    expect(screen.getByText('Delete')).toBeTruthy()
+  })
+
   it('offers permanent delete when the user can manage the underlying workflow', async () => {
     mockItems.current = [makeOwnedWorkflow()]
     removeItemMock.mockResolvedValue(undefined)
@@ -231,7 +239,9 @@ describe('LibraryTab delete flow', () => {
     render(<LibraryTab />)
     fireEvent.mouseOver(screen.getByText('NSF Proposal Extractor'))
     fireEvent.click(await screen.findByLabelText('More actions'))
-    fireEvent.click(screen.getByText('Delete'))
+    // Bookmark-only items say "Remove", never "Delete"
+    expect(screen.queryByText('Delete')).toBeNull()
+    fireEvent.click(screen.getByText('Remove'))
     // Bookmark-only removal goes through the (mocked, auto-confirming) confirm
     // dialog — no "Delete permanently" option should ever render.
     await waitFor(() => expect(removeItemMock).toHaveBeenCalledWith('li-wf'))


### PR DESCRIPTION
## Ticket

> When I add a verified workflow or extraction from Explore to my Library, the three-dots menu shows a red "Delete" button. But clicking it doesn't actually delete anything — it only removes the item from my library (the confirm dialog even says "Only the bookmark is removed — the workflow is kept by its owner"). The button label should say "Remove" instead of "Delete" for these items, the same way KB cards already do.

## Cause

The backend already reports `can_delete_underlying` per library item, and `LibraryTab.handleRemove` uses it to choose between the delete-choice dialog and the bookmark-only confirm. The menu label in `LibraryItemRow` was hardcoded to `label="Delete"` with `danger`, so a bookmark-only removal was presented as a destructive delete.

## Change

`frontend/src/components/library/LibraryItemRow.tsx` — the three-dots action now reads:

- **Delete** (red / `danger`) when `can_delete_underlying` is true — an item you own; opens the existing delete-choice dialog.
- **Remove** (neutral, like KB cards' reference Remove) otherwise, with tooltip "Remove from library — the workflow itself is kept by its owner" (the kind name follows the row's existing `kindLabel`, so prompts/formatters read correctly).

Behavior is otherwise unchanged — same `onRemove` call, same confirm flows.

## Tests

`frontend/src/components/workspace/LibraryTab.test.tsx`
- new: an owned item's menu says "Delete"
- updated: a bookmark-only item's menu has no "Delete", and the flow is driven by clicking "Remove"

`LibraryTab.test.tsx` + `LibraryItemRow.test.tsx` pass (17 tests); `tsc --noEmit` clean.

## Note

Based on `main`. The same hardcoded label exists on `major/agentic-chat`, which will pick this up on its next merge from main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017f65pmoEKbpBGownseoHf7
