### PR TITLE
fix(tuning): don't stamp "Updated" when the refresh failed

### DIFF
--- a/frontend/src/components/shared/OptimizerInbox.test.tsx
+++ b/frontend/src/components/shared/OptimizerInbox.test.tsx
@@ -178,6 +178,18 @@ describe('OptimizerInbox', () => {
     expect(await screen.findByText(/Updated just now/i)).toBeInTheDocument()
   })
 
+  it('does not claim the data is fresh when the refresh failed', async () => {
+    mockGet.mockResolvedValueOnce(makeResponse([makeItem()]))
+    render(<OptimizerInbox />)
+    await screen.findByText('Proposal intake')
+
+    mockGet.mockRejectedValueOnce(new Error('Backend unavailable'))
+    fireEvent.click(screen.getByRole('button', { name: /Refresh/i }))
+
+    expect(await screen.findByText('Backend unavailable')).toBeInTheDocument()
+    expect(screen.queryByText(/Updated/i)).not.toBeInTheDocument()
+  })
+
   it('offers nothing to apply on a tied candidate', async () => {
     mockGet.mockResolvedValue(makeResponse([
       makeItem({ category: 'no_change', tied_with_baseline: true }),

--- a/frontend/src/components/shared/OptimizerInbox.tsx
+++ b/frontend/src/components/shared/OptimizerInbox.tsx
@@ -119,14 +119,18 @@ export function OptimizerInbox() {
   const [busyRun, setBusyRun] = useState<string | null>(null)
   const [previewFor, setPreviewFor] = useState<OptimizerInboxItem | null>(null)
 
-  const load = useCallback(async (includeDismissed: boolean) => {
+  /** Returns whether the fetch succeeded, so a caller can tell a real refresh
+   *  from one that only produced an error banner. */
+  const load = useCallback(async (includeDismissed: boolean): Promise<boolean> => {
     setLoading(true)
     setError(null)
     try {
       setData(await getOptimizerInbox({ includeDismissed }))
       setLoadedAt(new Date().toISOString())
+      return true
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Failed to load tuning suggestions')
+      return false
     } finally {
       setLoading(false)
     }
@@ -145,8 +149,10 @@ export function OptimizerInbox() {
 
   const handleRefresh = useCallback(async () => {
     setJustRefreshed(false)
-    await load(showDismissed)
-    setJustRefreshed(true)
+    // Only on success: a failed refresh renders its own error banner, and a
+    // green "✓ Updated just now" beside it against the *previous* load's
+    // timestamp tells the user their data is fresh when it isn't.
+    if (await load(showDismissed)) setJustRefreshed(true)
   }, [load, showDismissed])
 
   const applyItem = useCallback(async (item: OptimizerInboxItem) => {


### PR DESCRIPTION
Follow-up to #778, caught in review.

`handleRefresh` set `justRefreshed = true` unconditionally after awaiting `load`, but `load` swallows its own error and renders an error banner instead. A failed refresh therefore showed the green "✓ Updated just now" next to that banner — against the *previous* load's timestamp. The one moment the data is definitely stale is the moment it claimed freshness.

`load` now returns whether the fetch succeeded, and the stamp follows it. The error banner and its Retry button are unchanged.

## Tests

`OptimizerInbox.test.tsx` — a refresh that rejects shows the error and no "Updated" stamp. 10 tests pass; `tsc -b` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017f65pmoEKbpBGownseoHf7