### PR TITLE
fix(tuning): stop auto-starting tuning runs that cannot succeed, plus two inbox UX fixes

### DIFF
--- a/backend/app/services/optimizer_signal_service.py
+++ b/backend/app/services/optimizer_signal_service.py
@@ -11,6 +11,12 @@ Every entry point here:
   run was auto-enqueued because X" and distinguish from user-launched runs.
 - Enforces a per-item cooldown so a noisy signal can't fork hundreds of
   optimizer runs.
+- Refuses to enqueue an item that can't be tuned yet (no validation plan, no
+  test inputs / test cases with expected values). The optimizer raises on
+  those and the manual start routes reject them with a 400 before a run doc
+  exists; an auto-trigger that skipped the check spent a run document per
+  signal and filled the Tuning suggestions page with failures nobody asked
+  for and nobody could act on.
 
 Phase 6 reuses these helpers from the ``QualityAlert.insert`` hook so that
 the same alert → shadow-optimizer pipeline works for both report-only
@@ -74,6 +80,59 @@ async def _already_recent(
             },
         )
     return recent is not None
+
+
+async def _workflow_blocker(workflow_id: str) -> Optional[str]:
+    """Why a workflow can't be tuned right now, or None when it can.
+
+    The optimizer raises on these preconditions and the manual start route
+    rejects them with a 400 before any run doc exists. Auto-triggered runs
+    skipped the check entirely, so every signal on an un-testable workflow
+    created a run that was dispatched, died in the worker, and landed on the
+    Tuning suggestions page as a "Tuning failed" row — 49 of them on one
+    deployment, with nothing a user could do about any of them.
+    """
+    from beanie import PydanticObjectId
+
+    from app.models.workflow import Workflow
+
+    try:
+        wf = await Workflow.get(PydanticObjectId(workflow_id))
+    except Exception:
+        wf = None
+    if not wf:
+        return "workflow not found"
+    if not wf.validation_plan:
+        return "workflow has no validation plan"
+
+    from app.services.workflow_optimizer import _resolve_test_inputs
+
+    if not await _resolve_test_inputs(wf):
+        return "workflow has no test inputs (no run marked as expected output)"
+    return None
+
+
+async def _extraction_blocker(search_set_uuid: str) -> Optional[str]:
+    """Why an extraction set can't be tuned right now, or None when it can.
+
+    Mirrors ``_workflow_blocker`` for the preconditions
+    ``run_extraction_optimization`` raises on.
+    """
+    from app.models.extraction_test_case import ExtractionTestCase
+    from app.services.search_set_service import get_extraction_keys
+
+    if not await get_extraction_keys(search_set_uuid):
+        return "extraction set has no fields defined"
+
+    test_cases = await ExtractionTestCase.find(
+        {"search_set_uuid": search_set_uuid},
+    ).to_list()
+    if not any(
+        tc.expected_values and any(v for v in tc.expected_values.values())
+        for tc in test_cases
+    ):
+        return "extraction set has no test cases with expected values"
+    return None
 
 
 async def enqueue_kb_shadow_run(
@@ -172,6 +231,13 @@ async def enqueue_extraction_shadow_run(
         )
         return None
 
+    blocker = await _extraction_blocker(search_set_uuid)
+    if blocker:
+        logger.info(
+            "Skipping shadow extraction run for %s — %s", search_set_uuid, blocker,
+        )
+        return None
+
     run = ExtractionOptimizationRun(
         search_set_uuid=search_set_uuid,
         user_id=user_id,
@@ -227,6 +293,13 @@ async def enqueue_workflow_shadow_run(
         logger.info(
             "Skipping shadow workflow run for %s — active run %s already in flight",
             workflow_id, active.uuid,
+        )
+        return None
+
+    blocker = await _workflow_blocker(workflow_id)
+    if blocker:
+        logger.info(
+            "Skipping shadow workflow run for %s — %s", workflow_id, blocker,
         )
         return None
 

--- a/backend/tests/test_optimizer_signal_preflight.py
+++ b/backend/tests/test_optimizer_signal_preflight.py
@@ -1,0 +1,181 @@
+"""Auto-triggered ("shadow") optimizer runs must respect the same
+preconditions the manual start routes enforce.
+
+Without this gate a quality signal on a workflow that has no validation plan
+or no test inputs created a run document, dispatched it, and let it die in the
+worker — surfacing on the Tuning suggestions page as a "Tuning failed" row the
+user can do nothing about.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services import optimizer_signal_service as sig
+
+_WF_OID = "507f1f77bcf86cd799439011"
+
+
+_PLAN = {"checks": [{"id": "c1"}]}
+
+
+def _workflow(validation_plan=_PLAN):
+    wf = MagicMock()
+    wf.validation_plan = validation_plan
+    return wf
+
+
+def _run_model():
+    """Stand-in for a Beanie run Document class."""
+    instance = MagicMock()
+    instance.uuid = "run-uuid"
+    instance.insert = AsyncMock()
+    model = MagicMock(return_value=instance)
+    model.find_one = AsyncMock(return_value=None)
+    return model, instance
+
+
+class TestWorkflowShadowPreflight:
+    @pytest.mark.asyncio
+    async def test_skips_when_no_test_inputs(self):
+        model, instance = _run_model()
+
+        with patch.object(sig, "WorkflowOptimizationRun", model), \
+             patch.object(sig, "_already_recent", AsyncMock(return_value=False)), \
+             patch("app.models.workflow.Workflow") as MockWf, \
+             patch("app.services.workflow_optimizer._resolve_test_inputs",
+                   AsyncMock(return_value=[])), \
+             patch("app.tasks.workflow_optimization_tasks.optimize_workflow_task") as task:
+            MockWf.get = AsyncMock(return_value=_workflow())
+
+            result = await sig.enqueue_workflow_shadow_run(
+                workflow_id=_WF_OID, user_id="u1", trigger="cross_field_failure",
+            )
+
+        assert result is None
+        instance.insert.assert_not_awaited()
+        task.delay.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_skips_when_no_validation_plan(self):
+        model, instance = _run_model()
+
+        with patch.object(sig, "WorkflowOptimizationRun", model), \
+             patch.object(sig, "_already_recent", AsyncMock(return_value=False)), \
+             patch("app.models.workflow.Workflow") as MockWf, \
+             patch("app.tasks.workflow_optimization_tasks.optimize_workflow_task") as task:
+            MockWf.get = AsyncMock(return_value=_workflow(validation_plan=None))
+            # Guard order matters: the plan check must short-circuit before the
+            # (more expensive) test-input resolution.
+            with patch("app.services.workflow_optimizer._resolve_test_inputs",
+                       AsyncMock(side_effect=AssertionError("should not resolve"))):
+                result = await sig.enqueue_workflow_shadow_run(
+                    workflow_id=_WF_OID, user_id="u1", trigger="quality_alert",
+                )
+
+        assert result is None
+        instance.insert.assert_not_awaited()
+        task.delay.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_skips_when_workflow_missing(self):
+        model, instance = _run_model()
+
+        with patch.object(sig, "WorkflowOptimizationRun", model), \
+             patch.object(sig, "_already_recent", AsyncMock(return_value=False)), \
+             patch("app.models.workflow.Workflow") as MockWf, \
+             patch("app.tasks.workflow_optimization_tasks.optimize_workflow_task") as task:
+            MockWf.get = AsyncMock(return_value=None)
+
+            result = await sig.enqueue_workflow_shadow_run(
+                workflow_id=_WF_OID, user_id="u1", trigger="quality_alert",
+            )
+
+        assert result is None
+        task.delay.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_enqueues_when_preconditions_hold(self):
+        model, instance = _run_model()
+
+        with patch.object(sig, "WorkflowOptimizationRun", model), \
+             patch.object(sig, "_already_recent", AsyncMock(return_value=False)), \
+             patch("app.models.workflow.Workflow") as MockWf, \
+             patch("app.services.workflow_optimizer._resolve_test_inputs",
+                   AsyncMock(return_value=[{"id": "vi-1", "doc_uuids": ["d1"]}])), \
+             patch("app.tasks.workflow_optimization_tasks.optimize_workflow_task") as task:
+            MockWf.get = AsyncMock(return_value=_workflow())
+
+            result = await sig.enqueue_workflow_shadow_run(
+                workflow_id=_WF_OID, user_id="u1", trigger="cross_field_failure",
+            )
+
+        assert result == "run-uuid"
+        instance.insert.assert_awaited_once()
+        task.delay.assert_called_once()
+
+
+def _test_case(expected_values):
+    return SimpleNamespace(expected_values=expected_values)
+
+
+def _patch_test_cases(cases):
+    model = MagicMock()
+    model.find = MagicMock(return_value=SimpleNamespace(
+        to_list=AsyncMock(return_value=cases),
+    ))
+    return model
+
+
+class TestExtractionShadowPreflight:
+    @pytest.mark.asyncio
+    async def test_skips_when_no_expected_values(self):
+        model, instance = _run_model()
+
+        with patch.object(sig, "ExtractionOptimizationRun", model), \
+             patch("app.services.search_set_service.get_extraction_keys",
+                   AsyncMock(return_value=["field_a"])), \
+             patch("app.models.extraction_test_case.ExtractionTestCase",
+                   _patch_test_cases([_test_case({}), _test_case({"field_a": ""})])), \
+             patch("app.tasks.extraction_tasks.optimize_extraction_task") as task:
+            result = await sig.enqueue_extraction_shadow_run(
+                search_set_uuid="ss-1", user_id="u1", trigger="quality_alert",
+            )
+
+        assert result is None
+        instance.insert.assert_not_awaited()
+        task.delay.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_skips_when_no_fields(self):
+        model, instance = _run_model()
+
+        with patch.object(sig, "ExtractionOptimizationRun", model), \
+             patch("app.services.search_set_service.get_extraction_keys",
+                   AsyncMock(return_value=[])), \
+             patch("app.tasks.extraction_tasks.optimize_extraction_task") as task:
+            result = await sig.enqueue_extraction_shadow_run(
+                search_set_uuid="ss-1", user_id="u1", trigger="quality_alert",
+            )
+
+        assert result is None
+        task.delay.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_enqueues_when_a_case_has_expected_values(self):
+        model, instance = _run_model()
+
+        with patch.object(sig, "ExtractionOptimizationRun", model), \
+             patch("app.services.search_set_service.get_extraction_keys",
+                   AsyncMock(return_value=["field_a"])), \
+             patch("app.models.extraction_test_case.ExtractionTestCase",
+                   _patch_test_cases([_test_case({"field_a": "Idaho"})])), \
+             patch("app.tasks.extraction_tasks.optimize_extraction_task") as task:
+            result = await sig.enqueue_extraction_shadow_run(
+                search_set_uuid="ss-1", user_id="u1", trigger="quality_alert",
+            )
+
+        assert result == "run-uuid"
+        instance.insert.assert_awaited_once()
+        task.delay.assert_called_once()

--- a/frontend/src/components/shared/OptimizerInbox.test.tsx
+++ b/frontend/src/components/shared/OptimizerInbox.test.tsx
@@ -156,6 +156,28 @@ describe('OptimizerInbox', () => {
     expect(screen.queryByRole('button', { name: /Dismiss/i })).not.toBeInTheDocument()
   })
 
+  it('opens an item in a new tab so the worklist survives', async () => {
+    mockGet.mockResolvedValue(makeResponse([makeItem()]))
+    render(<OptimizerInbox />)
+
+    const open = await screen.findByRole('link', { name: /Open/i })
+    expect(open).toHaveAttribute('href', '/?workflow=wf-1')
+    expect(open).toHaveAttribute('target', '_blank')
+    expect(open).toHaveAttribute('rel', 'noopener noreferrer')
+  })
+
+  it('acknowledges a refresh that returns the same rows', async () => {
+    mockGet.mockResolvedValue(makeResponse([makeItem()]))
+    render(<OptimizerInbox />)
+
+    await screen.findByText('Proposal intake')
+    fireEvent.click(screen.getByRole('button', { name: /Refresh/i }))
+
+    await waitFor(() => expect(mockGet).toHaveBeenCalledTimes(2))
+    // Identical data comes back — the confirmation is the only visible change.
+    expect(await screen.findByText(/Updated just now/i)).toBeInTheDocument()
+  })
+
   it('offers nothing to apply on a tied candidate', async () => {
     mockGet.mockResolvedValue(makeResponse([
       makeItem({ category: 'no_change', tied_with_baseline: true }),

--- a/frontend/src/components/shared/OptimizerInbox.tsx
+++ b/frontend/src/components/shared/OptimizerInbox.tsx
@@ -112,6 +112,10 @@ export function OptimizerInbox() {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [showDismissed, setShowDismissed] = useState(false)
+  // Stamped on every successful load so Refresh has something to show for
+  // itself — a reload that returns identical rows otherwise looks like a
+  // no-op button.
+  const [loadedAt, setLoadedAt] = useState<string | null>(null)
   const [busyRun, setBusyRun] = useState<string | null>(null)
   const [previewFor, setPreviewFor] = useState<OptimizerInboxItem | null>(null)
 
@@ -120,6 +124,7 @@ export function OptimizerInbox() {
     setError(null)
     try {
       setData(await getOptimizerInbox({ includeDismissed }))
+      setLoadedAt(new Date().toISOString())
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Failed to load tuning suggestions')
     } finally {
@@ -128,6 +133,21 @@ export function OptimizerInbox() {
   }, [])
 
   useEffect(() => { void load(showDismissed) }, [load, showDismissed])
+
+  // A manual refresh that returns the same rows looks like a dead button, so
+  // acknowledge it explicitly for a beat after the request lands.
+  const [justRefreshed, setJustRefreshed] = useState(false)
+  useEffect(() => {
+    if (!justRefreshed) return
+    const t = setTimeout(() => setJustRefreshed(false), 2500)
+    return () => clearTimeout(t)
+  }, [justRefreshed])
+
+  const handleRefresh = useCallback(async () => {
+    setJustRefreshed(false)
+    await load(showDismissed)
+    setJustRefreshed(true)
+  }, [load, showDismissed])
 
   const applyItem = useCallback(async (item: OptimizerInboxItem) => {
     setBusyRun(item.run_uuid)
@@ -247,9 +267,22 @@ export function OptimizerInbox() {
             />
             Show dismissed
           </label>
-          <button onClick={() => void load(showDismissed)} style={secondaryButton} disabled={loading}>
-            <RotateCcw style={{ width: 12, height: 12 }} />
-            Refresh
+          {loadedAt && !loading && (
+            <span style={{
+              fontSize: 11, display: 'inline-flex', alignItems: 'center', gap: 4,
+              color: justRefreshed ? '#166534' : '#9ca3af',
+            }}>
+              {justRefreshed && <CheckCircle2 style={{ width: 11, height: 11 }} />}
+              Updated {relativeTime(loadedAt).toLowerCase()}
+            </span>
+          )}
+          <button onClick={() => void handleRefresh()} style={secondaryButton} disabled={loading}>
+            {loading ? (
+              <Loader2 className="animate-spin" style={{ width: 12, height: 12 }} />
+            ) : (
+              <RotateCcw style={{ width: 12, height: 12 }} />
+            )}
+            {loading ? 'Refreshing…' : 'Refresh'}
           </button>
         </div>
       </div>
@@ -473,7 +506,15 @@ function Row({ item, busy, onApply, onDismiss, onRestore }: {
               Restore
             </button>
           )}
-          <a href={item.link} style={{ ...secondaryButton, textDecoration: 'none' }}>
+          {/* New tab: the inbox is a worklist you triage down a row at a time,
+              and the item pages it links to have no route back here. */}
+          <a
+            href={item.link}
+            target="_blank"
+            rel="noopener noreferrer"
+            title={`${meta.openLabel} in a new tab`}
+            style={{ ...secondaryButton, textDecoration: 'none' }}
+          >
             <ExternalLink style={{ width: 12, height: 12 }} />
             Open
           </a>


### PR DESCRIPTION
## Ticket

Tuning suggestions page shows **49 Failed / 0 Ready to review** — every failure is `No test inputs available`. Plus: "Open" navigates away with no way back, and "Refresh" looks like it does nothing.

## 1. Auto-tuning started runs that could never succeed (the main issue)

`workflow_optimizer.run_workflow_optimization` raises on two preconditions, and the manual start route (`POST /workflows/{id}/optimize`) checks both up front so the user gets a 400 and *no run document is created*:

- workflow has no `validation_plan`
- `_resolve_test_inputs(wf)` is empty (no past run marked as expected output)

`optimizer_signal_service.enqueue_workflow_shadow_run` — the auto path fired from `quality_service` (cross-field failures) and `quality_tasks` (regression alerts) — checked cooldown and in-flight runs, but neither precondition. So every signal on an un-testable workflow minted a run doc, dispatched it to Celery, and let it die in the worker. Each corpse becomes a "Tuning failed" row.

**Fix:** a `_workflow_blocker()` preflight in the same chokepoint, run before the run doc is created. When it returns a reason, we log and return `None` — no doc, no dispatch, no inbox row.

`enqueue_extraction_shadow_run` had the identical hole (`extraction_optimizer` raises `No test cases with expected values found`), so it gets the matching `_extraction_blocker()`. KB shadow runs need no gate — `kb_optimizer` auto-generates test queries when the user has none.

Nothing user-facing announces the skip, deliberately: silence beats a red row the user can't act on, and the manual "Validate & improve" path already explains what's missing when they go to tune by hand.

**Existing backlog:** the 49 rows already in Mongo stay until they fall out of the inbox's 14-day lookback (`INBOX_LOOKBACK`), or the user dismisses them. Nothing new joins them after this ships. Say the word if you want a bulk "Dismiss all failed" control — deliberately not built here.

## 2. "Open" takes you away with no way back

The button carried an `ExternalLink` icon but was a plain same-tab anchor, and the workspace it lands on has no route back to `/tuning`. Now `target="_blank" rel="noopener noreferrer"`, with the (previously unused) `SURFACE_META.openLabel` as its tooltip — triage a row, close the tab, keep your place in the list.

## 3. "Refresh" looked broken

`load()` flipped a `loading` flag that nothing rendered, so a refresh returning identical rows produced zero visible change. The button now shows a spinner and "Refreshing…" while the request is in flight, and an "Updated just now" stamp (green, with a check, for ~2.5s after a manual refresh) once it lands.

## Tests

`backend/tests/test_optimizer_signal_preflight.py` (new, 7 cases) — workflow skips on missing test inputs / missing validation plan / missing workflow and enqueues when both hold; extraction skips on no fields / no expected values and enqueues otherwise. Asserts no run doc is inserted and no Celery task dispatched on the skip paths, and that the plan check short-circuits before the more expensive test-input resolution.

`OptimizerInbox.test.tsx` — new cases for the new-tab link attributes and for the refresh acknowledgement surviving an identical payload.

Backend: `test_optimizer_signal_preflight.py` (7), `test_optimizer_inbox.py` + `test_admin_optimizer_activity.py` (36) pass; ruff clean. Frontend: `OptimizerInbox.test.tsx` (9) passes; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017f65pmoEKbpBGownseoHf7
