### PR TITLE
fix(extractions): say what happened when a template PDF has no form fields

### DIFF
--- a/backend/app/routers/extractions.py
+++ b/backend/app/routers/extractions.py
@@ -642,19 +642,35 @@ async def upload_pdf_template(
     settings = Settings()
     file_bytes = await file.read()
 
+    # Read the form fields BEFORE writing anything: this template file is
+    # named after the search set, so saving first meant a PDF that turns out
+    # to have no fields overwrote the bytes of the template already attached.
+    import io
+    try:
+        reader = PdfReader(io.BytesIO(file_bytes))
+        raw_fields = reader.get_fields() or {}
+    except Exception:
+        raise HTTPException(
+            status_code=400,
+            detail="That file could not be read as a PDF. Attach a fillable PDF.",
+        )
+    if not raw_fields:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                "This PDF has no form fields, so there is nothing to build "
+                "extraction fields from. Attach Template needs a fillable PDF "
+                "(one with form fields you can type into). To build fields from "
+                "a regular document, use From Document instead."
+            ),
+        )
+
     # Save template file
     upload_dir = Path(settings.upload_dir)
     upload_dir.mkdir(parents=True, exist_ok=True)
     template_filename = f"{uuid}_template.pdf"
     template_path = upload_dir / template_filename
     template_path.write_bytes(file_bytes)
-
-    # Extract form field names
-    import io
-    reader = PdfReader(io.BytesIO(file_bytes))
-    raw_fields = reader.get_fields() or {}
-    if not raw_fields:
-        raise HTTPException(status_code=422, detail="No form fields found in PDF")
 
     # Build field info dict: {field_name: value_or_options}
     field_info: dict[str, object] = {}

--- a/backend/tests/test_extraction_template_upload.py
+++ b/backend/tests/test_extraction_template_upload.py
@@ -1,0 +1,118 @@
+"""POST /api/extractions/search-sets/{uuid}/upload-template failure paths.
+
+Attaching a PDF with no form fields used to be a dead end for the user: the
+API answered 422 but the UI never surfaced it, and the file had already been
+written over the previously attached template. Both halves are covered here —
+the message has to be actionable, and nothing may touch disk before the PDF is
+known to be usable.
+"""
+
+import secrets
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.config import Settings
+from app.utils.security import create_access_token
+
+_TEST_SETTINGS = Settings(jwt_secret_key="test-secret-key", environment="development")
+
+
+def _make_user(user_id="testuser"):
+    user = MagicMock()
+    user.id = "fake-id"
+    user.user_id = user_id
+    user.email = f"{user_id}@example.com"
+    user.name = "Test User"
+    user.is_admin = False
+    user.is_examiner = False
+    user.current_team = None
+    user.is_demo_user = False
+    user.token_version = 0
+    user.demo_status = None
+    return user
+
+
+def _auth(user_id="testuser"):
+    token = create_access_token(user_id, _TEST_SETTINGS)
+    csrf = secrets.token_urlsafe(32)
+    return {"access_token": token, "csrf_token": csrf}, {"X-CSRF-Token": csrf}
+
+
+@pytest.fixture
+async def client():
+    with patch("app.main.init_db", new_callable=AsyncMock):
+        from app.main import app
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        ) as ac:
+            yield ac
+
+
+def _reader_with_fields(fields):
+    reader = MagicMock()
+    reader.get_fields = MagicMock(return_value=fields)
+    return MagicMock(return_value=reader)
+
+
+async def _post_template(client, tmp_path, *, reader):
+    """POST a PDF, with the upload dir pointed at tmp_path."""
+    user = _make_user()
+    cookies, headers = _auth()
+    ss = MagicMock()
+    ss.uuid = "ss-uuid-1"
+
+    with (
+        patch("app.dependencies.decode_token", return_value={"sub": "testuser", "type": "access"}),
+        patch("app.dependencies.User") as MockUser,
+        patch("app.routers.extractions._get_search_set_or_404",
+              new_callable=AsyncMock, return_value=ss),
+        patch("app.config.Settings",
+              MagicMock(return_value=SimpleNamespace(upload_dir=str(tmp_path)))),
+        patch("PyPDF2.PdfReader", reader),
+    ):
+        MockUser.find_one = AsyncMock(return_value=user)
+        return await client.post(
+            "/api/extractions/search-sets/ss-uuid-1/upload-template",
+            files={"file": ("form.pdf", b"%PDF-1.4 not-really-a-pdf", "application/pdf")},
+            cookies=cookies,
+            headers=headers,
+        )
+
+
+class TestUploadTemplateWithoutFormFields:
+    @pytest.mark.asyncio
+    async def test_explains_that_a_fillable_pdf_is_required(self, client, tmp_path):
+        resp = await _post_template(client, tmp_path, reader=_reader_with_fields({}))
+
+        assert resp.status_code == 422
+        detail = resp.json()["detail"]
+        assert "no form fields" in detail.lower()
+        # Actionable: says what is needed, and names the other path on the same
+        # screen that does work for a regular document.
+        assert "fillable" in detail.lower()
+        assert "From Document" in detail
+
+    @pytest.mark.asyncio
+    async def test_leaves_the_attached_template_untouched(self, client, tmp_path):
+        existing = tmp_path / "ss-uuid-1_template.pdf"
+        existing.write_bytes(b"%PDF-1.4 the-good-template")
+
+        resp = await _post_template(client, tmp_path, reader=_reader_with_fields({}))
+
+        assert resp.status_code == 422
+        assert existing.read_bytes() == b"%PDF-1.4 the-good-template"
+
+    @pytest.mark.asyncio
+    async def test_unreadable_pdf_is_a_400_not_a_500(self, client, tmp_path):
+        reader = MagicMock(side_effect=Exception("not a pdf"))
+
+        resp = await _post_template(client, tmp_path, reader=reader)
+
+        assert resp.status_code == 400
+        assert "could not be read" in resp.json()["detail"].lower()
+        assert list(tmp_path.iterdir()) == []

--- a/frontend/src/components/workspace/ExtractionEditorPanel.tsx
+++ b/frontend/src/components/workspace/ExtractionEditorPanel.tsx
@@ -487,14 +487,31 @@ export function ExtractionEditorPanel() {
     }
   }
 
+  // Persisted next to the Attach Template card: the failure explanation is
+  // two sentences long, which a toast doesn't hold on screen long enough for.
+  const [templateError, setTemplateError] = useState<string | null>(null)
   const handleAttachTemplate = async (file: File) => {
     if (!openExtractionId) return
+    setTemplateError(null)
     setAttachingTemplate(true)
     try {
       const ss = await uploadPdfTemplate(openExtractionId, file)
       setSearchSet(ss)
       refreshItems()
       setActiveTab('design')
+      toast(
+        ss.item_count
+          ? `Template attached — ${ss.item_count} field${ss.item_count === 1 ? '' : 's'} generated from the PDF form`
+          : 'Template attached',
+        'success',
+      )
+    } catch (err) {
+      // The common failure is a PDF with no form fields (422). It used to
+      // reject silently: nothing awaited this promise, so the button just sat
+      // there and the upload looked broken.
+      const message = err instanceof ApiError ? err.message : 'Could not attach the template'
+      setTemplateError(message)
+      toast(message, 'error')
     } finally {
       setAttachingTemplate(false)
     }
@@ -868,6 +885,7 @@ export function ExtractionEditorPanel() {
           onBuildFromDocument={handleBuildFromDocument}
           buildingFromDoc={buildingFromDoc}
           attachingTemplate={attachingTemplate}
+          templateError={templateError}
           generatingTemplate={generatingTemplate}
           exportingPdf={exportingPdf}
           hasDocuments={selectedDocUuids.length > 0}
@@ -1796,7 +1814,7 @@ function QualityPulse({ searchSetUuid, itemCount = 0 }: { searchSetUuid?: string
 
 /* ── Tools Tab ── */
 
-function ToolsTab({
+export function ToolsTab({
   onClone,
   onDelete,
   onAttachTemplate,
@@ -1805,6 +1823,7 @@ function ToolsTab({
   onBuildFromDocument,
   buildingFromDoc,
   attachingTemplate,
+  templateError,
   generatingTemplate,
   exportingPdf,
   hasDocuments,
@@ -1820,6 +1839,7 @@ function ToolsTab({
   onBuildFromDocument: () => void
   buildingFromDoc: boolean
   attachingTemplate: boolean
+  templateError: string | null
   generatingTemplate: boolean
   exportingPdf: boolean
   hasDocuments: boolean
@@ -1854,7 +1874,7 @@ function ToolsTab({
           description={
             !hasDocuments
               ? 'Select a document first, then use AI to generate extraction fields'
-              : 'Build extraction from a selected document using AI'
+              : 'Build extraction fields from a selected document using AI — works with any document'
           }
           onClick={onBuildFromDocument}
           disabled={buildingFromDoc || !hasDocuments}
@@ -1871,10 +1891,11 @@ function ToolsTab({
           description={
             hasTemplate
               ? 'A fillable PDF template is attached. Click to replace it.'
-              : 'Upload a fillable PDF to auto-generate extraction fields and enable PDF export'
+              : 'Upload a fillable PDF — one with form fields in it — to auto-generate matching extraction fields and enable PDF export. For a regular document, use From Document.'
           }
           onClick={onAttachTemplate}
           disabled={attachingTemplate || generatingTemplate}
+          error={templateError}
           secondaryAction={{
             label: generatingTemplate ? 'Generating...' : 'Generate example from fields →',
             onClick: onGenerateTemplate,
@@ -1903,6 +1924,7 @@ function ToolCard({
   onClick,
   style,
   secondaryAction,
+  error,
 }: {
   title: string
   description: string
@@ -1911,6 +1933,7 @@ function ToolCard({
   onClick: () => void
   style?: React.CSSProperties
   secondaryAction?: { label: string; onClick: () => void; disabled?: boolean }
+  error?: string | null
 }) {
   return (
     <div
@@ -1955,6 +1978,18 @@ function ToolCard({
         {title}
       </div>
       <div style={{ fontSize: 12, color: '#5f6368', lineHeight: 1.4 }}>{description}</div>
+      {error && (
+        <div
+          role="alert"
+          style={{
+            fontSize: 12, lineHeight: 1.4, color: '#991b1b',
+            background: '#fef2f2', border: '1px solid #fecaca',
+            borderRadius: 6, padding: '8px 10px',
+          }}
+        >
+          {error}
+        </div>
+      )}
       {secondaryAction && (
         <>
           <div style={{ borderTop: '1px solid #f3f4f6', marginTop: 4 }} />

--- a/frontend/src/components/workspace/ExtractionToolsTab.test.tsx
+++ b/frontend/src/components/workspace/ExtractionToolsTab.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { ToolsTab } from './ExtractionEditorPanel'
+
+const baseProps = {
+  onClone: vi.fn(),
+  onDelete: vi.fn(),
+  onAttachTemplate: vi.fn(),
+  onGenerateTemplate: vi.fn(),
+  onExportPdf: vi.fn(),
+  onBuildFromDocument: vi.fn(),
+  buildingFromDoc: false,
+  attachingTemplate: false,
+  templateError: null as string | null,
+  generatingTemplate: false,
+  exportingPdf: false,
+  hasDocuments: true,
+  hasResults: false,
+  hasTemplate: false,
+  hasItems: true,
+}
+
+// Timeouts are generous: importing the extraction editor module is slow enough
+// under jsdom that the first test in the file pays for it.
+describe('ToolsTab template attachment', () => {
+  it('reports a failed attachment instead of leaving the card silent', () => {
+    const { rerender } = render(
+      <ToolsTab
+        {...baseProps}
+        templateError="This PDF has no form fields, so there is nothing to build extraction fields from."
+      />,
+    )
+    expect(screen.getByRole('alert').textContent).toMatch(/no form fields/i)
+
+    // …and says nothing when the last attachment didn't fail.
+    rerender(<ToolsTab {...baseProps} />)
+    expect(screen.queryByRole('alert')).toBeNull()
+  }, 60000)
+
+  it('distinguishes Attach Template from From Document', () => {
+    render(<ToolsTab {...baseProps} />)
+
+    // Attach Template states its precondition; From Document states it has none.
+    expect(screen.getByText(/one with form fields in it/i)).toBeTruthy()
+    expect(screen.getByText(/works with any document/i)).toBeTruthy()
+  }, 30000)
+})


### PR DESCRIPTION
## Ticket

Attach Template (extraction → Tools) accepts a PDF with no form fields and then says nothing — no confirmation, no error, no sign the file arrived. A proper fillable PDF works fine; only the failure case is silent. Also, Attach Template and From Document sit next to each other with no cue that one needs a fillable PDF and the other takes any document.

## Cause

The backend was already answering `422 {"detail": "No form fields found in PDF"}`. The client threw it away:

```ts
const handleAttachTemplate = async (file: File) => {
  setAttachingTemplate(true)
  try { … } finally { setAttachingTemplate(false) }   // no catch
}
```

and the file input's `onChange` called it without `await`, so the rejection went nowhere — no toast, no console path a user would see. The success case was equally quiet; it just happened to change the screen (fields appear, tab switches), which is why only the failure reads as broken.

## Change

**Report the outcome** (`ExtractionEditorPanel`)
- Catch the failure and hold it on the Attach Template card as a `role="alert"` block, plus a toast. The explanation is two sentences — longer than a 4-second toast holds.
- Toast the success too: "Template attached — N fields generated from the PDF form".
- Clear the error when a new attach starts.

**Make the message actionable** (`routers/extractions.py`)
- 422 now reads: *"This PDF has no form fields, so there is nothing to build extraction fields from. Attach Template needs a fillable PDF (one with form fields you can type into). To build fields from a regular document, use From Document instead."*
- A file that isn't parseable as a PDF is a 400 with its own message instead of an unhandled `PdfReader` exception (500).

**A real second bug found on the way**: the route wrote the upload to `{uuid}_template.pdf` *before* reading its fields. Attaching a fieldless PDF therefore overwrote the bytes of the template already attached to that set while the request failed and `fillable_pdf_url` stayed pointing at the same filename — a working template silently replaced by a useless one. Field reading now happens first; nothing touches disk until the PDF is known to be usable.

**Tell the two cards apart** (the "easy to pick the wrong file" half)
- Attach Template: "Upload a fillable PDF — one with form fields in it — to auto-generate matching extraction fields and enable PDF export. For a regular document, use From Document."
- From Document: "Build extraction fields from a selected document using AI — works with any document"

## Tests

`backend/tests/test_extraction_template_upload.py` (new) — the 422 names the requirement and points at From Document; an existing attached template survives a fieldless upload byte-for-byte; an unreadable file is a 400 and writes nothing.

`frontend/src/components/workspace/ExtractionToolsTab.test.tsx` (new) — the card renders the failure as an alert and drops it when there is none; the two card descriptions state their preconditions. (`ToolsTab` is now exported for this, the way `AdvancedTab` already was.)

Backend 3 pass, ruff clean. Frontend 9 pass across the two extraction-tab suites, `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017f65pmoEKbpBGownseoHf7
