### PR TITLE
feat(chat): attach up to three knowledge bases to one conversation

### DIFF
--- a/backend/app/routers/chat.py
+++ b/backend/app/routers/chat.py
@@ -41,6 +41,11 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
+# Each attached knowledge base is retrieved separately (its own embedding
+# query, and its own optional rewrite/rerank LLM steps) before the pools are
+# merged, so the ceiling is about latency and spend per turn, not storage.
+MAX_CHAT_KNOWLEDGE_BASES = 3
+
 
 async def _get_authorized_activity(activity_id: str, user: User) -> ActivityEvent:
     """Resolve an activity only when it belongs to the caller."""
@@ -88,28 +93,43 @@ async def chat(
         source_documents.append({"uuid": doc.uuid, "title": doc.title or doc.uuid})
     document_uuids = authorized_document_uuids
 
-    # The KB scope passed to retrieval. A project scope overrides it with the
-    # project's implicit KB (authorized by project access, not KB sharing).
-    resolved_kb_uuid = body.knowledge_base_uuid
-
-    if body.knowledge_base_uuid:
-        user_org_ancestry = await organization_service.get_user_org_ancestry(user)
-        kb = await access_control.get_authorized_knowledge_base(
-            body.knowledge_base_uuid,
-            user,
-            user_org_ancestry=user_org_ancestry,
-            allow_admin=True,
-            team_access=team_access,
+    # The KB scope passed to retrieval, as [(uuid, title)]. A project scope
+    # overrides it with the project's implicit KB (authorized by project
+    # access, not KB sharing).
+    requested_kb_uuids = list(dict.fromkeys(
+        [u for u in ([body.knowledge_base_uuid] if body.knowledge_base_uuid else [])
+         + list(body.knowledge_base_uuids) if u]
+    ))
+    if len(requested_kb_uuids) > MAX_CHAT_KNOWLEDGE_BASES:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"At most {MAX_CHAT_KNOWLEDGE_BASES} knowledge bases can be "
+                "attached to one chat."
+            ),
         )
-        if not kb:
-            raise HTTPException(status_code=404, detail="Knowledge base not found")
-        try:
-            from app.services import knowledge_service
 
-            await knowledge_service.record_kb_usage(user_id, kb.uuid)
-        except Exception:
-            # Usage tracking is best-effort — never block chat on it.
-            logger.warning("Failed to record KB usage", exc_info=True)
+    resolved_kbs: list[tuple[str, str]] = []
+    if requested_kb_uuids:
+        user_org_ancestry = await organization_service.get_user_org_ancestry(user)
+        for kb_uuid in requested_kb_uuids:
+            kb = await access_control.get_authorized_knowledge_base(
+                kb_uuid,
+                user,
+                user_org_ancestry=user_org_ancestry,
+                allow_admin=True,
+                team_access=team_access,
+            )
+            if not kb:
+                raise HTTPException(status_code=404, detail="Knowledge base not found")
+            resolved_kbs.append((kb.uuid, kb.title or ""))
+            try:
+                from app.services import knowledge_service
+
+                await knowledge_service.record_kb_usage(user_id, kb.uuid)
+            except Exception:
+                # Usage tracking is best-effort — never block chat on it.
+                logger.warning("Failed to record KB usage", exc_info=True)
 
     if body.project_uuid:
         from app.services import project_service
@@ -118,7 +138,9 @@ async def chat(
         if not project:
             raise HTTPException(status_code=404, detail="Project not found")
         if project.kb_uuid:
-            resolved_kb_uuid = project.kb_uuid
+            # A project chat is scoped to the project's own KB, whatever else
+            # was attached.
+            resolved_kbs = [(project.kb_uuid, project.title or "")]
 
     # Resolve folder selections: find all documents inside selected folders
     if body.folder_uuids:
@@ -234,7 +256,7 @@ async def chat(
                 activity_id=str(activity.id) if activity else None,
                 settings=settings,
                 model_override=body.model,
-                kb_uuid=resolved_kb_uuid,
+                kbs=resolved_kbs,
                 include_onboarding_context=body.include_onboarding_context,
                 is_first_session=body.is_first_session,
             ):

--- a/backend/app/schemas/chat.py
+++ b/backend/app/schemas/chat.py
@@ -12,6 +12,10 @@ class ChatRequest(BaseModel):
     folder_uuids: list[str] = []
     model: Optional[str] = None
     knowledge_base_uuid: Optional[str] = None
+    # Several knowledge bases in one turn. Retrieval fans out across them and
+    # merges the results; ``knowledge_base_uuid`` remains for single-KB
+    # callers and is folded in when both are sent.
+    knowledge_base_uuids: list[str] = []
     # Scope chat to a project's implicit KB. Access is governed by project
     # membership; resolves to the project's hidden kb_uuid server-side.
     project_uuid: Optional[str] = None

--- a/backend/app/services/chat_service.py
+++ b/backend/app/services/chat_service.py
@@ -440,6 +440,9 @@ async def chat_stream(
     settings=None,
     model_override: Optional[str] = None,
     kb_uuid: Optional[str] = None,
+    # Several knowledge bases attached to one turn, as [(uuid, title)]. Takes
+    # precedence over ``kb_uuid``, which stays for the single-KB callers.
+    kbs: Optional[list[tuple[str, str]]] = None,
     include_onboarding_context: bool = False,
     is_first_session: bool = False,
 ) -> AsyncGenerator[str, None]:
@@ -600,23 +603,39 @@ async def chat_stream(
         )
 
     # KB context: query ChromaDB for relevant chunks and add as a segment.
+    active_kbs: list[tuple[str, str]] = list(kbs or [])
+    if not active_kbs and kb_uuid:
+        active_kbs = [(kb_uuid, "")]
     kb_sources: list[dict] = []
     kb_manifest: list[dict] = []
-    if kb_uuid:
+    manifests: dict[str, list[dict]] = {}
+    if active_kbs:
+        from app.services.knowledge_service import get_kb_manifest
+
+        for uuid, title in active_kbs:
+            try:
+                entries = await get_kb_manifest(uuid)
+            except Exception as e:
+                logger.warning("KB manifest fetch failed for kb_uuid=%s: %s", uuid, e)
+                continue
+            # With several KBs attached the manifest is a union, and a bare
+            # filename in it would not say which KB holds it.
+            if len(active_kbs) > 1 and title:
+                entries = [{**e, "kb_title": title} for e in entries]
+            manifests[uuid] = entries
+            kb_manifest.extend(entries)
         try:
-            from app.services.knowledge_service import get_kb_manifest
-            kb_manifest = await get_kb_manifest(kb_uuid)
-        except Exception as e:
-            logger.warning("KB manifest fetch failed for kb_uuid=%s: %s", kb_uuid, e)
-        try:
-            kb_segment, kb_sources = await _build_kb_segment(
-                kb_uuid, message, model_name, manifest=kb_manifest,
+            kb_segment, kb_sources = await _build_multi_kb_segment(
+                active_kbs, message, model_name, manifests=manifests,
                 history=previous_messages, user_id=user_id,
             )
             if kb_segment:
                 doc_segments.insert(0, kb_segment)
         except Exception as e:
-            logger.error("KB context retrieval failed for kb_uuid=%s: %s", kb_uuid, e)
+            logger.error(
+                "KB context retrieval failed for kb_uuids=%s: %s",
+                [u for u, _ in active_kbs], e,
+            )
             kb_sources = []
 
     # Select system prompt based on whether we have document context.
@@ -627,7 +646,7 @@ async def chat_stream(
     system_prompt: Optional[str] = select_chat_system_prompt(
         kb_sources=kb_sources,
         have_context=have_context,
-        kb_uuid=kb_uuid,
+        kb_uuid=active_kbs[0][0] if active_kbs else None,
         is_first_session=is_first_session,
         include_onboarding_context=include_onboarding_context,
         manifest_block=_build_manifest_block(kb_manifest),
@@ -1069,7 +1088,14 @@ def _build_manifest_block(manifest: list[dict]) -> str:
         if not name:
             continue
         status = entry.get("status")
-        line = f"- {name}" + (" (still indexing)" if status and status != "ready" else "")
+        kb_title = entry.get("kb_title")
+        line = f"- {name}"
+        # Only set when several knowledge bases are attached, where a bare
+        # filename would not say which one holds the document.
+        if kb_title:
+            line += f" — {kb_title}"
+        if status and status != "ready":
+            line += " (still indexing)"
         if total_chars + len(line) > _MANIFEST_MAX_CHARS:
             break
         lines.append(line)
@@ -1544,6 +1570,95 @@ async def _build_kb_segment(
     the KB's tuned relevance floor, so the caller falls through to the empty-KB
     prompt and the model abstains instead of answering from junk.
     """
+    results = await _retrieve_kb_results(
+        kb_uuid, message, model_name,
+        manifest=manifest, history=history,
+    )
+    if not results:
+        return None, []
+    return await _render_kb_segment(results, message, user_id=user_id)
+
+
+# One KB contributes its own tuned ``k`` (typically 8) snippets. Three at full
+# budget would triple the prompt for one question, so a multi-KB turn shares a
+# single ceiling: each KB is retrieved at its own settings, then the pools are
+# round-robined — so every attached KB is represented before the trim — and cut
+# to this many snippets in total.
+MULTI_KB_SNIPPET_BUDGET = 12
+
+
+async def _build_multi_kb_segment(
+    kbs: list[tuple[str, str]],
+    message: str,
+    model_name: str,
+    manifests: Optional[dict[str, list[dict]]] = None,
+    history: Optional[list[ModelMessage]] = None,
+    user_id: Optional[str] = None,
+) -> tuple[Optional[DocumentSegment], list[dict]]:
+    """Retrieve across several knowledge bases for one chat turn.
+
+    ``kbs`` is ``[(kb_uuid, kb_title)]``. Each KB is retrieved with its own
+    tuned config — they differ, and a shared floor would either drown a strict
+    KB in a loose one's near-misses or discard a strict KB's good hits. The
+    pools are then merged round-robin so a KB that ranks lower overall still
+    reaches the prompt, and every snippet carries the KB it came from.
+
+    A KB whose retrieval fails is skipped rather than failing the turn: the
+    answer is then grounded in the ones that did respond, which is what the
+    model is told it has.
+    """
+    if not kbs:
+        return None, []
+    if len(kbs) == 1:
+        kb_uuid, kb_title = kbs[0]
+        results = await _retrieve_kb_results(
+            kb_uuid, message, model_name,
+            manifest=(manifests or {}).get(kb_uuid), history=history,
+        )
+        for r in results:
+            r["kb_title"] = kb_title
+            r["kb_uuid"] = kb_uuid
+        if not results:
+            return None, []
+        return await _render_kb_segment(results, message, user_id=user_id)
+
+    pools = await asyncio.gather(*[
+        _retrieve_kb_results(
+            kb_uuid, message, model_name,
+            manifest=(manifests or {}).get(kb_uuid), history=history,
+        )
+        for kb_uuid, _ in kbs
+    ], return_exceptions=True)
+
+    tagged: list[list[dict]] = []
+    for (kb_uuid, kb_title), pool in zip(kbs, pools):
+        if isinstance(pool, BaseException):
+            logger.error("KB retrieval failed for kb_uuid=%s: %s", kb_uuid, pool)
+            continue
+        for r in pool:
+            r["kb_title"] = kb_title
+            r["kb_uuid"] = kb_uuid
+        tagged.append(pool)
+
+    merged = _round_robin_merge(tagged)[:MULTI_KB_SNIPPET_BUDGET]
+    if not merged:
+        logger.warning(
+            "KB query returned no results across %d knowledge bases", len(kbs),
+        )
+        return None, []
+    return await _render_kb_segment(merged, message, user_id=user_id)
+
+
+async def _retrieve_kb_results(
+    kb_uuid: str,
+    message: str,
+    model_name: str,
+    manifest: Optional[list[dict]] = None,
+    history: Optional[list[ModelMessage]] = None,
+) -> list[dict]:
+    """The ranked chunks one KB contributes to a turn, already trimmed to its
+    tuned ``k``. Split out from ``_build_kb_segment`` so a multi-KB turn can
+    fan out over it and merge the pools before any prompt text is built."""
     from app.services.kb_validation_service import (
         _ensure_system_config_loaded,
         condense_retrieval_query,
@@ -1628,6 +1743,21 @@ async def _build_kb_segment(
     )
     if not kb_results:
         logger.warning("KB query returned no results for kb_uuid=%s", kb_uuid)
+    return kb_results
+
+
+async def _render_kb_segment(
+    kb_results: list[dict],
+    message: str,
+    user_id: Optional[str] = None,
+) -> tuple[Optional[DocumentSegment], list[dict]]:
+    """Turn ranked chunks into the prompt segment and the citation list.
+
+    Knowledge-base agnostic: a chunk carrying ``kb_title`` (a multi-KB turn)
+    is labelled with it, so the model — and the reader — can tell which
+    knowledge base a claim came from when several are attached.
+    """
+    if not kb_results:
         return None, []
 
     kb_sources: list[dict] = []
@@ -1646,6 +1776,9 @@ async def _build_kb_segment(
         page, page_end, approximate = cited["page"], cited["page_end"], cited["page_approximate"]
         locator = format_page_range(page, page_end, approximate) if page is not None else locator_for_meta(meta)
         label = f"{src} ({locator})" if locator else src
+        kb_title = r.get("kb_title")
+        if kb_title:
+            label = f"{label} — {kb_title}"
         any_approximate = any_approximate or approximate
         annotated = annotate_chunk_pages(content, meta)
         any_spanning = any_spanning or annotated != content
@@ -1661,6 +1794,11 @@ async def _build_kb_segment(
             "score": r.get("score"),
             "similarity": r.get("similarity"),
             "content_preview": (r.get("content") or "")[:240],
+            # Which knowledge base this snippet came from. Only set on a
+            # multi-KB turn; the UI shows it beside the filename so a merged
+            # answer stays auditable.
+            "kb_title": kb_title,
+            "kb_uuid": r.get("kb_uuid"),
         })
     kb_text = (
         "\n\n## Retrieved Knowledge Base Snippets\n"

--- a/backend/app/services/chat_service.py
+++ b/backend/app/services/chat_service.py
@@ -623,7 +623,14 @@ async def chat_stream(
             if len(active_kbs) > 1 and title:
                 entries = [{**e, "kb_title": title} for e in entries]
             manifests[uuid] = entries
-            kb_manifest.extend(entries)
+        # The manifest block is truncated by entry count and characters, so
+        # concatenating KB by KB lets a large first KB crowd the last one out
+        # entirely — and the model is then told those documents don't exist
+        # here. Interleave so the cut falls evenly across attached KBs.
+        kb_manifest = _round_robin_merge(
+            [manifests[uuid] for uuid, _ in active_kbs if uuid in manifests],
+            key="source_uuid",
+        )
         try:
             kb_segment, kb_sources = await _build_multi_kb_segment(
                 active_kbs, message, model_name, manifests=manifests,
@@ -1531,13 +1538,13 @@ def _split_questions(message: str) -> list[str]:
     return questions if len(questions) >= 2 else []
 
 
-def _round_robin_merge(pools: list[list[dict]]) -> list[dict]:
-    """Interleave per-question result pools so each question is fairly ranked.
+def _round_robin_merge(pools: list[list[dict]], key: str = "chunk_id") -> list[dict]:
+    """Interleave pools so each contributes before any contributes twice.
 
-    Taking each pool's #1 before any pool's #2 means the downstream top-k trim
-    can't spend the whole budget on the first (or loudest) question — every
-    question contributes before any question gets a second chunk. Deduped by
-    chunk_id.
+    Taking each pool's #1 before any pool's #2 means the downstream trim can't
+    spend the whole budget on the first (or loudest) pool — used for the
+    per-question retrieval pools, for the per-KB pools of a multi-KB turn, and
+    for the manifest union those KBs produce. Deduped on ``key``.
     """
     import itertools
 
@@ -1547,7 +1554,7 @@ def _round_robin_merge(pools: list[list[dict]]) -> list[dict]:
         for r in tier:
             if r is None:
                 continue
-            cid = r.get("chunk_id")
+            cid = r.get(key)
             if cid is not None and cid in seen:
                 continue
             if cid is not None:
@@ -1610,16 +1617,19 @@ async def _build_multi_kb_segment(
     if not kbs:
         return None, []
     if len(kbs) == 1:
-        kb_uuid, kb_title = kbs[0]
+        # One KB reads exactly as it always has: naming it on every snippet
+        # and citation would relabel every existing chat, where there is no
+        # other KB to tell it apart from. The uuid still rides along for
+        # callers that want to know which KB answered.
+        kb_uuid, _kb_title = kbs[0]
         results = await _retrieve_kb_results(
             kb_uuid, message, model_name,
             manifest=(manifests or {}).get(kb_uuid), history=history,
         )
-        for r in results:
-            r["kb_title"] = kb_title
-            r["kb_uuid"] = kb_uuid
         if not results:
             return None, []
+        for r in results:
+            r["kb_uuid"] = kb_uuid
         return await _render_kb_segment(results, message, user_id=user_id)
 
     pools = await asyncio.gather(*[

--- a/backend/tests/test_chat_multi_kb.py
+++ b/backend/tests/test_chat_multi_kb.py
@@ -1,0 +1,280 @@
+"""Chatting with several knowledge bases at once.
+
+Chat carried exactly one KB: the request took a single ``knowledge_base_uuid``
+and retrieval queried one collection. These cover the fan-out — each KB
+retrieved at its own tuned settings, the pools merged so every attached KB is
+represented, and each snippet labelled with the KB it came from.
+"""
+
+import secrets
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.config import Settings
+from app.services import chat_service
+from app.utils.security import create_access_token
+
+_TEST_SETTINGS = Settings(jwt_secret_key="test-secret-key", environment="development")
+
+
+def _chunk(i: int, source: str) -> dict:
+    return {
+        "content": f"chunk {i} of {source}",
+        "metadata": {"source_name": source, "source_id": f"src-{source}"},
+        "chunk_id": f"{source}_chunk_{i}",
+        "score": 0.1 * i,
+        "similarity": round(0.95 - 0.05 * i, 2),
+    }
+
+
+class TestMultiKBSegment:
+    @pytest.mark.asyncio
+    async def test_merges_pools_and_labels_each_snippet_with_its_kb(self):
+        pools = {
+            "kb-a": [_chunk(0, "policy.pdf"), _chunk(1, "policy.pdf")],
+            "kb-b": [_chunk(0, "award.pdf")],
+        }
+
+        async def fake_retrieve(kb_uuid, *_args, **_kwargs):
+            return list(pools[kb_uuid])
+
+        with (
+            patch.object(chat_service, "_retrieve_kb_results", new=fake_retrieve),
+            patch(
+                "app.services.knowledge_service.resolve_openable_documents",
+                new_callable=AsyncMock, return_value={},
+            ),
+        ):
+            segment, sources = await chat_service._build_multi_kb_segment(
+                [("kb-a", "Policies"), ("kb-b", "Awards")],
+                "what is the closeout deadline?", "test-model",
+            )
+
+        assert segment is not None
+        # Round-robin: the second KB is represented before the first KB's
+        # second chunk, so a KB that ranks lower overall still reaches the model.
+        assert [s["document_title"] for s in sources] == [
+            "policy.pdf", "award.pdf", "policy.pdf",
+        ]
+        assert [s["kb_title"] for s in sources] == ["Policies", "Awards", "Policies"]
+        assert [s["kb_uuid"] for s in sources] == ["kb-a", "kb-b", "kb-a"]
+        # …and the prompt text says which KB each snippet came from.
+        assert "policy.pdf — Policies" in segment.text
+        assert "award.pdf — Awards" in segment.text
+
+    @pytest.mark.asyncio
+    async def test_caps_the_total_number_of_snippets(self):
+        async def fake_retrieve(kb_uuid, *_args, **_kwargs):
+            return [_chunk(i, f"{kb_uuid}.pdf") for i in range(8)]
+
+        with (
+            patch.object(chat_service, "_retrieve_kb_results", new=fake_retrieve),
+            patch(
+                "app.services.knowledge_service.resolve_openable_documents",
+                new_callable=AsyncMock, return_value={},
+            ),
+        ):
+            _segment, sources = await chat_service._build_multi_kb_segment(
+                [("kb-a", "A"), ("kb-b", "B"), ("kb-c", "C")],
+                "question?", "test-model",
+            )
+
+        assert len(sources) == chat_service.MULTI_KB_SNIPPET_BUDGET
+        # The budget is shared evenly rather than spent on the first KB.
+        assert {s["kb_uuid"] for s in sources} == {"kb-a", "kb-b", "kb-c"}
+
+    @pytest.mark.asyncio
+    async def test_one_failing_kb_does_not_lose_the_turn(self):
+        async def fake_retrieve(kb_uuid, *_args, **_kwargs):
+            if kb_uuid == "kb-broken":
+                raise RuntimeError("chroma down")
+            return [_chunk(0, "policy.pdf")]
+
+        with (
+            patch.object(chat_service, "_retrieve_kb_results", new=fake_retrieve),
+            patch(
+                "app.services.knowledge_service.resolve_openable_documents",
+                new_callable=AsyncMock, return_value={},
+            ),
+        ):
+            segment, sources = await chat_service._build_multi_kb_segment(
+                [("kb-broken", "Broken"), ("kb-a", "Policies")],
+                "question?", "test-model",
+            )
+
+        assert segment is not None
+        assert [s["kb_title"] for s in sources] == ["Policies"]
+
+    @pytest.mark.asyncio
+    async def test_a_single_kb_is_not_labelled(self):
+        async def fake_retrieve(*_args, **_kwargs):
+            return [_chunk(0, "policy.pdf")]
+
+        with (
+            patch.object(chat_service, "_retrieve_kb_results", new=fake_retrieve),
+            patch(
+                "app.services.knowledge_service.resolve_openable_documents",
+                new_callable=AsyncMock, return_value={},
+            ),
+        ):
+            segment, sources = await chat_service._build_multi_kb_segment(
+                [("kb-a", "")], "question?", "test-model",
+            )
+
+        assert sources[0]["kb_title"] == ""
+        assert "—" not in segment.text.split("**Source:")[1].split("**")[0]
+
+
+def _make_user(user_id="user1"):
+    user = MagicMock()
+    user.id = "fake-id"
+    user.user_id = user_id
+    user.email = f"{user_id}@example.com"
+    user.name = "Test User"
+    user.is_admin = False
+    user.is_examiner = False
+    user.current_team = None
+    user.is_demo_user = False
+    user.token_version = 0
+    user.demo_status = None
+    return user
+
+
+def _auth(user_id="user1"):
+    token = create_access_token(user_id, _TEST_SETTINGS)
+    csrf = secrets.token_urlsafe(32)
+    return {"access_token": token, "csrf_token": csrf}, {"X-CSRF-Token": csrf}
+
+
+@pytest.fixture
+async def client():
+    with patch("app.main.init_db", new_callable=AsyncMock):
+        from app.main import app
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test",
+        ) as ac:
+            yield ac
+
+
+def _kb(uuid, title):
+    kb = MagicMock()
+    kb.uuid = uuid
+    kb.title = title
+    return kb
+
+
+class TestChatRouteAcceptsSeveralKBs:
+    @pytest.mark.asyncio
+    async def test_rejects_more_than_the_cap(self, client):
+        user = _make_user()
+        cookies, headers = _auth()
+
+        with (
+            patch("app.dependencies.decode_token", return_value={"sub": "user1", "type": "access"}),
+            patch("app.dependencies.User") as MockUser,
+            patch("app.routers.chat.access_control") as mock_ac,
+        ):
+            MockUser.find_one = AsyncMock(return_value=user)
+            mock_ac.get_team_access_context = AsyncMock(return_value=MagicMock())
+
+            resp = await client.post(
+                "/api/chat",
+                json={
+                    "message": "hi",
+                    "knowledge_base_uuids": ["kb-1", "kb-2", "kb-3", "kb-4"],
+                },
+                cookies=cookies, headers=headers,
+            )
+
+        assert resp.status_code == 400
+        assert "at most 3" in resp.json()["detail"].lower()
+
+    @pytest.mark.asyncio
+    async def test_every_attached_kb_is_authorized_and_passed_to_retrieval(self, client):
+        user = _make_user()
+        cookies, headers = _auth()
+        kbs = {"kb-1": _kb("kb-1", "Policies"), "kb-2": _kb("kb-2", "Awards")}
+        captured = {}
+
+        async def fake_stream(**kwargs):
+            captured.update(kwargs)
+            yield '{"kind": "text", "content": "ok"}\n'
+
+        with (
+            patch("app.dependencies.decode_token", return_value={"sub": "user1", "type": "access"}),
+            patch("app.dependencies.User") as MockUser,
+            patch("app.routers.chat.access_control") as mock_ac,
+            patch("app.routers.chat.organization_service") as mock_org,
+            patch("app.routers.chat.activity_service") as mock_activity,
+            patch("app.routers.chat.audit_service") as mock_audit,
+            patch("app.routers.chat.ChatConversation") as MockConvo,
+            patch("app.routers.chat.chat_stream", new=fake_stream),
+            patch(
+                "app.services.knowledge_service.record_kb_usage",
+                new_callable=AsyncMock,
+            ),
+        ):
+            MockUser.find_one = AsyncMock(return_value=user)
+            mock_org.get_user_org_ancestry = AsyncMock(return_value=[])
+            mock_ac.get_team_access_context = AsyncMock(return_value=MagicMock())
+            mock_ac.get_authorized_knowledge_base = AsyncMock(
+                side_effect=lambda uuid, *a, **kw: kbs.get(uuid),
+            )
+            convo = MagicMock()
+            convo.uuid = "conv-1"
+            convo.add_message = AsyncMock()
+            convo.insert = AsyncMock()
+            convo.save = AsyncMock()
+            MockConvo.return_value = convo
+            MockConvo.find_one = AsyncMock(return_value=None)
+            activity = MagicMock()
+            activity.id = "act-1"
+            activity.title = "Chat"
+            activity.save = AsyncMock()
+            mock_activity.activity_start = AsyncMock(return_value=activity)
+            mock_activity.get_activity = AsyncMock(return_value=None)
+            mock_audit.log_event = AsyncMock()
+
+            resp = await client.post(
+                "/api/chat",
+                json={"message": "hi", "knowledge_base_uuids": ["kb-1", "kb-2"]},
+                cookies=cookies, headers=headers,
+            )
+            assert resp.status_code == 200
+            await resp.aread()
+
+        assert mock_ac.get_authorized_knowledge_base.await_count == 2
+        assert captured["kbs"] == [("kb-1", "Policies"), ("kb-2", "Awards")]
+
+    @pytest.mark.asyncio
+    async def test_an_unauthorized_kb_in_the_list_is_a_404(self, client):
+        user = _make_user()
+        cookies, headers = _auth()
+
+        with (
+            patch("app.dependencies.decode_token", return_value={"sub": "user1", "type": "access"}),
+            patch("app.dependencies.User") as MockUser,
+            patch("app.routers.chat.access_control") as mock_ac,
+            patch("app.routers.chat.organization_service") as mock_org,
+            patch(
+                "app.services.knowledge_service.record_kb_usage",
+                new_callable=AsyncMock,
+            ),
+        ):
+            MockUser.find_one = AsyncMock(return_value=user)
+            mock_org.get_user_org_ancestry = AsyncMock(return_value=[])
+            mock_ac.get_team_access_context = AsyncMock(return_value=MagicMock())
+            mock_ac.get_authorized_knowledge_base = AsyncMock(
+                side_effect=[_kb("kb-1", "Policies"), None],
+            )
+
+            resp = await client.post(
+                "/api/chat",
+                json={"message": "hi", "knowledge_base_uuids": ["kb-1", "kb-secret"]},
+                cookies=cookies, headers=headers,
+            )
+
+        assert resp.status_code == 404

--- a/backend/tests/test_chat_multi_kb.py
+++ b/backend/tests/test_chat_multi_kb.py
@@ -109,6 +109,9 @@ class TestMultiKBSegment:
 
     @pytest.mark.asyncio
     async def test_a_single_kb_is_not_labelled(self):
+        """One KB reads as it always has — every existing chat sends one, and
+        naming it would relabel all of them. The title is real here on purpose:
+        an empty one would pass whatever the code did."""
         async def fake_retrieve(*_args, **_kwargs):
             return [_chunk(0, "policy.pdf")]
 
@@ -120,11 +123,27 @@ class TestMultiKBSegment:
             ),
         ):
             segment, sources = await chat_service._build_multi_kb_segment(
-                [("kb-a", "")], "question?", "test-model",
+                [("kb-a", "Export Control")], "question?", "test-model",
             )
 
-        assert sources[0]["kb_title"] == ""
-        assert "—" not in segment.text.split("**Source:")[1].split("**")[0]
+        assert sources[0]["kb_title"] is None
+        assert sources[0]["kb_uuid"] == "kb-a"
+        assert "Export Control" not in segment.text
+
+
+class TestManifestUnion:
+    @pytest.mark.asyncio
+    async def test_interleaves_so_a_big_kb_cannot_crowd_out_a_small_one(self):
+        """The manifest block is cut by entry count and characters. Listing KB
+        by KB let a large first KB fill it and leave the model told the last
+        KB's documents don't exist here."""
+        pools = [
+            [{"source_uuid": f"a-{i}", "name": f"a{i}.pdf"} for i in range(50)],
+            [{"source_uuid": "b-0", "name": "b0.pdf"}],
+        ]
+        merged = chat_service._round_robin_merge(pools, key="source_uuid")
+
+        assert merged[1]["source_uuid"] == "b-0"
 
 
 def _make_user(user_id="user1"):

--- a/frontend/src/api/chat.ts
+++ b/frontend/src/api/chat.ts
@@ -7,7 +7,7 @@ export async function streamChat(
   activityId?: string | null,
   onChunk?: (chunk: StreamChunk) => void,
   model?: string,
-  knowledgeBaseUuid?: string,
+  knowledgeBaseUuids?: string[],
   includeOnboardingContext?: boolean,
   folderUuids?: string[],
   isFirstSession?: boolean,
@@ -20,7 +20,9 @@ export async function streamChat(
       message,
       document_uuids: documentUuids,
       activity_id: activityId || null,
-      knowledge_base_uuid: knowledgeBaseUuid || null,
+      // Several knowledge bases can be attached to one turn; retrieval fans
+      // out across them server-side.
+      knowledge_base_uuids: knowledgeBaseUuids || [],
       ...(model ? { model } : {}),
       ...(includeOnboardingContext ? { include_onboarding_context: true } : {}),
       ...(folderUuids?.length ? { folder_uuids: folderUuids } : {}),

--- a/frontend/src/components/chat/AttachKBModal.test.tsx
+++ b/frontend/src/components/chat/AttachKBModal.test.tsx
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import React from 'react'
+import { AttachKBModal } from './AttachKBModal'
+import { listKnowledgeBasesV2 } from '../../api/knowledge'
+
+vi.mock('focus-trap-react', () => ({
+  FocusTrap: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+vi.mock('../../api/knowledge', () => ({ listKnowledgeBasesV2: vi.fn() }))
+
+const mockList = vi.mocked(listKnowledgeBasesV2)
+
+function kb(uuid: string, title: string, status = 'ready') {
+  return { uuid, title, status, description: null, total_sources: 1, total_chunks: 4 }
+}
+
+beforeEach(() => {
+  mockList.mockReset()
+  mockList.mockResolvedValue({
+    items: [
+      kb('kb-1', 'Export Control'),
+      kb('kb-2', 'Uniform Guidance'),
+      kb('kb-3', 'Broken bookmark', 'unavailable'),
+    ],
+    total: 3,
+  } as never)
+})
+
+describe('AttachKBModal', () => {
+  it('attaches several knowledge bases at once', async () => {
+    const onAttach = vi.fn()
+    const onClose = vi.fn()
+    render(
+      <AttachKBModal attachedUuids={[]} maxAttached={3} onAttach={onAttach} onClose={onClose} />,
+    )
+
+    fireEvent.click(await screen.findByRole('button', { name: /Export Control/ }))
+    fireEvent.click(screen.getByRole('button', { name: /Uniform Guidance/ }))
+    fireEvent.click(screen.getByRole('button', { name: 'Attach 2' }))
+
+    expect(onAttach).toHaveBeenCalledWith([
+      { uuid: 'kb-1', title: 'Export Control' },
+      { uuid: 'kb-2', title: 'Uniform Guidance' },
+    ])
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('hides a broken bookmark, which has no KB behind it to search', async () => {
+    render(
+      <AttachKBModal attachedUuids={[]} maxAttached={3} onAttach={vi.fn()} onClose={vi.fn()} />,
+    )
+
+    await screen.findByRole('button', { name: /Export Control/ })
+    expect(screen.queryByText('Broken bookmark')).not.toBeInTheDocument()
+  })
+
+  it('will not exceed the attachment limit', async () => {
+    render(
+      <AttachKBModal
+        attachedUuids={['kb-9', 'kb-8']}
+        maxAttached={3}
+        onAttach={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    )
+
+    // One slot left: taking it disables the other option.
+    fireEvent.click(await screen.findByRole('button', { name: /Export Control/ }))
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /Uniform Guidance/ })).toBeDisabled(),
+    )
+    expect(screen.getByText(/reached the limit/i)).toBeInTheDocument()
+  })
+
+  it('marks a knowledge base already attached to the chat', async () => {
+    render(
+      <AttachKBModal
+        attachedUuids={['kb-1']}
+        maxAttached={3}
+        onAttach={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    )
+
+    const row = await screen.findByRole('button', { name: /Export Control/ })
+    expect(row).toBeDisabled()
+    expect(row.textContent).toMatch(/attached/)
+  })
+})

--- a/frontend/src/components/chat/AttachKBModal.tsx
+++ b/frontend/src/components/chat/AttachKBModal.tsx
@@ -1,0 +1,194 @@
+import { useEffect, useMemo, useState } from 'react'
+import { FocusTrap } from 'focus-trap-react'
+import { BookOpen, Check, Loader2, Search, X } from 'lucide-react'
+import { listKnowledgeBasesV2 } from '../../api/knowledge'
+import type { KnowledgeBase, KBScope } from '../../types/knowledge'
+
+/**
+ * Attach knowledge bases to the current chat.
+ *
+ * The "Add Knowledge Base" item in the chat's + menu used to switch the
+ * workspace to the Knowledge panel, leaving the user to find the KB and press
+ * "Chat with this KB" — which also replaced the conversation. This attaches in
+ * place, several at a time, without leaving the chat.
+ */
+
+const SCOPES: { value: KBScope; label: string }[] = [
+  { value: 'mine', label: 'Mine' },
+  { value: 'team', label: 'Team' },
+  { value: 'verified', label: 'Verified' },
+]
+
+interface Props {
+  attachedUuids: string[]
+  maxAttached: number
+  onAttach: (kbs: { uuid: string; title: string }[]) => void
+  onClose: () => void
+}
+
+export function AttachKBModal({ attachedUuids, maxAttached, onAttach, onClose }: Props) {
+  const [scope, setScope] = useState<KBScope>('mine')
+  const [kbs, setKbs] = useState<KnowledgeBase[] | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [search, setSearch] = useState('')
+  const [picked, setPicked] = useState<Record<string, string>>({})
+
+  useEffect(() => {
+    let cancelled = false
+    setKbs(null)
+    setError(null)
+    listKnowledgeBasesV2({ scope, limit: 100 })
+      .then(res => {
+        if (cancelled) return
+        // A broken bookmark ('unavailable') has no KB behind it to retrieve from.
+        setKbs(res.items.filter(kb => kb.status !== 'unavailable'))
+      })
+      .catch(() => { if (!cancelled) setError('Could not load knowledge bases.') })
+    return () => { cancelled = true }
+  }, [scope])
+
+  const pickedCount = Object.keys(picked).length
+  const remaining = maxAttached - attachedUuids.length - pickedCount
+
+  const visible = useMemo(() => {
+    const q = search.trim().toLowerCase()
+    if (!q) return kbs || []
+    return (kbs || []).filter(kb => kb.title.toLowerCase().includes(q))
+  }, [kbs, search])
+
+  const toggle = (kb: KnowledgeBase) => {
+    setPicked(prev => {
+      if (prev[kb.uuid]) {
+        const next = { ...prev }
+        delete next[kb.uuid]
+        return next
+      }
+      if (remaining <= 0) return prev
+      return { ...prev, [kb.uuid]: kb.title }
+    })
+  }
+
+  const confirm = () => {
+    onAttach(Object.entries(picked).map(([uuid, title]) => ({ uuid, title })))
+    onClose()
+  }
+
+  return (
+    <div
+      className="fixed inset-0 flex items-center justify-center bg-black/50"
+      style={{ zIndex: 900 }}
+      onKeyDown={e => { if (e.key === 'Escape') onClose() }}
+    >
+      <FocusTrap focusTrapOptions={{ allowOutsideClick: true, escapeDeactivates: false, tabbableOptions: { displayCheck: 'none' } }}>
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="attach-kb-title"
+          className="flex w-full max-w-md flex-col rounded-lg bg-white shadow-xl"
+          style={{ maxHeight: '70vh' }}
+        >
+          <div className="flex items-center justify-between border-b border-gray-200 px-5 py-3">
+            <h3 id="attach-kb-title" className="text-base font-medium text-gray-900">
+              Attach knowledge bases
+            </h3>
+            <button type="button" onClick={onClose} aria-label="Close" className="text-gray-500 hover:text-gray-700">
+              <X className="h-5 w-5" />
+            </button>
+          </div>
+
+          <div className="px-5 pt-3">
+            <p className="text-xs text-gray-500">
+              Chat can search up to {maxAttached} knowledge bases at once, alongside any
+              documents you have selected.
+              {remaining <= 0 && ' You have reached the limit — detach one to add another.'}
+            </p>
+            <div className="mt-3 flex gap-1">
+              {SCOPES.map(s => (
+                <button
+                  key={s.value}
+                  type="button"
+                  aria-pressed={scope === s.value}
+                  onClick={() => setScope(s.value)}
+                  className={`rounded-full px-3 py-1 text-xs font-medium ${
+                    scope === s.value ? 'bg-gray-900 text-white' : 'bg-gray-100 text-gray-600'
+                  }`}
+                >
+                  {s.label}
+                </button>
+              ))}
+            </div>
+            <div className="relative mt-3">
+              <Search className="pointer-events-none absolute left-2.5 top-2.5 h-4 w-4 text-gray-400" />
+              <input
+                aria-label="Search knowledge bases"
+                value={search}
+                onChange={e => setSearch(e.target.value)}
+                placeholder="Search knowledge bases"
+                className="w-full rounded-md border border-gray-300 py-2 pl-8 pr-3 text-sm"
+              />
+            </div>
+          </div>
+
+          <div className="flex-1 overflow-y-auto px-5 py-3" style={{ minHeight: 120 }}>
+            {error ? (
+              <p className="text-sm text-red-700">{error}</p>
+            ) : kbs === null ? (
+              <div className="flex justify-center py-6 text-gray-400">
+                <Loader2 className="h-4 w-4 animate-spin" />
+              </div>
+            ) : visible.length === 0 ? (
+              <p className="py-6 text-center text-sm text-gray-500">
+                {search ? 'No knowledge base matches that.' : 'No knowledge bases here yet.'}
+              </p>
+            ) : (
+              <ul className="flex flex-col gap-1">
+                {visible.map(kb => {
+                  const already = attachedUuids.includes(kb.uuid)
+                  const selected = !!picked[kb.uuid]
+                  const blocked = !already && !selected && remaining <= 0
+                  return (
+                    <li key={kb.uuid}>
+                      <button
+                        type="button"
+                        disabled={already || blocked}
+                        aria-pressed={selected}
+                        onClick={() => toggle(kb)}
+                        className="flex w-full items-center gap-2.5 rounded-md px-2 py-2 text-left text-sm hover:bg-black/[.04] disabled:cursor-not-allowed disabled:opacity-50"
+                      >
+                        <BookOpen className="h-4 w-4 shrink-0 text-gray-400" />
+                        <span className="flex-1 truncate text-gray-900">{kb.title}</span>
+                        {already ? (
+                          <span className="shrink-0 text-xs text-gray-500">attached</span>
+                        ) : selected ? (
+                          <Check className="h-4 w-4 shrink-0 text-green-600" />
+                        ) : null}
+                      </button>
+                    </li>
+                  )
+                })}
+              </ul>
+            )}
+          </div>
+
+          <div className="flex items-center justify-end gap-2 border-t border-gray-200 px-5 py-3">
+            <button
+              type="button"
+              onClick={onClose}
+              className="rounded-md px-3 py-1.5 text-sm text-gray-700 hover:bg-black/[.04]"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={confirm}
+              disabled={pickedCount === 0}
+              className="rounded-md bg-gray-900 px-3 py-1.5 text-sm font-medium text-white disabled:opacity-40"
+            >
+              {pickedCount > 1 ? `Attach ${pickedCount}` : 'Attach'}
+            </button>
+          </div>
+        </div>
+      </FocusTrap>
+    </div>
+  )
+}

--- a/frontend/src/components/chat/ChatMessage.tsx
+++ b/frontend/src/components/chat/ChatMessage.tsx
@@ -378,7 +378,10 @@ export function ChatMessage({ message, messageIndex, conversationUuid, streaming
                   </span>
                   {message.citations.map((c, i) => {
                     const locator = formatPageLocator(c.page, c.page_approximate, c.page_end) ?? (c.sheet || null)
-                    const label = locator ? `${c.document_title} · ${locator}` : c.document_title
+                    const base = locator ? `${c.document_title} · ${locator}` : c.document_title
+                    // With several knowledge bases attached, the filename
+                    // alone doesn't say which one a claim came from.
+                    const label = c.kb_title ? `${base} · ${c.kb_title}` : base
                     const preview = c.content_preview || ''
                     const isOpen = openCitation === i
                     const menuOpen = citationMenu === i

--- a/frontend/src/components/chat/ChatPanel.tsx
+++ b/frontend/src/components/chat/ChatPanel.tsx
@@ -6,10 +6,11 @@ import { ChatInput } from './ChatInput'
 import { AttachmentList } from './AttachmentList'
 import { ContextMeter } from './ContextMeter'
 import { ContextLimitDialog } from './ContextLimitDialog'
+import { AttachKBModal } from './AttachKBModal'
 import { useChat } from '../../hooks/useChat'
 import { useProject } from '../../hooks/useProjects'
 import { useOnboarding } from '../../hooks/useOnboarding'
-import { useWorkspace, type PendingChatMessage } from '../../contexts/WorkspaceContext'
+import { useWorkspace, MAX_ATTACHED_KBS, type PendingChatMessage } from '../../contexts/WorkspaceContext'
 import { useToast } from '../../contexts/ToastContext'
 import { useBranding } from '../../contexts/BrandingContext'
 import { useShareLink } from '../../lib/shareLink'
@@ -87,7 +88,7 @@ export function ChatPanel({ conversationToLoad, pendingMessage, onPendingMessage
     setActivity,
   } = useChat()
 
-  const { bumpActivitySignal, processingDoc, selectedDocsProcessing, selectedDocUuids, setSelectedDocUuids, selectedDocNames, setSelectedDocNames, selectedFolderUuids, activeKBUuid, activeKBTitle, activateKB, deactivateKB, activeProjectUuid, activeProjectTitle, setCurrentConversationUuid, focusChatSignal, setWorkspaceMode } = useWorkspace()
+  const { bumpActivitySignal, processingDoc, selectedDocsProcessing, selectedDocUuids, setSelectedDocUuids, selectedDocNames, setSelectedDocNames, selectedFolderUuids, activeKBs, activeKBUuid, activeKBTitle, activateKB, attachKB, detachKB, deactivateKB, activeProjectUuid, activeProjectTitle, setCurrentConversationUuid, focusChatSignal, setWorkspaceMode } = useWorkspace()
 
   // When scoped to a project, surface its file/index status so the empty state
   // reflects the project (not a generic assistant) and sets honest expectations.
@@ -113,6 +114,7 @@ export function ChatPanel({ conversationToLoad, pendingMessage, onPendingMessage
   const [urlAttachments, setUrlAttachments] = useState<UrlAttachment[]>([])
   const [attachLoading, setAttachLoading] = useState(false)
   const [selectedModel, setSelectedModel] = useState<string>('')
+  const [showAttachKB, setShowAttachKB] = useState(false)
   const [modelsList, setModelsList] = useState<ModelInfo[]>([])
   const [showContextDialog, setShowContextDialog] = useState(false)
   const contextDialogShownRef = useRef(false)
@@ -343,7 +345,7 @@ export function ChatPanel({ conversationToLoad, pendingMessage, onPendingMessage
     // In first-session mode, every message uses the first-session system prompt.
     // Use the locked ref so remounts / refetches can't flip this mid-conversation.
     const firstSession = effectiveFirstSession && !hasDocContext && !activeKBUuid && !activeProjectUuid
-    send(message, selectedDocUuids, selectedModel || undefined, activeKBUuid || undefined, includeOnboardingContext, selectedFolderUuids, firstSession || undefined, activeProjectUuid || undefined)
+    send(message, selectedDocUuids, selectedModel || undefined, activeKBs.map(kb => kb.uuid), includeOnboardingContext, selectedFolderUuids, firstSession || undefined, activeProjectUuid || undefined)
     // Defer markFirstSessionComplete until the user has had enough exchanges
     // to experience the value discovery (at least 3 user messages).
     // messages.length counts both user + assistant; 4 = 2 full exchanges done.
@@ -940,9 +942,10 @@ export function ChatPanel({ conversationToLoad, pendingMessage, onPendingMessage
 
 
 
-      {/* KB active badge */}
-      {activeKBUuid && (
+      {/* One row per attached knowledge base — chat searches all of them. */}
+      {activeKBs.map(kb => (
         <div
+          key={kb.uuid}
           style={{
             display: 'flex',
             alignItems: 'center',
@@ -956,9 +959,9 @@ export function ChatPanel({ conversationToLoad, pendingMessage, onPendingMessage
           }}
         >
           <BookOpen size={14} />
-          <span style={{ flex: 1 }}>Knowledge Base: {activeKBTitle}</span>
+          <span style={{ flex: 1 }}>Knowledge Base: {kb.title}</span>
           <button
-            onClick={() => shareLink('kb', activeKBUuid, activeKBTitle || undefined)}
+            onClick={() => shareLink('kb', kb.uuid, kb.title || undefined)}
             title="Copy share link"
             style={{
               background: 'transparent',
@@ -973,7 +976,8 @@ export function ChatPanel({ conversationToLoad, pendingMessage, onPendingMessage
             <Link2 size={14} />
           </button>
           <button
-            onClick={deactivateKB}
+            onClick={() => detachKB(kb.uuid)}
+            aria-label={`Detach knowledge base: ${kb.title}`}
             style={{
               background: 'transparent',
               border: 'none',
@@ -987,6 +991,22 @@ export function ChatPanel({ conversationToLoad, pendingMessage, onPendingMessage
             <X size={14} />
           </button>
         </div>
+      ))}
+
+      {showAttachKB && (
+        <AttachKBModal
+          attachedUuids={activeKBs.map(kb => kb.uuid)}
+          maxAttached={MAX_ATTACHED_KBS}
+          onAttach={(kbs) => {
+            for (const kb of kbs) {
+              if (!attachKB(kb.uuid, kb.title)) {
+                toast(`Chat can search at most ${MAX_ATTACHED_KBS} knowledge bases`, 'error')
+                break
+              }
+            }
+          }}
+          onClose={() => setShowAttachKB(false)}
+        />
       )}
 
       {/* Input */}
@@ -994,7 +1014,7 @@ export function ChatPanel({ conversationToLoad, pendingMessage, onPendingMessage
         onSend={handleSend}
         onAttachFile={handleAttachFile}
         onAttachLink={handleAttachLink}
-        onAddKnowledge={() => setWorkspaceMode('knowledge')}
+        onAddKnowledge={() => setShowAttachKB(true)}
         disabled={isStreaming}
         selectedModel={selectedModel}
         onModelChange={handleModelChange}

--- a/frontend/src/components/chat/ChatPanel.tsx
+++ b/frontend/src/components/chat/ChatPanel.tsx
@@ -88,7 +88,7 @@ export function ChatPanel({ conversationToLoad, pendingMessage, onPendingMessage
     setActivity,
   } = useChat()
 
-  const { bumpActivitySignal, processingDoc, selectedDocsProcessing, selectedDocUuids, setSelectedDocUuids, selectedDocNames, setSelectedDocNames, selectedFolderUuids, activeKBs, activeKBUuid, activeKBTitle, activateKB, attachKB, detachKB, activeProjectUuid, activeProjectTitle, setCurrentConversationUuid, focusChatSignal } = useWorkspace()
+  const { bumpActivitySignal, processingDoc, selectedDocsProcessing, selectedDocUuids, setSelectedDocUuids, selectedDocNames, setSelectedDocNames, selectedFolderUuids, activeKBs, activeKBUuid, activeKBTitle, activateKB, attachKBs, detachKB, activeProjectUuid, activeProjectTitle, setCurrentConversationUuid, focusChatSignal } = useWorkspace()
 
   // When scoped to a project, surface its file/index status so the empty state
   // reflects the project (not a generic assistant) and sets honest expectations.
@@ -998,12 +998,14 @@ export function ChatPanel({ conversationToLoad, pendingMessage, onPendingMessage
           attachedUuids={activeKBs.map(kb => kb.uuid)}
           maxAttached={MAX_ATTACHED_KBS}
           onAttach={(kbs) => {
-            for (const kb of kbs) {
-              if (!attachKB(kb.uuid, kb.title)) {
-                toast(`Chat can search at most ${MAX_ATTACHED_KBS} knowledge bases`, 'error')
-                break
-              }
+            // Capacity is decided here, against the attachment as rendered —
+            // the modal already blocks over-selection, so this only fires if
+            // something was attached from elsewhere while it was open.
+            const room = MAX_ATTACHED_KBS - activeKBs.length
+            if (kbs.length > room) {
+              toast(`Chat can search at most ${MAX_ATTACHED_KBS} knowledge bases`, 'error')
             }
+            attachKBs(kbs)
           }}
           onClose={() => setShowAttachKB(false)}
         />

--- a/frontend/src/components/chat/ChatPanel.tsx
+++ b/frontend/src/components/chat/ChatPanel.tsx
@@ -88,7 +88,7 @@ export function ChatPanel({ conversationToLoad, pendingMessage, onPendingMessage
     setActivity,
   } = useChat()
 
-  const { bumpActivitySignal, processingDoc, selectedDocsProcessing, selectedDocUuids, setSelectedDocUuids, selectedDocNames, setSelectedDocNames, selectedFolderUuids, activeKBs, activeKBUuid, activeKBTitle, activateKB, attachKB, detachKB, deactivateKB, activeProjectUuid, activeProjectTitle, setCurrentConversationUuid, focusChatSignal, setWorkspaceMode } = useWorkspace()
+  const { bumpActivitySignal, processingDoc, selectedDocsProcessing, selectedDocUuids, setSelectedDocUuids, selectedDocNames, setSelectedDocNames, selectedFolderUuids, activeKBs, activeKBUuid, activeKBTitle, activateKB, attachKB, detachKB, activeProjectUuid, activeProjectTitle, setCurrentConversationUuid, focusChatSignal } = useWorkspace()
 
   // When scoped to a project, surface its file/index status so the empty state
   // reflects the project (not a generic assistant) and sets honest expectations.

--- a/frontend/src/contexts/WorkspaceContext.tsx
+++ b/frontend/src/contexts/WorkspaceContext.tsx
@@ -98,9 +98,13 @@ interface ChatStateContextValue {
   // Replace whatever is attached with this KB and start a fresh chat — what
   // "Chat with this KB" does from the knowledge surfaces.
   activateKB: (uuid: string, title: string) => void
-  // Add a KB to the current chat without disturbing it. No-op when already
-  // attached or at MAX_ATTACHED_KBS; returns false when it did not attach.
-  attachKB: (uuid: string, title: string) => boolean
+  // Add KBs to the current chat without disturbing it. Attaches in one update
+  // — a per-KB call that reported success from inside its own state updater
+  // could not: React defers the updater once one is queued, so attaching a
+  // batch mis-reported the second onwards and skipped the rest. Already
+  // attached and past MAX_ATTACHED_KBS are dropped silently; the caller knows
+  // the capacity (activeKBs.length) and warns before calling.
+  attachKBs: (kbs: AttachedKB[]) => void
   detachKB: (uuid: string) => void
   deactivateKB: () => void
   // Project scope — the whole workspace (files, chat, …) re-scoped to one project.
@@ -235,6 +239,24 @@ export interface AttachedKB {
 // MAX_CHAT_KNOWLEDGE_BASES in backend/app/routers/chat.py, which enforces it.
 export const MAX_ATTACHED_KBS = 3
 
+/**
+ * The attachment after adding `incoming`: already-attached uuids are ignored
+ * and anything past `max` is dropped. Pure and batch-shaped on purpose — the
+ * first version decided per KB *inside* a React state updater and reported
+ * back from there, which React defers once an update is queued, so attaching
+ * three at once mis-reported the second and skipped the third.
+ */
+export function mergeAttachedKBs(
+  prev: AttachedKB[], incoming: AttachedKB[], max: number = MAX_ATTACHED_KBS,
+): AttachedKB[] {
+  const next = [...prev]
+  for (const kb of incoming) {
+    if (next.length >= max) break
+    if (!next.some(existing => existing.uuid === kb.uuid)) next.push(kb)
+  }
+  return next.length === prev.length ? prev : next
+}
+
 function storedKBValue(kbs: AttachedKB[]): string {
   return JSON.stringify(kbs.map(kb => kb.uuid))
 }
@@ -340,6 +362,7 @@ export function WorkspaceProvider({ children }: { children: ReactNode }) {
     [],
   )
   const [activeKBs, setActiveKBs] = useState<AttachedKB[]>([])
+  const kbsHydratedRef = useRef(false)
   const activeKBUuid = activeKBs[0]?.uuid ?? null
   const activeKBTitle = activeKBs[0]?.title ?? null
   const [activeProjectUuid, setActiveProjectUuid] = useState<string | null>(null)
@@ -479,24 +502,12 @@ export function WorkspaceProvider({ children }: { children: ReactNode }) {
     updateSearch((prev) => ({ ...prev, mode: undefined, workflow: undefined, extraction: undefined, automation: undefined, tab: undefined }))
   }, [updateSearch])
 
-  const attachKB = useCallback((uuid: string, title: string) => {
-    let attached = false
-    setActiveKBs(prev => {
-      if (prev.some(kb => kb.uuid === uuid) || prev.length >= MAX_ATTACHED_KBS) return prev
-      attached = true
-      const next = [...prev, { uuid, title }]
-      setStoredRaw(KB_STORAGE_KEY, storedKBValue(next))
-      return next
-    })
-    return attached
+  const attachKBs = useCallback((kbs: AttachedKB[]) => {
+    setActiveKBs(prev => mergeAttachedKBs(prev, kbs))
   }, [])
 
   const detachKB = useCallback((uuid: string) => {
-    setActiveKBs(prev => {
-      const next = prev.filter(kb => kb.uuid !== uuid)
-      setStoredRaw(KB_STORAGE_KEY, next.length ? storedKBValue(next) : null)
-      return next
-    })
+    setActiveKBs(prev => prev.filter(kb => kb.uuid !== uuid))
   }, [])
 
   const deactivateKB = useCallback(() => {
@@ -651,7 +662,9 @@ export function WorkspaceProvider({ children }: { children: ReactNode }) {
     }
 
     const storedKBUuids = parseStoredKBs(getStoredRaw(KB_STORAGE_KEY))
-    if (storedKBUuids.length) {
+    if (!storedKBUuids.length) {
+      kbsHydratedRef.current = true
+    } else {
       import('../api/knowledge').then(({ getKnowledgeBase }) => {
         // Titles are re-fetched rather than persisted, so a renamed KB never
         // shows stale chrome. A KB that no longer resolves is dropped; the
@@ -666,12 +679,23 @@ export function WorkspaceProvider({ children }: { children: ReactNode }) {
             })
             setActiveKBs(restored)
             setStoredRaw(KB_STORAGE_KEY, restored.length ? storedKBValue(restored) : null)
+            kbsHydratedRef.current = true
           })
-      }).catch(() => {})
+      }).catch(() => { kbsHydratedRef.current = true })
     }
     // Run once on mount; search params are read for the deep-link guard only.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
+
+  // Persist the attachment whenever it changes. Deliberately an effect, not a
+  // write inside the state updaters: StrictMode double-invokes those, and a
+  // reducer with a side effect in it is a trap for the next reader. Held off
+  // until the mount-time restore has finished, so an empty initial state can't
+  // clear storage before the stored uuids have been resolved.
+  useEffect(() => {
+    if (!kbsHydratedRef.current) return
+    setStoredRaw(KB_STORAGE_KEY, activeKBs.length ? storedKBValue(activeKBs) : null)
+  }, [activeKBs])
 
   // Projects and knowledge bases are team-scoped. Switching the current team
   // (which happens live, without a reload) must drop any active scope so we
@@ -757,7 +781,7 @@ export function WorkspaceProvider({ children }: { children: ReactNode }) {
     newChatSignal, triggerNewChat,
     focusChatSignal, focusChat,
     pendingChatMessage, sendChatMessage, clearPendingChatMessage,
-    activeKBs, activeKBUuid, activeKBTitle, activateKB, attachKB, detachKB, deactivateKB,
+    activeKBs, activeKBUuid, activeKBTitle, activateKB, attachKBs, detachKB, deactivateKB,
     activeProjectUuid, activeProjectTitle, activeProjectRootFolder, activeProjectTeamId, activeProjectRole, activateProject, deactivateProject, refreshActiveProject,
     processingDoc, setProcessingDoc,
     selectedDocsProcessing, setSelectedDocsProcessing,
@@ -766,7 +790,7 @@ export function WorkspaceProvider({ children }: { children: ReactNode }) {
     newChatSignal, triggerNewChat,
     focusChatSignal, focusChat,
     pendingChatMessage, sendChatMessage, clearPendingChatMessage,
-    activeKBs, activeKBUuid, activeKBTitle, activateKB, attachKB, detachKB, deactivateKB,
+    activeKBs, activeKBUuid, activeKBTitle, activateKB, attachKBs, detachKB, deactivateKB,
     activeProjectUuid, activeProjectTitle, activeProjectRootFolder, activeProjectTeamId, activeProjectRole, activateProject, deactivateProject, refreshActiveProject,
     processingDoc,
     selectedDocsProcessing, setSelectedDocsProcessing,

--- a/frontend/src/contexts/WorkspaceContext.tsx
+++ b/frontend/src/contexts/WorkspaceContext.tsx
@@ -643,9 +643,22 @@ export function WorkspaceProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     if (didRehydrateScope.current) return
     didRehydrateScope.current = true
-    if (search.project || search.kb) return
 
-    const storedProject = getStoredRaw(PROJECT_STORAGE_KEY)
+    const deepLink = !!(search.project || search.kb)
+    const storedProject = deepLink ? null : getStoredRaw(PROJECT_STORAGE_KEY)
+    const storedKBUuids = deepLink || storedProject
+      ? []
+      : parseStoredKBs(getStoredRaw(KB_STORAGE_KEY))
+
+    // KB persistence is parked in exactly one situation: a restore is in
+    // flight and about to overwrite the attachment from storage. Decided once,
+    // here, rather than armed per branch below — a path that forgot to arm it
+    // silently stopped writing attach/detach for the rest of the session, and
+    // a reload then resurrected a KB the user had detached.
+    kbsHydratedRef.current = storedKBUuids.length === 0
+
+    if (deepLink) return
+
     if (storedProject) {
       import('../api/projects').then(({ getProject }) => {
         getProject(storedProject)
@@ -661,10 +674,7 @@ export function WorkspaceProvider({ children }: { children: ReactNode }) {
       return
     }
 
-    const storedKBUuids = parseStoredKBs(getStoredRaw(KB_STORAGE_KEY))
-    if (!storedKBUuids.length) {
-      kbsHydratedRef.current = true
-    } else {
+    if (storedKBUuids.length) {
       import('../api/knowledge').then(({ getKnowledgeBase }) => {
         // Titles are re-fetched rather than persisted, so a renamed KB never
         // shows stale chrome. A KB that no longer resolves is dropped; the
@@ -679,8 +689,9 @@ export function WorkspaceProvider({ children }: { children: ReactNode }) {
             })
             setActiveKBs(restored)
             setStoredRaw(KB_STORAGE_KEY, restored.length ? storedKBValue(restored) : null)
-            kbsHydratedRef.current = true
           })
+          // Whatever happens to the restore, persistence has to come back on.
+          .finally(() => { kbsHydratedRef.current = true })
       }).catch(() => { kbsHydratedRef.current = true })
     }
     // Run once on mount; search params are read for the deep-link guard only.

--- a/frontend/src/contexts/WorkspaceContext.tsx
+++ b/frontend/src/contexts/WorkspaceContext.tsx
@@ -89,9 +89,19 @@ interface ChatStateContextValue {
     options?: { documentUuids?: string[]; folderUuids?: string[] },
   ) => void
   clearPendingChatMessage: () => void
+  // Knowledge bases attached to the chat. Several can be attached at once;
+  // retrieval fans out across them. activeKBUuid/Title are the first one,
+  // kept for the surfaces that only ever deal with a single KB.
+  activeKBs: AttachedKB[]
   activeKBUuid: string | null
   activeKBTitle: string | null
+  // Replace whatever is attached with this KB and start a fresh chat — what
+  // "Chat with this KB" does from the knowledge surfaces.
   activateKB: (uuid: string, title: string) => void
+  // Add a KB to the current chat without disturbing it. No-op when already
+  // attached or at MAX_ATTACHED_KBS; returns false when it did not attach.
+  attachKB: (uuid: string, title: string) => boolean
+  detachKB: (uuid: string) => void
   deactivateKB: () => void
   // Project scope — the whole workspace (files, chat, …) re-scoped to one project.
   activeProjectUuid: string | null
@@ -215,6 +225,34 @@ function setStoredRaw(key: string, value: string | null): void {
 const PROJECT_STORAGE_KEY = 'workspace:project'
 const KB_STORAGE_KEY = 'workspace:kb'
 
+export interface AttachedKB {
+  uuid: string
+  title: string
+}
+
+// Each attached KB is retrieved separately before the results are merged, so
+// the ceiling is about how long a turn takes and what it costs. Mirrors
+// MAX_CHAT_KNOWLEDGE_BASES in backend/app/routers/chat.py, which enforces it.
+export const MAX_ATTACHED_KBS = 3
+
+function storedKBValue(kbs: AttachedKB[]): string {
+  return JSON.stringify(kbs.map(kb => kb.uuid))
+}
+
+/** Attached-KB uuids from storage, tolerating the pre-multi-KB single uuid. */
+function parseStoredKBs(raw: string | null): string[] {
+  if (!raw) return []
+  try {
+    const parsed = JSON.parse(raw)
+    if (Array.isArray(parsed)) {
+      return parsed.filter((u): u is string => typeof u === 'string' && !!u)
+    }
+  } catch {
+    // Not JSON: a single uuid written before chat took more than one KB.
+  }
+  return [raw]
+}
+
 type WorkspaceSearchState = {
   mode: WorkspaceMode | undefined
   tab: RightTab | undefined
@@ -301,8 +339,9 @@ export function WorkspaceProvider({ children }: { children: ReactNode }) {
     },
     [],
   )
-  const [activeKBUuid, setActiveKBUuid] = useState<string | null>(null)
-  const [activeKBTitle, setActiveKBTitle] = useState<string | null>(null)
+  const [activeKBs, setActiveKBs] = useState<AttachedKB[]>([])
+  const activeKBUuid = activeKBs[0]?.uuid ?? null
+  const activeKBTitle = activeKBs[0]?.title ?? null
   const [activeProjectUuid, setActiveProjectUuid] = useState<string | null>(null)
   const [activeProjectTitle, setActiveProjectTitle] = useState<string | null>(null)
   const [activeProjectRootFolder, setActiveProjectRootFolder] = useState<string | null>(null)
@@ -393,8 +432,7 @@ export function WorkspaceProvider({ children }: { children: ReactNode }) {
     setPendingChatMessage(null)
     setHighlightTerms([])
     setStoredRaw(KB_STORAGE_KEY, null)
-    setActiveKBUuid(null)
-    setActiveKBTitle(null)
+    setActiveKBs([])
     setStoredRaw(PROJECT_STORAGE_KEY, null)
     setActiveProjectUuid(null)
     setActiveProjectTitle(null)
@@ -434,18 +472,36 @@ export function WorkspaceProvider({ children }: { children: ReactNode }) {
   }, [])
 
   const activateKB = useCallback((uuid: string, title: string) => {
-    setStoredRaw(KB_STORAGE_KEY, uuid)
-    setActiveKBUuid(uuid)
-    setActiveKBTitle(title)
+    setStoredRaw(KB_STORAGE_KEY, storedKBValue([{ uuid, title }]))
+    setActiveKBs([{ uuid, title }])
     setNewChatSignal(prev => prev + 1)
     localStorage.setItem('workspace:mode', 'chat')
     updateSearch((prev) => ({ ...prev, mode: undefined, workflow: undefined, extraction: undefined, automation: undefined, tab: undefined }))
   }, [updateSearch])
 
+  const attachKB = useCallback((uuid: string, title: string) => {
+    let attached = false
+    setActiveKBs(prev => {
+      if (prev.some(kb => kb.uuid === uuid) || prev.length >= MAX_ATTACHED_KBS) return prev
+      attached = true
+      const next = [...prev, { uuid, title }]
+      setStoredRaw(KB_STORAGE_KEY, storedKBValue(next))
+      return next
+    })
+    return attached
+  }, [])
+
+  const detachKB = useCallback((uuid: string) => {
+    setActiveKBs(prev => {
+      const next = prev.filter(kb => kb.uuid !== uuid)
+      setStoredRaw(KB_STORAGE_KEY, next.length ? storedKBValue(next) : null)
+      return next
+    })
+  }, [])
+
   const deactivateKB = useCallback(() => {
     setStoredRaw(KB_STORAGE_KEY, null)
-    setActiveKBUuid(null)
-    setActiveKBTitle(null)
+    setActiveKBs([])
   }, [])
 
   const activateProject = useCallback((uuid: string, title: string) => {
@@ -457,8 +513,7 @@ export function WorkspaceProvider({ children }: { children: ReactNode }) {
     setActiveProjectTitle(title)
     // Entering a project starts a fresh, project-scoped chat.
     setStoredRaw(KB_STORAGE_KEY, null)
-    setActiveKBUuid(null)
-    setActiveKBTitle(null)
+    setActiveKBs([])
     setNewChatSignal(prev => prev + 1)
     localStorage.setItem('workspace:mode', 'chat')
     updateSearch((prev) => ({ ...prev, mode: undefined, workflow: undefined, extraction: undefined, automation: undefined, tab: undefined }))
@@ -495,9 +550,8 @@ export function WorkspaceProvider({ children }: { children: ReactNode }) {
     import('../api/knowledge').then(({ getKnowledgeBase }) => {
       getKnowledgeBase(kbParam)
         .then((kb) => {
-          setStoredRaw(KB_STORAGE_KEY, kbParam)
-          setActiveKBUuid(kbParam)
-          setActiveKBTitle(kb.title)
+          setStoredRaw(KB_STORAGE_KEY, storedKBValue([{ uuid: kbParam, title: kb.title }]))
+          setActiveKBs([{ uuid: kbParam, title: kb.title }])
           localStorage.setItem('workspace:mode', 'chat')
           navigate({
             search: (prev) => ({ ...emptyWorkspaceSearch(), ...prev, kb: undefined, mode: undefined, workflow: undefined, extraction: undefined, automation: undefined, tab: undefined }),
@@ -535,8 +589,7 @@ export function WorkspaceProvider({ children }: { children: ReactNode }) {
           setActiveProjectTeamId(project.team_id ?? null)
           setActiveProjectRole(project.role)
           setStoredRaw(KB_STORAGE_KEY, null)
-          setActiveKBUuid(null)
-          setActiveKBTitle(null)
+          setActiveKBs([])
           setNewChatSignal(prev => prev + 1)
           // Land in whatever mode was requested (e.g. ?project=X&mode=files),
           // defaulting to chat. Viewers (shared-in PIs) are chat-only.
@@ -597,15 +650,23 @@ export function WorkspaceProvider({ children }: { children: ReactNode }) {
       return
     }
 
-    const storedKB = getStoredRaw(KB_STORAGE_KEY)
-    if (storedKB) {
+    const storedKBUuids = parseStoredKBs(getStoredRaw(KB_STORAGE_KEY))
+    if (storedKBUuids.length) {
       import('../api/knowledge').then(({ getKnowledgeBase }) => {
-        getKnowledgeBase(storedKB)
-          .then((kb) => {
-            setActiveKBUuid(storedKB)
-            setActiveKBTitle(kb.title)
+        // Titles are re-fetched rather than persisted, so a renamed KB never
+        // shows stale chrome. A KB that no longer resolves is dropped; the
+        // rest of the attachment survives.
+        Promise.allSettled(storedKBUuids.map(uuid => getKnowledgeBase(uuid)))
+          .then(results => {
+            const restored: AttachedKB[] = []
+            results.forEach((res, i) => {
+              if (res.status === 'fulfilled') {
+                restored.push({ uuid: storedKBUuids[i], title: res.value.title })
+              }
+            })
+            setActiveKBs(restored)
+            setStoredRaw(KB_STORAGE_KEY, restored.length ? storedKBValue(restored) : null)
           })
-          .catch(() => { setStoredRaw(KB_STORAGE_KEY, null) })
       }).catch(() => {})
     }
     // Run once on mount; search params are read for the deep-link guard only.
@@ -633,8 +694,7 @@ export function WorkspaceProvider({ children }: { children: ReactNode }) {
     setActiveProjectTeamId(null)
     setActiveProjectRole(null)
     setStoredRaw(KB_STORAGE_KEY, null)
-    setActiveKBUuid(null)
-    setActiveKBTitle(null)
+    setActiveKBs([])
   }, [currentTeam?.uuid])
 
   // ── UI callbacks ────────────────────────────────────────────────────────
@@ -697,7 +757,7 @@ export function WorkspaceProvider({ children }: { children: ReactNode }) {
     newChatSignal, triggerNewChat,
     focusChatSignal, focusChat,
     pendingChatMessage, sendChatMessage, clearPendingChatMessage,
-    activeKBUuid, activeKBTitle, activateKB, deactivateKB,
+    activeKBs, activeKBUuid, activeKBTitle, activateKB, attachKB, detachKB, deactivateKB,
     activeProjectUuid, activeProjectTitle, activeProjectRootFolder, activeProjectTeamId, activeProjectRole, activateProject, deactivateProject, refreshActiveProject,
     processingDoc, setProcessingDoc,
     selectedDocsProcessing, setSelectedDocsProcessing,
@@ -706,7 +766,7 @@ export function WorkspaceProvider({ children }: { children: ReactNode }) {
     newChatSignal, triggerNewChat,
     focusChatSignal, focusChat,
     pendingChatMessage, sendChatMessage, clearPendingChatMessage,
-    activeKBUuid, activeKBTitle, activateKB, deactivateKB,
+    activeKBs, activeKBUuid, activeKBTitle, activateKB, attachKB, detachKB, deactivateKB,
     activeProjectUuid, activeProjectTitle, activeProjectRootFolder, activeProjectTeamId, activeProjectRole, activateProject, deactivateProject, refreshActiveProject,
     processingDoc,
     selectedDocsProcessing, setSelectedDocsProcessing,

--- a/frontend/src/contexts/attachedKBs.test.ts
+++ b/frontend/src/contexts/attachedKBs.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest'
+import { mergeAttachedKBs, MAX_ATTACHED_KBS } from './WorkspaceContext'
+
+const kb = (uuid: string) => ({ uuid, title: uuid.toUpperCase() })
+
+// The first version of this decided per KB inside a React state updater and
+// returned the outcome from there. React defers the updater once one is
+// queued, so attaching three at once attached the first, reported a false
+// "at most 3" error on the second, and dropped the third.
+describe('mergeAttachedKBs', () => {
+  it('attaches a whole batch in one go', () => {
+    expect(mergeAttachedKBs([], [kb('a'), kb('b'), kb('c')]).map(k => k.uuid))
+      .toEqual(['a', 'b', 'c'])
+  })
+
+  it('ignores a KB that is already attached', () => {
+    expect(mergeAttachedKBs([kb('a')], [kb('a'), kb('b')]).map(k => k.uuid))
+      .toEqual(['a', 'b'])
+  })
+
+  it('stops at the limit instead of overfilling', () => {
+    const merged = mergeAttachedKBs([kb('a')], [kb('b'), kb('c'), kb('d')])
+    expect(merged).toHaveLength(MAX_ATTACHED_KBS)
+    expect(merged.map(k => k.uuid)).toEqual(['a', 'b', 'c'])
+  })
+
+  it('returns the same array when nothing changes, so React can skip the render', () => {
+    const prev = [kb('a')]
+    expect(mergeAttachedKBs(prev, [kb('a')])).toBe(prev)
+    expect(mergeAttachedKBs(prev, [])).toBe(prev)
+  })
+})

--- a/frontend/src/hooks/useChat.ts
+++ b/frontend/src/hooks/useChat.ts
@@ -43,7 +43,7 @@ export function useChat() {
   const citationsRef = useRef<Citation[]>([])
 
   const send = useCallback(
-    async (message: string, documentUuids: string[] = [], model?: string, knowledgeBaseUuid?: string, includeOnboardingContext?: boolean, folderUuids?: string[], isFirstSession?: boolean, projectUuid?: string) => {
+    async (message: string, documentUuids: string[] = [], model?: string, knowledgeBaseUuids?: string[], includeOnboardingContext?: boolean, folderUuids?: string[], isFirstSession?: boolean, projectUuid?: string) => {
       setError(null)
       setErrorDetails(null)
       setIsStreaming(true)
@@ -114,7 +114,7 @@ export function useChat() {
             }
           },
           model,
-          knowledgeBaseUuid,
+          knowledgeBaseUuids,
           includeOnboardingContext,
           folderUuids,
           isFirstSession,

--- a/frontend/src/types/chat.ts
+++ b/frontend/src/types/chat.ts
@@ -97,6 +97,10 @@ export interface Citation {
   /** Page was interpolated from OCR text, not measured. See #603. */
   page_approximate?: boolean
   sheet?: string | null
+  /** Which knowledge base this snippet came from. Only set when several are
+   *  attached to the chat, where the filename alone doesn't say. */
+  kb_title?: string | null
+  kb_uuid?: string | null
   chunk_id?: string | null
   score?: number | null
   content_preview?: string


### PR DESCRIPTION
## Ticket

> When I go to a chat and click add button to add a knowledge base it takes me to the knowledge base page but doesn't add it to the chat unless I click 'chat' or 'chat with this kb' there doesn't seem to be a way to chat with MULTIPLE kb's at once.

Both halves are real. `onAddKnowledge` was `() => setWorkspaceMode('knowledge')` — the menu item navigated, it never attached. And chat carried exactly one KB end to end: `activeKBUuid` → `knowledge_base_uuid` → one ChromaDB collection.

(KB **+ files** in one turn already worked — the KB segment is inserted alongside the document segments — so that part of the title needed nothing.)

Scoped with John: up to 3 KBs, citations name the KB they came from.

## Attaching

"Add Knowledge Base" now opens `AttachKBModal` — scope tabs (mine/team/verified), search, multi-select, attach without leaving the chat or resetting the conversation. Already-attached KBs are marked; broken bookmarks (`status: 'unavailable'`) are filtered out, since there is no KB behind them to search.

Each attached KB gets its own row above the input with its own detach button. `activateKB` ("Chat with this KB", `?kb=` deep links) keeps replacing the attachment and starting a fresh chat; the new `attachKB`/`detachKB` add and remove without disturbing the conversation. `activeKBUuid`/`activeKBTitle` remain as the first attached KB, so the single-KB surfaces (LeftPanel, FileBrowser, KBExploreTab) are untouched. Storage now holds a uuid array and still reads the old single-uuid value.

## Retrieval

`_build_kb_segment` is split into `_retrieve_kb_results` (per KB, through `_compose_kb_results`) and `_render_kb_segment` (KB-agnostic), so a multi-KB turn has ranked pools to merge *before* any prompt text exists.

- **Each KB is retrieved at its own tuned config.** They differ per KB (k, min_similarity, rewrite, rerank); one shared floor would either drown a strict KB in a loose one's near-misses or throw away a strict KB's good hits.
- **Pools merge round-robin** (`_round_robin_merge`, already used for multi-question turns) so a KB that ranks lower overall still reaches the model, then trim to `MULTI_KB_SNIPPET_BUDGET = 12`. One KB contributes ~8; three at full budget would triple the prompt for one question.
- **Every snippet carries its KB** — `**Source: policy.pdf (p. 3) — Export Control**` in the prompt, `kb_title`/`kb_uuid` on each citation, and `policy.pdf · p. 3 · Export Control` on the chip. Single-KB turns are unlabelled, exactly as today.
- **A KB whose retrieval fails is skipped**, not fatal: the answer is grounded in the ones that responded, which is what the model is told it has.
- The document manifest is the union, with each entry tagged by KB when more than one is attached.

## Cap

`MAX_CHAT_KNOWLEDGE_BASES = 3` in the router (400 past it), mirrored as `MAX_ATTACHED_KBS` in the context and shown in the picker. Each KB costs its own embedding query plus any rewrite/rerank LLM calls, so the ceiling is latency and spend per turn.

`knowledge_base_uuid` still works and is folded into the list. A project chat still overrides everything with the project's own KB.

## Tests

`backend/tests/test_chat_multi_kb.py` (new, 7) — round-robin ordering and per-snippet KB labels, the shared budget spread across KBs rather than spent on the first, a failing KB skipped, a single KB left unlabelled; and on the route: the cap rejected, every KB authorized and passed through as `[(uuid, title)]`, one unauthorized KB in the list → 404.

`frontend/.../AttachKBModal.test.tsx` (new, 4) — multi-select attach, unavailable KBs hidden, the limit blocking further selection, already-attached rows marked.

Backend: 158 chat/KB tests pass, ruff clean. Frontend: the new suite plus the chat message suites pass; `tsc --noEmit` clean.

## Merge note

PR #782 (chat condense fix) edits the same block of `chat_service.py` that this PR moved into `_retrieve_kb_results`. Whichever lands second needs a one-hunk manual merge — the condense call and `_looks_anaphoric` guard now live inside `_retrieve_kb_results`, unchanged otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017f65pmoEKbpBGownseoHf7
