### PR TITLE
feat(knowledge): Clone on the open knowledge base, not just its card

### DIFF
--- a/frontend/src/components/workspace/KnowledgePanel.test.tsx
+++ b/frontend/src/components/workspace/KnowledgePanel.test.tsx
@@ -65,12 +65,14 @@ vi.mock('../../hooks/useProjectPins', () => ({
 }))
 
 const refreshKBSource = vi.fn().mockResolvedValue({ ok: true, status: 'queued', source_uuid: 'src-1' })
+const cloneKnowledgeBase = vi.fn().mockResolvedValue({ uuid: 'kb-copy', title: 'Export Control Regulations (copy)' })
 
 vi.mock('../../api/knowledge', () => ({
   getKnowledgeBase: (uuid: string) => getKnowledgeBase(uuid),
   getKBQuality: vi.fn().mockResolvedValue({}),
   getKBSourceHealth: vi.fn().mockResolvedValue({}),
   refreshKBSource: (uuid: string, sourceUuid: string) => refreshKBSource(uuid, sourceUuid),
+  cloneKnowledgeBase: (uuid: string) => cloneKnowledgeBase(uuid),
 }))
 
 vi.mock('../../api/organizations', () => ({
@@ -258,6 +260,35 @@ describe('KnowledgePanel add-source permissions', () => {
 
     expect(screen.queryByLabelText('Refresh source')).not.toBeInTheDocument()
     expect(screen.getByLabelText('Remove source')).toBeInTheDocument()
+  }, 30000)
+})
+
+// Support ticket: Clone was on the KB cards but nowhere on the page you land
+// on after opening a KB — which is where someone decides they want a copy.
+describe('KnowledgePanel clone on an open KB', () => {
+  beforeEach(() => {
+    getKnowledgeBase.mockClear()
+    cloneKnowledgeBase.mockClear()
+  })
+
+  it('offers Clone and copies the open knowledge base', async () => {
+    detail.current = makeDetail({ can_manage: true, total_sources: 2 })
+    await openDetail()
+
+    fireEvent.click(screen.getByRole('button', { name: /^Clone$/ }))
+    await waitFor(() => expect(cloneKnowledgeBase).toHaveBeenCalledWith('kb-1'))
+  }, 30000)
+
+  it('disables Clone on a knowledge base with nothing to copy', async () => {
+    detail.current = makeDetail({
+      can_manage: true, total_sources: 0, sources_ready: 0, total_chunks: 0, status: 'empty',
+    })
+    await openDetail()
+
+    const clone = screen.getByRole('button', { name: /^Clone$/ })
+    expect(clone).toBeDisabled()
+    fireEvent.click(clone)
+    expect(cloneKnowledgeBase).not.toHaveBeenCalled()
   }, 30000)
 })
 

--- a/frontend/src/components/workspace/KnowledgePanel.tsx
+++ b/frontend/src/components/workspace/KnowledgePanel.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
-import { Plus, Loader2, ArrowLeft, X, FileText, Globe, MessageSquare, AlertCircle, AlertTriangle, CheckCircle2, Users, ShieldCheck, Send, Tag, Check, Download, Upload, HelpCircle, Pencil, Pin, PinOff, FolderKanban, ChevronDown, ChevronRight, RefreshCw } from 'lucide-react'
+import { Plus, Loader2, ArrowLeft, X, FileText, Globe, MessageSquare, AlertCircle, AlertTriangle, CheckCircle2, Users, ShieldCheck, Send, Tag, Check, Download, Upload, HelpCircle, Pencil, Pin, PinOff, FolderKanban, ChevronDown, ChevronRight, RefreshCw, Copy } from 'lucide-react'
 import { useKnowledgeBases, useScopedKnowledgeBases } from '../../hooks/useKnowledgeBases'
 import { describeSourceCurrency, formatCurrencyDateTime, shortHash } from '../knowledge/sourceCurrency'
 import { useProjectPins } from '../../hooks/useProjectPins'
@@ -252,6 +252,8 @@ export function KnowledgePanel() {
   // Clone lands an owned, editable copy in My KBs (sources re-ingest in the
   // background, so it opens in 'building' status).
   const handleClone = async (uuid: string) => {
+    if (cloning) return
+    setCloning(true)
     try {
       const clone = await api.cloneKnowledgeBase(uuid)
       const newUuid = (clone as { uuid?: string }).uuid
@@ -264,6 +266,8 @@ export function KnowledgePanel() {
     } catch (err) {
       console.error('Failed to clone KB:', err)
       toast(err instanceof Error ? err.message : 'Failed to clone knowledge base', 'error')
+    } finally {
+      setCloning(false)
     }
   }
 
@@ -524,6 +528,7 @@ export function KnowledgePanel() {
 
   // Export / Import state
   const [exporting, setExporting] = useState(false)
+  const [cloning, setCloning] = useState(false)
   const [importing, setImporting] = useState(false)
   const importInputRef = useRef<HTMLInputElement | null>(null)
 
@@ -1114,6 +1119,27 @@ export function KnowledgePanel() {
               >
                 {exporting ? <Loader2 size={13} style={{ animation: 'spin 1s linear infinite' }} /> : <Download size={13} />}
                 {exporting ? 'Exporting...' : 'Export'}
+              </button>
+              {/* Clone lives on the KB cards too, but this is the page you are
+                  on once you have opened a KB and decided you want a copy of
+                  it — the support ticket was written from here. */}
+              <button
+                onClick={() => handleClone(selectedKB.uuid)}
+                disabled={cloning || !hasSources}
+                title={hasSources
+                  ? 'Make an editable copy of this knowledge base'
+                  : 'Add at least one source to this knowledge base first'}
+                style={{
+                  display: 'flex', alignItems: 'center', gap: 6,
+                  padding: '6px 12px', fontSize: 12, fontWeight: 600, fontFamily: 'inherit',
+                  color: '#e5e5e5', backgroundColor: '#2a2a2a',
+                  border: '1px solid #3a3a3a', borderRadius: 6,
+                  cursor: cloning || !hasSources ? 'default' : 'pointer',
+                  opacity: cloning || !hasSources ? 0.5 : 1,
+                }}
+              >
+                {cloning ? <Loader2 size={13} style={{ animation: 'spin 1s linear infinite' }} /> : <Copy size={13} />}
+                {cloning ? 'Cloning...' : 'Clone'}
               </button>
               {selectedKB.status === 'ready' && !selectedKB.verified && (
                 verificationSubmitted ? (


### PR DESCRIPTION
## Ticket

> The Knowledge Base page does not provide a Clone option for existing Knowledge Bases… Retested on the latest build and can confirm that the clone option button is still not visible on the UI.

## What's actually there

`POST /api/knowledge/{uuid}/clone` works, and Clone is on every KB **card** in My KBs / Team / Verified — restored in `8eaaab80` after a merge dropped it, with regression tests in `KBGridView.test.tsx` pinning it there. It shipped in v4.10.0.

What has no Clone anywhere is the **open KB** — the detail page you get after clicking into one, whose header offers Pin, Share with Team, Export, verification and Delete. That is the page the ticket names, and the page where someone actually decides they want a copy: you open a KB, look at its sources, and want to fork it before experimenting.

## Change

Clone beside Export in the open-KB header:

- Runs the same `handleClone` the cards use — the copy lands in My KBs, the panel switches there and opens it while its sources re-ingest.
- Disabled with a reason when the KB has no sources ("Add at least one source to this knowledge base first"), matching Export's rule and the `require_kb_sources` gate the endpoint enforces — a clone of an empty KB is a 400 and a copy of nothing.
- Shows "Cloning…" with a spinner while in flight. Cloning re-ingests every source, so it takes noticeably longer than the other header actions look like they take.

Works on any KB the user can see, not just ones they own — cloning a verified catalog KB into your own workspace is the main reason to reach for it, and the endpoint already allows view access.

No backend change: the endpoint, its authorization, and its empty-KB guard were already right.

## Tests

`KnowledgePanel.test.tsx` — Clone appears on an open KB and calls `cloneKnowledgeBase` with its uuid; on a KB with no sources it renders disabled and clicking it does nothing.

`KnowledgePanel.test.tsx` (12) and `KBGridView.test.tsx` (the existing card-level guards) pass; `tsc --noEmit` clean.

## Worth checking

If the reporter genuinely sees no Clone on the **cards** either, their deployment is older than v4.10.0 — that's where the card action landed. Worth confirming the deployed version before closing the ticket, since this PR only adds the detail-page affordance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017f65pmoEKbpBGownseoHf7
