### PR TITLE
fix(workflows): unlinking a saved prompt keeps its text

### DIFF
--- a/frontend/src/components/workspace/WorkflowEditorPanel.tsx
+++ b/frontend/src/components/workspace/WorkflowEditorPanel.tsx
@@ -2528,6 +2528,29 @@ function describeConfigSaveError(err: unknown, what: string): string {
  * backend now fails such a run, but refusing the save is where the author
  * actually is when the mistake happens.
  */
+/**
+ * Detach a saved prompt or formatter from a step, keeping an editable copy of
+ * the text it was running.
+ *
+ * Linking deletes the inline body — while linked, the saved item is the source
+ * of truth and is resolved at runtime — so dropping the link on its own left a
+ * named step with no instruction text at all. ``body`` is the resolved saved
+ * body the editor already loaded for its preview; an empty one (a saved prompt
+ * with no content yet) leaves the field alone rather than writing "".
+ */
+export function unlinkSavedItem(
+  data: Record<string, unknown>,
+  linkField: 'saved_prompt_uuid' | 'saved_formatter_uuid',
+  bodyField: 'prompt' | 'format_template',
+  body: string,
+): Record<string, unknown> {
+  const next = { ...data }
+  delete next[linkField]
+  if (body) next[bodyField] = body
+  return next
+}
+
+
 export function requiredFieldMessage(taskName: string, data: Record<string, unknown>): string | null {
   const text = (key: string) => (typeof data[key] === 'string' ? (data[key] as string) : '').trim()
   if (taskName === 'AddWebsite' && !text('url')) {
@@ -3282,11 +3305,11 @@ function TaskEditModal({ task, selectedDocUuids, workflow, workflowId, onClose, 
   }
 
   const handleUnlinkSavedPrompt = () => {
-    setTaskData(prev => {
-      const next = { ...prev }
-      delete (next as Record<string, unknown>).saved_prompt_uuid
-      return next
-    })
+    // Unlink means "detach into an editable copy". Linking deleted the inline
+    // prompt (the saved body is the source of truth while linked), so dropping
+    // the link alone left a named step with no instruction text at all. Carry
+    // the resolved body across — it is already loaded for the preview above.
+    setTaskData(prev => unlinkSavedItem(prev, 'saved_prompt_uuid', 'prompt', linkedSavedBody))
   }
 
   const handleSelectSavedFormatter = (id: string, name: string) => {
@@ -3299,11 +3322,8 @@ function TaskEditModal({ task, selectedDocUuids, workflow, workflowId, onClose, 
   }
 
   const handleUnlinkSavedFormatter = () => {
-    setTaskData(prev => {
-      const next = { ...prev }
-      delete (next as Record<string, unknown>).saved_formatter_uuid
-      return next
-    })
+    // Same as the prompt above: keep the template the step was running.
+    setTaskData(prev => unlinkSavedItem(prev, 'saved_formatter_uuid', 'format_template', linkedSavedBody))
   }
 
   // AI: suggest extraction fields from the workspace's selected document(s).
@@ -3637,7 +3657,10 @@ function TaskEditModal({ task, selectedDocUuids, workflow, workflowId, onClose, 
                       <button
                         type="button"
                         onClick={handleUnlinkSavedPrompt}
-                        title="Unlink this saved prompt and enter one manually"
+                        disabled={linkedSavedLoading}
+                        title={linkedSavedLoading
+                          ? 'Loading the saved prompt…'
+                          : 'Unlink this saved prompt and keep an editable copy of its text'}
                         style={{
                           fontSize: 11, padding: '2px 8px', border: '1px solid #d1d5db',
                           borderRadius: 4, backgroundColor: '#fff', color: '#374151',
@@ -3830,7 +3853,10 @@ function TaskEditModal({ task, selectedDocUuids, workflow, workflowId, onClose, 
                       <button
                         type="button"
                         onClick={handleUnlinkSavedFormatter}
-                        title="Unlink this saved formatter and enter one manually"
+                        disabled={linkedSavedLoading}
+                        title={linkedSavedLoading
+                          ? 'Loading the saved formatter…'
+                          : 'Unlink this saved formatter and keep an editable copy of its template'}
                         style={{
                           fontSize: 11, padding: '2px 8px', border: '1px solid #d1d5db',
                           borderRadius: 4, backgroundColor: '#fff', color: '#374151',

--- a/frontend/src/components/workspace/WorkflowEditorPanel.unlinkSaved.test.ts
+++ b/frontend/src/components/workspace/WorkflowEditorPanel.unlinkSaved.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import { unlinkSavedItem } from './WorkflowEditorPanel'
+
+// Support ticket: unlinking a saved prompt dropped the link and the text with
+// it, leaving a named Prompt step with no instruction at all. Unlink is meant
+// to detach into an editable copy.
+describe('unlinkSavedItem', () => {
+  it('keeps the prompt text the step was running', () => {
+    const next = unlinkSavedItem(
+      { name: 'Summarize award', saved_prompt_uuid: 'p-1' },
+      'saved_prompt_uuid', 'prompt',
+      'Summarize the award notice in three bullets.',
+    )
+
+    expect(next.saved_prompt_uuid).toBeUndefined()
+    expect(next.prompt).toBe('Summarize the award notice in three bullets.')
+    // The name is the step's own; unlinking is not a rename.
+    expect(next.name).toBe('Summarize award')
+  })
+
+  it('keeps the formatter template the same way', () => {
+    const next = unlinkSavedItem(
+      { name: 'Memo', saved_formatter_uuid: 'f-1' },
+      'saved_formatter_uuid', 'format_template',
+      '# {{title}}\n\n{{body}}',
+    )
+
+    expect(next.saved_formatter_uuid).toBeUndefined()
+    expect(next.format_template).toBe('# {{title}}\n\n{{body}}')
+  })
+
+  it('writes nothing when the saved item has no content', () => {
+    const next = unlinkSavedItem(
+      { name: 'Empty', saved_prompt_uuid: 'p-1' }, 'saved_prompt_uuid', 'prompt', '',
+    )
+
+    expect(next.saved_prompt_uuid).toBeUndefined()
+    expect('prompt' in next).toBe(false)
+  })
+
+  it('does not mutate the step it was given', () => {
+    const data = { name: 'Summarize', saved_prompt_uuid: 'p-1' }
+    unlinkSavedItem(data, 'saved_prompt_uuid', 'prompt', 'Do the thing.')
+
+    expect(data.saved_prompt_uuid).toBe('p-1')
+  })
+})


### PR DESCRIPTION
## Ticket

> In a Prompt step that uses a saved prompt, clicking "Unlink" (to detach it into an editable copy) removes the prompt's content but leaves the name behind. The user is left with a named prompt step that has no instruction text.

## Cause

Linking is deliberately destructive to the inline field — while a saved prompt is linked, it is the source of truth and its body is resolved at runtime, so `handleSelectSavedPrompt` deletes `data.prompt` to keep state matching what the UI shows:

```ts
const next = { ...prev, saved_prompt_uuid: id, name: name || prev.name }
delete (next as Record<string, unknown>).prompt
```

`handleUnlinkSavedPrompt` then deleted only `saved_prompt_uuid`. Nothing ever put the body back, so the step came out named (the name was set on link) with no instruction text — and the next run had nothing to send.

## Change

Unlink carries the resolved body into the step's own field, which is what "detach into an editable copy" means. The body is `linkedSavedBody`, already fetched for the preview rendered directly above the button, so there is nothing new to load.

The button is disabled while that fetch is in flight — unlinking mid-load would copy an empty string and reproduce the bug exactly. Its tooltip now says what it does ("keep an editable copy of its text") rather than "enter one manually".

A saved prompt with no content of its own leaves the field absent rather than writing `""`, so the step reads as empty rather than as an empty-string instruction.

**Saved formatters** had the identical handler with the identical hole (`format_template` deleted on link, never restored). Both now go through one exported `unlinkSavedItem`.

## Not fixed here

Saved **extraction sets** have the same shape — `handleSelectSavedSet` deletes `extractions`, and unlink doesn't restore the field list. It needs a different fix (the set's fields aren't loaded in the editor the way a prompt body is, so it needs a fetch, and what to restore — names vs. field prompts — is a judgement call I'd rather not guess). Say the word and I'll do it as a follow-up.

## Tests

`WorkflowEditorPanel.unlinkSaved.test.ts` (new) — the prompt text survives unlink and the step keeps its name; the formatter template behaves the same; an empty saved body writes nothing; the input step object isn't mutated.

Follows the file's existing idiom of exporting pure helpers (`requiredFieldMessage`, `fillReportSummary`) and testing them directly, rather than mounting the whole editor.

`WorkflowEditorPanel.*.test.*` (17) pass; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017f65pmoEKbpBGownseoHf7
