### PR TITLE
fix(api): accept x-api-key on GET /api/workflows/status

### DIFF
--- a/backend/app/dependencies.py
+++ b/backend/app/dependencies.py
@@ -172,3 +172,24 @@ async def get_api_key_user(
             detail="DEMO_EXPIRED",
         )
     return user
+
+
+async def get_current_user_or_api_key(
+    access_token: str | None = Cookie(default=None),
+    x_api_key: str | None = Header(default=None, alias="X-API-Key"),
+    settings: Settings = Depends(get_settings),
+) -> User:
+    """Authenticate a browser session *or* an external API-key integration.
+
+    For endpoints the UI polls with its session cookie and scripts poll with
+    ``x-api-key`` (workflow run status, say). The cookie wins when both are
+    present so browser behavior is unchanged; the key is only consulted when
+    there is no session.
+    """
+    if access_token:
+        return await get_current_user(access_token=access_token, settings=settings)
+    if x_api_key:
+        return await get_api_key_user(x_api_key)
+    raise HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED, detail="Not authenticated"
+    )

--- a/backend/app/routers/workflows.py
+++ b/backend/app/routers/workflows.py
@@ -16,7 +16,7 @@ from fastapi.concurrency import run_in_threadpool
 from fastapi.responses import Response, StreamingResponse
 from pydantic import BaseModel
 
-from app.dependencies import get_api_key_user, get_current_user
+from app.dependencies import get_api_key_user, get_current_user, get_current_user_or_api_key
 from app.exceptions import TrialSpendBlockedError
 from app.models.user import User
 from app.services import access_control
@@ -222,8 +222,15 @@ async def list_workflows(
 async def get_workflow_status(
     session_id: str,
     share_token: str | None = Query(default=None),
-    user: User = Depends(get_current_user),
+    user: User = Depends(get_current_user_or_api_key),
 ):
+    """Poll a workflow run by session id.
+
+    Accepts a session cookie (the UI) or an ``x-api-key`` header — the run
+    started by ``POST /run-integrated`` is polled here, and that endpoint is
+    key-authenticated, so this one has to be too. Authorization is unchanged:
+    the service resolves the result against the caller.
+    """
     status = await svc.get_workflow_status(session_id, user=user, share_token=share_token)
     if not status:
         raise HTTPException(status_code=404, detail="Workflow result not found")
@@ -246,7 +253,7 @@ async def get_batch_status(
 async def stream_workflow_status(
     session_id: str,
     share_token: str | None = Query(default=None),
-    user: User = Depends(get_current_user),
+    user: User = Depends(get_current_user_or_api_key),
 ):
     """SSE endpoint that streams workflow status updates until completion."""
     initial_status = await svc.get_workflow_status(session_id, user=user, share_token=share_token)

--- a/backend/tests/test_workflow_routes_extended.py
+++ b/backend/tests/test_workflow_routes_extended.py
@@ -103,6 +103,55 @@ class TestGetWorkflowStatus:
 
         assert resp.status_code == 404
 
+    async def test_accepts_api_key(self, client):
+        """Scripts poll with x-api-key — the same key that started the run.
+
+        POST /run-integrated is key-authenticated, so polling the session it
+        returns has to accept the key too (it used to 401 "Not authenticated").
+        """
+        user = _make_user()
+        user.api_token_expires_at = None
+
+        with patch("app.dependencies.User") as MockUser, \
+             patch("app.routers.workflows.svc") as mock_svc:
+            MockUser.find_one = AsyncMock(return_value=user)
+            mock_svc.get_workflow_status = AsyncMock(return_value={
+                "status": "completed",
+                "num_steps_completed": 2,
+                "num_steps_total": 2,
+                "current_step_name": None,
+                "current_step_detail": None,
+                "current_step_preview": None,
+                "final_output": {"output": "result"},
+                "steps_output": {},
+            })
+
+            resp = await client.get(
+                "/api/workflows/status?session_id=sess123",
+                headers={"x-api-key": "test-api-key"},
+            )
+
+        assert resp.status_code == 200
+        assert resp.json()["final_output"] == {"output": "result"}
+        # Authorization still runs against the key's user
+        assert mock_svc.get_workflow_status.await_args.kwargs["user"] is user
+
+    async def test_rejects_unknown_api_key(self, client):
+        with patch("app.dependencies.User") as MockUser:
+            MockUser.find_one = AsyncMock(return_value=None)
+            resp = await client.get(
+                "/api/workflows/status?session_id=sess123",
+                headers={"x-api-key": "nope"},
+            )
+
+        assert resp.status_code == 401
+        assert resp.json()["detail"] == "Invalid API key"
+
+    async def test_rejects_no_credentials(self, client):
+        resp = await client.get("/api/workflows/status?session_id=sess123")
+        assert resp.status_code == 401
+        assert resp.json()["detail"] == "Not authenticated"
+
 
 # ---------------------------------------------------------------------------
 # GET /api/workflows/batch-status

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,6 +1,6 @@
 # Vandalizer External API
 
-For integrating Vandalizer extractions and automations into other tools. Authenticated with an API key (no session cookie or CSRF needed).
+For integrating Vandalizer extractions, workflows, and automations into other tools. Authenticated with an API key (no session cookie or CSRF needed).
 
 ## Authentication
 
@@ -147,6 +147,70 @@ Returns `status`, `started_at`, `finished_at`, `error`, `documents_touched`, and
 
 ---
 
+## `POST /api/workflows/run-integrated`
+
+Run a workflow against uploaded files. Unlike extractions, this queues the run and returns immediately — poll `GET /api/workflows/status` for the result. Rate-limited to 10 requests/minute per user.
+
+### Request
+
+`multipart/form-data`:
+
+| Field         | Required | Description |
+|---------------|----------|-------------|
+| `workflow_id` | yes      | ID of the workflow to run (from the workflow's URL or the API panel in the Workflow editor). |
+| `files`       | yes      | One or more file uploads. |
+
+### Response
+
+```json
+{
+  "status": "queued",
+  "activity_id": "...",
+  "session_id": "..."
+}
+```
+
+Keep the `session_id` — it is what you poll. `activity_id` only reports that the run is `running`/`complete`; it does not carry the workflow output.
+
+```bash
+curl -X POST "https://vandalizer.example.edu/api/workflows/run-integrated" \
+  -H "x-api-key: YOUR_API_KEY" \
+  -F "workflow_id=YOUR_WORKFLOW_ID" \
+  -F "files=@/absolute/path/to/document.pdf"
+```
+
+---
+
+## `GET /api/workflows/status`
+
+Poll a queued workflow run and read its output.
+
+```bash
+curl "https://vandalizer.example.edu/api/workflows/status?session_id=SESSION_ID" \
+  -H "x-api-key: YOUR_API_KEY"
+```
+
+```python
+import time
+
+while True:
+    status = requests.get(
+        "https://vandalizer.example.edu/api/workflows/status",
+        headers={"x-api-key": "YOUR_API_KEY"},
+        params={"session_id": session_id},
+    ).json()
+    if status["status"] in ("completed", "error", "failed", "canceled"):
+        break
+    time.sleep(2)
+print(status["final_output"])
+```
+
+Returns `status` (`running`, `completed`, `error`, `failed`, `canceled`), `num_steps_completed` / `num_steps_total`, `current_step_name`, `final_output`, `steps_output`, and `error`. The run's result lives in `final_output`.
+
+`GET /api/workflows/status/stream` is the same data as a server-sent event stream, ending when the run reaches a terminal state.
+
+---
+
 ## Troubleshooting
 
 ### `results` is `[]`
@@ -165,6 +229,10 @@ Check the `documents` array. The combination of fields tells you why:
 
 Your client sent the file part with zero bytes. The most common cause is curl resolving `-F files=@<filename>` against the wrong working directory. Use an absolute path.
 
+### HTTP 401 — "Not authenticated"
+
+Your request reached an endpoint without credentials. Check the header name is `x-api-key` — a workflow `session_id` polled without it returns this rather than a 403.
+
 ### HTTP 404 — "SearchSet not found"
 
 Either the UUID is wrong, or your API key's user doesn't have access to that search set (e.g. it belongs to another team). Verify in the UI.
@@ -180,4 +248,4 @@ The endpoint is rate-limited to 10 requests/minute per user. Back off and retry.
 - **`POST /api/automations/{id}/trigger`** — Fire a configured automation. See the Automations editor in the UI for trigger-specific input formats.
 - **`GET /api/automations/runs/{trigger_event_id}`** — Poll an automation run for completion.
 
-The Extraction editor in the UI has copy-paste-ready snippets for the search set you have open — use those when you're integrating against a specific search set.
+The Extraction and Workflow editors in the UI have copy-paste-ready snippets for the search set or workflow you have open — use those when you're integrating against a specific one.


### PR DESCRIPTION
## Ticket

> Workflow submission succeeds via `POST /api/workflows/run-integrated`, but polling the returned session with the same valid `x-api-key` fails: `GET /api/workflows/status?session_id=…` → `{"detail":"Not authenticated"}`. The activity endpoint reports `running`, but does not expose the workflow result.

Barrie is right, and the workaround they found doesn't exist: `GET /api/extractions/status/{activity_id}` is key-authenticated, but its workflow equivalent was not, and the activity record carries run state without `final_output`.

## Cause

`backend/app/routers/workflows.py` — `/run-integrated` depends on `get_api_key_user`, while `/status` (and `/status/stream`) depended on `get_current_user`, which reads the session cookie only. So the endpoint the run hands you a `session_id` for could not be reached with the key that started the run. The in-app Workflow editor API panel (`WorkflowApiSection`) prints exactly the snippet Barrie used:

```python
requests.get(f"{base}/api/workflows/status",
             headers={"x-api-key": "..."}, params={"session_id": ...})
```

## Change

- `backend/app/dependencies.py` — new `get_current_user_or_api_key`: cookie first (browser behavior byte-for-byte unchanged), `x-api-key` when there's no session, 401 "Not authenticated" when neither is present.
- `backend/app/routers/workflows.py` — `/status` and `/status/stream` use it.

Authorization is untouched: `workflow_service.get_workflow_status` still resolves the result through `_get_authorized_workflow_result(session_id, user, share_token)`, so a key only ever reads its own user's runs. Share-token access is unaffected.

## Docs

`docs/api.md` covered extractions and automations only — no workflow endpoints at all. Added `POST /api/workflows/run-integrated` and `GET /api/workflows/status` (with the poll loop and the note that the result is in `final_output`, not on the activity), plus an HTTP 401 troubleshooting entry.

## Tests

`backend/tests/test_workflow_routes_extended.py::TestGetWorkflowStatus`
- `test_accepts_api_key` — 200 + `final_output`, and asserts the service is still called with the key's user
- `test_rejects_unknown_api_key` — 401 "Invalid API key"
- `test_rejects_no_credentials` — 401 "Not authenticated"

`test_workflow_routes_extended.py` (43), `test_workflow_routes.py`, `test_workflow_authz.py`, `test_auth_routes.py` all pass.

## Note

Based on `main`. `major/agentic-chat` has the same dependency on `/status` and picks this up on its next merge from main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017f65pmoEKbpBGownseoHf7
