### PR TITLE
test(tuning): stop claiming a test pins the refresh-stamp gate

### DIFF
--- a/frontend/src/components/shared/OptimizerInbox.test.tsx
+++ b/frontend/src/components/shared/OptimizerInbox.test.tsx
@@ -178,7 +178,7 @@ describe('OptimizerInbox', () => {
     expect(await screen.findByText(/Updated just now/i)).toBeInTheDocument()
   })
 
-  it('does not claim the data is fresh when the refresh failed', async () => {
+  it('replaces the panel with the error when a refresh fails', async () => {
     mockGet.mockResolvedValueOnce(makeResponse([makeItem()]))
     render(<OptimizerInbox />)
     await screen.findByText('Proposal intake')
@@ -186,8 +186,15 @@ describe('OptimizerInbox', () => {
     mockGet.mockRejectedValueOnce(new Error('Backend unavailable'))
     fireEvent.click(screen.getByRole('button', { name: /Refresh/i }))
 
+    // The error branch returns before the header, so the whole panel — rows,
+    // Refresh, "Updated …" stamp — is replaced by the banner and its Retry.
+    // This pins that early return, NOT the justRefreshed gate added in #791:
+    // that gate has no observable effect precisely because of this branch, and
+    // a test written against it passes with or without it.
     expect(await screen.findByText('Backend unavailable')).toBeInTheDocument()
-    expect(screen.queryByText(/Updated/i)).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Retry/i })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Refresh/i })).not.toBeInTheDocument()
+    expect(screen.queryByText('Proposal intake')).not.toBeInTheDocument()
   })
 
   it('offers nothing to apply on a tied candidate', async () => {

--- a/frontend/src/components/shared/OptimizerInbox.tsx
+++ b/frontend/src/components/shared/OptimizerInbox.tsx
@@ -149,9 +149,10 @@ export function OptimizerInbox() {
 
   const handleRefresh = useCallback(async () => {
     setJustRefreshed(false)
-    // Only on success: a failed refresh renders its own error banner, and a
-    // green "✓ Updated just now" beside it against the *previous* load's
-    // timestamp tells the user their data is fresh when it isn't.
+    // Only on success. State hygiene rather than a visible fix: a failed load
+    // replaces this whole panel with the error banner (see the `if (error)`
+    // return below), so a stamp set here could not be seen anyway. Gated so
+    // that stays true if the error ever renders inline instead.
     if (await load(showDismissed)) setJustRefreshed(true)
   }, [load, showDismissed])
 


### PR DESCRIPTION
Follow-up to #791, from review — and a correction to my own PR.

## What was wrong

#791's test asserted that after a failed refresh no "Updated" stamp appears. It passes against the **unfixed** code. I verified it by reverting the gate locally (`await load(...); setJustRefreshed(true)`) and re-running the suite: 10/10 green either way.

The reason is `OptimizerInbox.tsx`'s `if (error) return <banner>` — an early return that replaces the entire panel. The header carrying the stamp never renders while `error` is set, so the stamp's absence has nothing to do with `justRefreshed`. The symptom I described in #791 (a green "✓ Updated" beside the error banner) is unreachable.

## Change

The test now pins what actually happens: the banner and its Retry replace the rows, the Refresh button and the stamp. Its comment says outright that it does not pin the `justRefreshed` gate, and why — so the next reader does not trust a guard that cannot fail.

The gate stays. It is correct state hygiene, and it keeps being correct if the error is ever rendered inline instead of replacing the panel; its comment now says that instead of describing a bug that cannot occur.

10 tests pass; `tsc -b` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017f65pmoEKbpBGownseoHf7