### PR TITLE
fix(chat): don't answer a new question on the previous one's subject

### DIFF
--- a/backend/app/services/chat_service.py
+++ b/backend/app/services/chat_service.py
@@ -932,19 +932,68 @@ _ANAPHORA_RE = re.compile(
 _FOLLOWUP_STARTERS = ("what about", "how about", "and ", "also ", "why", "same for")
 
 
+def _names_its_own_subject(message: str) -> bool:
+    """True when the message carries a subject of its own — a section
+    citation, an identifier, a quoted phrase, a run of shouted tokens.
+
+    Only the literal channels count. The "what is/are …" noun phrase that
+    ``_extract_pin_terms`` also infers is *not* a subject in this sense: "what
+    is the amount?" after a question about an award is exactly the elliptical
+    follow-up condensing exists for.
+    """
+    message = message or ""
+    if _SECTION_REF_RE.search(message) or _QUOTED_PHRASE_RE.search(message):
+        return True
+    for m in _IDENTIFIER_REF_RE.finditer(message):
+        if any(c.isdigit() for c in m.group(0)):
+            return True
+    if _CODE_REF_RE.search(message):
+        return True
+    for m in _SHOUTED_PHRASE_RE.finditer(message):
+        tokens = m.group(0).split()
+        if tokens[0] in _CITATION_TITLE_WORDS:
+            continue
+        if any(sum(ch.isalpha() for ch in tok) >= 3 for tok in tokens):
+            return True
+    return False
+
+
+def _keep_own_terms(message: str, condensed: Optional[str]) -> Optional[str]:
+    """Re-attach any literal term of the user's message the condenser dropped.
+
+    The condense step rewrites for referents, and a rewrite that resolves "it"
+    correctly can still lose the identifier the user typed — retrieving on the
+    conversation's topic instead of what was asked. Cheap to repair: append
+    what went missing rather than trusting the rewrite wholesale.
+    """
+    if not condensed:
+        return condensed
+    lowered = condensed.lower()
+    missing = [t for t in _extract_pin_terms(message) if t.lower() not in lowered]
+    return f"{condensed} {' '.join(missing)}" if missing else condensed
+
+
 def _looks_anaphoric(message: str) -> bool:
     """Heuristic: does this message likely depend on conversation context for
     retrieval? Errs toward True — a needless condense only costs one bounded
     LLM call, while retrieving on a bare "what about year 2?" loses grounding.
+
+    Short does not mean elliptical, though. Treating every message under 100
+    characters as a follow-up meant a new question that named its own subject
+    ("SCARLET ALBATROSS CLOSEOUT 9928") got condensed against the previous
+    turn, retrieved the *previous* question's chunks, and was answered on that
+    subject. A message that names its own subject is left alone.
     """
     msg = " ".join((message or "").strip().lower().split())
     if not msg:
         return False
-    if len(msg) < 100:
-        return True
     if _ANAPHORA_RE.search(msg):
         return True
-    return msg.startswith(_FOLLOWUP_STARTERS)
+    if msg.startswith(_FOLLOWUP_STARTERS):
+        return True
+    if len(msg) < 100:
+        return not _names_its_own_subject(message)
+    return False
 
 
 def _recent_turns(
@@ -1481,6 +1530,7 @@ async def _build_kb_segment(
             retrieval_query, _ = await condense_retrieval_query(
                 message, recent, model_name,
             )
+            retrieval_query = _keep_own_terms(message, retrieval_query)
 
     # Honour the KB's tuned retrieval knobs (k, min_similarity, query
     # rewriting, rerank). cfg.model / prompt_variant / answer_temperature

--- a/backend/tests/test_kb_retrieval.py
+++ b/backend/tests/test_kb_retrieval.py
@@ -433,6 +433,37 @@ def test_looks_anaphoric_table():
         assert chat_service._looks_anaphoric(message) is expected, message
 
 
+def test_short_message_naming_its_own_subject_is_not_a_followup():
+    """A new question that names its own subject must not be condensed against
+    the previous turn — that answered question 2 on question 1's subject."""
+    standalone = [
+        "SCARLET ALBATROSS CLOSEOUT 9928",     # shouted phrase
+        "What does section SPC-0500 say?",     # identifier
+        'Find "closeout obligations" please',  # quoted phrase
+        "What does § 200.1 require?",          # section citation
+    ]
+    for message in standalone:
+        assert chat_service._looks_anaphoric(message) is False, message
+
+    # Still elliptical: a short question whose subject only exists in the
+    # conversation. The inferred "what is …" noun phrase is not a subject.
+    for message in ("What is the amount?", "and the deadline?", "why not?"):
+        assert chat_service._looks_anaphoric(message) is True, message
+
+
+def test_keep_own_terms_reattaches_a_dropped_identifier():
+    # Condenser resolved the referent but lost what the user actually typed.
+    assert chat_service._keep_own_terms(
+        "what does it say about SPC-0500?", "the closeout policy document",
+    ) == "the closeout policy document SPC-0500"
+
+    # Nothing missing → untouched; nothing condensed → nothing to repair.
+    assert chat_service._keep_own_terms(
+        "what about SPC-0500?", "closeout policy SPC-0500",
+    ) == "closeout policy SPC-0500"
+    assert chat_service._keep_own_terms("anything", None) is None
+
+
 def test_recent_turns_flattens_history():
     from pydantic_ai.messages import (
         ModelRequest, ModelResponse, SystemPromptPart, TextPart, UserPromptPart,
@@ -530,6 +561,34 @@ async def test_build_kb_segment_condenses_anaphoric_followups():
     assert retrieve.await_args.kwargs["retrieval_query"] == "IRB expiration date year 2"
     # The raw message stays the primary query (answer prompt + rerank target).
     assert retrieve.await_args.args[1] == "what about year 2?"
+
+
+@pytest.mark.asyncio
+async def test_build_kb_segment_does_not_condense_a_new_subject():
+    """The reported bug: question 2 was answered on question 1's subject."""
+    from pydantic_ai.messages import ModelRequest, ModelResponse, TextPart, UserPromptPart
+
+    cfg = RAGConfig(k=4)
+    history = [
+        ModelRequest(parts=[UserPromptPart(content="What does section SPC-0500 say?")]),
+        ModelResponse(parts=[TextPart(content="SPC-0500 covers closeout.")]),
+    ]
+    retrieve = AsyncMock(return_value=([_chunk(0)], cfg, 0))
+    condense = AsyncMock(return_value=("SPC-0500 SCARLET ALBATROSS CLOSEOUT 9928", 0))
+
+    with patch.object(kb_validation_service, "_ensure_system_config_loaded",
+                      new=AsyncMock()), \
+         patch.object(kb_validation_service, "retrieve_kb_chunks", new=retrieve), \
+         patch.object(kb_validation_service, "condense_retrieval_query", new=condense), \
+         patch.object(chat_service, "_retrieve_pinned_chunks",
+                      new=AsyncMock(return_value=[])):
+        await chat_service._build_kb_segment(
+            "kb-1", "SCARLET ALBATROSS CLOSEOUT 9928", "test-model", history=history,
+        )
+
+    condense.assert_not_awaited()
+    assert retrieve.await_args.kwargs.get("retrieval_query") is None
+    assert retrieve.await_args.args[1] == "SCARLET ALBATROSS CLOSEOUT 9928"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Ticket

In a KB chat, asking "What does section SPC-0500 say?" answered correctly. Asking "SCARLET ALBATROSS CLOSEOUT 9928" next returned an answer about SPC-0500 again. The same phrase as the *first* message of a chat answers correctly.

## Cause

Chat retrieval condenses anaphoric follow-ups ("what about year 2?") into a standalone query using recent turns, because retrieval sees only the current message. The gate for that is `chat_service._looks_anaphoric`, and its first rule was:

```python
if len(msg) < 100:
    return True
```

Every short message was a follow-up by definition. "SCARLET ALBATROSS CLOSEOUT 9928" is 31 characters, so it went to the condenser along with the SPC-0500 turn, came back as a query carrying SPC-0500, and retrieval returned SPC-0500 chunks. The answer prompt then had the user's phrase plus snippets about a section they hadn't mentioned — hence an answer about SPC-0500 that contradicted the previous turn. First message in a new chat: no history, no condense, correct answer. That's the tell in the report, and it points straight here.

## Change

**Short ≠ elliptical.** `_looks_anaphoric` still fires on a pronoun, on a follow-up starter ("what about…", "and…"), and on a short message whose subject exists only in the conversation. It no longer fires on a short message that names its own subject, via a new `_names_its_own_subject`: section citation, identifier, hyphenless code, quoted phrase, or a run of shouted tokens.

Note what deliberately does *not* count as a subject: the "what is/are …" noun phrase that `_extract_pin_terms` also infers. "What is the amount?" after a question about an award is precisely the elliptical follow-up condensing exists for, so only the literal channels are consulted.

**Second guard.** A rewrite can resolve "it" correctly and still drop the identifier the user typed, which retrieves the conversation's topic instead of the question. `_keep_own_terms` appends any literal term the condenser lost back onto the retrieval query rather than trusting the rewrite wholesale.

The raw message keeps driving the answer prompt, rerank scoring, and lexical pinning, as before — only the retrieval query is affected.

## Tests

`backend/tests/test_kb_retrieval.py`
- `test_short_message_naming_its_own_subject_is_not_a_followup` — the four literal shapes are standalone; three elliptical messages still condense.
- `test_build_kb_segment_does_not_condense_a_new_subject` — replays the ticket: SPC-0500 in history, the shouted phrase as the new turn; asserts the condenser is never called and retrieval runs on the raw phrase.
- `test_keep_own_terms_reattaches_a_dropped_identifier` — plus the no-op cases.

`test_kb_retrieval.py` (66), `test_chat_service.py` + `test_chat_routes.py` (59), `test_chat_source_scope.py` + `test_chat_page_citations.py` (29) all pass; ruff clean.

## Note

The existing `_looks_anaphoric` table test kept passing throughout — its short cases are all genuinely elliptical, so the length rule and the real signal were indistinguishable under it. The new table covers the gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017f65pmoEKbpBGownseoHf7
